### PR TITLE
validate root file against cert store

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -47,7 +47,7 @@
 		},
 		{
 			"ImportPath": "github.com/endophage/gotuf",
-			"Rev": "36214c0646639c7f94b3151df15dc417a67a9406"
+			"Rev": "f45743d59471461fa065fd5f0c67dcc893524b9d"
 		},
 		{
 			"ImportPath": "github.com/go-sql-driver/mysql",

--- a/cmd/notary/cli_crypto_service.go
+++ b/cmd/notary/cli_crypto_service.go
@@ -36,9 +36,9 @@ func (ccs *cliCryptoService) Create(role string) (*data.PublicKey, error) {
 	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
 	pemdata := pem.EncodeToMemory(&block)
 
-	// If this key has the role root, save it as a trusted certificate on our caStore
+	// If this key has the role root, save it as a trusted certificate on our certificateStore
 	if role == "root" {
-		caStore.AddCertFromPEM(pemdata)
+		certificateStore.AddCertFromPEM(pemdata)
 	}
 
 	return data.NewPublicKey("RSA", string(pemdata)), nil
@@ -85,7 +85,6 @@ func (ccs *cliCryptoService) Sign(keyIDs []string, payload []byte) ([]data.Signa
 
 //TODO (diogo): Add support for EC P384
 func generateKeyAndCert(gun string) (crypto.PrivateKey, *x509.Certificate, error) {
-
 	// Generates a new RSA key
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/cmd/notary/cli_crypto_service.go
+++ b/cmd/notary/cli_crypto_service.go
@@ -51,9 +51,9 @@ func (ccs *cliCryptoService) Sign(keyIDs []string, payload []byte) ([]data.Signa
 	hashed := sha256.Sum256(payload)
 
 	signatures := make([]data.Signature, 0, len(keyIDs))
-	for _, kID := range keyIDs {
+	for _, fingerprint := range keyIDs {
 		// Get the PrivateKey filename
-		privKeyFilename := filepath.Join(viper.GetString("privDir"), ccs.gun, kID+".key")
+		privKeyFilename := filepath.Join(viper.GetString("privDir"), ccs.gun, fingerprint+".key")
 		// Read PrivateKey from file
 		privPEMBytes, err := ioutil.ReadFile(privKeyFilename)
 		if err != nil {
@@ -75,7 +75,7 @@ func (ccs *cliCryptoService) Sign(keyIDs []string, payload []byte) ([]data.Signa
 
 		// Append signatures to result array
 		signatures = append(signatures, data.Signature{
-			KeyID:     kID,
+			KeyID:     fingerprint,
 			Method:    "RSASSA-PKCS1-V1_5-SIGN",
 			Signature: sig[:],
 		})
@@ -109,10 +109,10 @@ func generateKeyAndCert(gun string) (crypto.PrivateKey, *x509.Certificate, error
 		return nil, nil, fmt.Errorf("failed to generate the certificate for key: %v", err)
 	}
 
-	kID := trustmanager.FingerprintCert(cert)
+	fingerprint := trustmanager.FingerprintCert(cert)
 	// The key is going to be stored in the private directory, using the GUN and
 	// the filename will be the TUF-compliant ID. The Store takes care of extensions.
-	privKeyFilename := filepath.Join(gun, string(kID))
+	privKeyFilename := filepath.Join(gun, fingerprint)
 	privKeyStore.Add(privKeyFilename, trustmanager.KeyToPEM(keyBytes))
 	return key, cert, nil
 }

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -67,7 +67,7 @@ func keysRemove(cmd *cobra.Command, args []string) {
 	gunOrID := args[0]
 
 	// Try to retrieve the ID from the CA store.
-	cert, err := caStore.GetCertificateBykID(gunOrID)
+	cert, err := caStore.GetCertificateByFingerprint(gunOrID)
 	if err == nil {
 		fmt.Printf("Removing: ")
 		printCert(cert)
@@ -81,7 +81,7 @@ func keysRemove(cmd *cobra.Command, args []string) {
 	}
 
 	// Try to retrieve the ID from the Certificate store.
-	cert, err = certificateStore.GetCertificateBykID(gunOrID)
+	cert, err = certificateStore.GetCertificateByFingerprint(gunOrID)
 	if err == nil {
 		fmt.Printf("Removing: ")
 		printCert(cert)
@@ -214,7 +214,7 @@ func keysGenerate(cmd *cobra.Command, args []string) {
 
 	certificateStore.AddCert(cert)
 	fingerprint := trustmanager.FingerprintCert(cert)
-	fmt.Println("Generated new keypair with ID: ", string(fingerprint))
+	fmt.Println("Generated new keypair with ID: ", fingerprint)
 }
 
 func newCertificate(gun, organization string) *x509.Certificate {
@@ -244,8 +244,8 @@ func newCertificate(gun, organization string) *x509.Certificate {
 
 func printCert(cert *x509.Certificate) {
 	timeDifference := cert.NotAfter.Sub(time.Now())
-	subjectKeyID := trustmanager.FingerprintCert(cert)
-	fmt.Printf("%s %s (expires in: %v days)\n", cert.Subject.CommonName, string(subjectKeyID), math.Floor(timeDifference.Hours()/24))
+	fingerprint := trustmanager.FingerprintCert(cert)
+	fmt.Printf("%s %s (expires in: %v days)\n", cert.Subject.CommonName, fingerprint, math.Floor(timeDifference.Hours()/24))
 }
 
 func printKey(keyPath string) {

--- a/notarymysql/start
+++ b/notarymysql/start
@@ -106,12 +106,12 @@ if [ -n "${DB_USER}" -o -n "${DB_NAME}" ]; then
         mysql -uroot -e "USE \`$db\`; DROP TABLE IF EXISTS \`$DB_TABLE\`;"
         mysql -uroot -e "USE \`$db\`; CREATE TABLE \`$DB_TABLE\` (
                     \`id\` int(11) NOT NULL AUTO_INCREMENT,
-                    \`qdn\` varchar(255) NOT NULL,
+                    \`gun\` varchar(255) NOT NULL,
                     \`role\` varchar(255) NOT NULL,
                     \`version\` int(11) NOT NULL,
                     \`data\` longblob NOT NULL,
                     PRIMARY KEY (\`id\`),
-                    UNIQUE KEY \`qdn\` (\`qdn\`,\`role\`,\`version\`)
+                    UNIQUE KEY \`gun\` (\`gun\`,\`role\`,\`version\`)
                     ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;"
       done
   fi

--- a/trustmanager/filestore_test.go
+++ b/trustmanager/filestore_test.go
@@ -182,7 +182,6 @@ func TestListGUN(t *testing.T) {
 		// Since we're generating this manually we need to add the extension '.'
 		fileName := fmt.Sprintf("%s-%s.%s", testName, strconv.Itoa(i), testExt)
 		expectedFilePath = filepath.Join(tempBaseDir, fileName)
-		fmt.Println(expectedFilePath)
 		_, err = generateRandomFile(expectedFilePath, perms)
 		if err != nil {
 			t.Fatalf("failed to generate random file: %v", err)

--- a/trustmanager/x509filestore.go
+++ b/trustmanager/x509filestore.go
@@ -203,6 +203,28 @@ func (s X509FileStore) GetVerifyOptions(dnsName string) (x509.VerifyOptions, err
 	return opts, nil
 }
 
+func (s X509FileStore) Verify(dnsName string, certs ...*x509.Certificate) error {
+	// If we have no Certificates loaded return error (we don't want to rever to using
+	// system CAs).
+	if len(s.fingerprintMap) == 0 {
+		return errors.New("no root CAs available")
+	}
+
+	// TODO: determine which cert in rootCerts is the leaf and add
+	// the intermediates to verifyOpts.Intermediates
+	opts := x509.VerifyOptions{
+		DNSName: dnsName,
+		Roots:   s.GetCertificatePool(),
+	}
+
+	// TODO: assuming only one cert ever passed and that it's the leaf
+	chains, err := certs[0].Verify(opts)
+	if len(chains) == 0 || err != nil {
+		return errors.New("Certificate did not verify")
+	}
+	return nil
+}
+
 func fileName(cert *x509.Certificate) string {
 	return path.Join(cert.Subject.CommonName, string(FingerprintCert(cert)))
 }

--- a/trustmanager/x509filestore.go
+++ b/trustmanager/x509filestore.go
@@ -68,7 +68,7 @@ func (s X509FileStore) AddCert(cert *x509.Certificate) error {
 // addNamedCert allows adding a certificate while controling the filename it gets
 // stored under. If the file does not exist on disk, saves it.
 func (s X509FileStore) addNamedCert(cert *x509.Certificate) error {
-	fingerprint := FingerprintCert(cert)
+	fingerprint := fingerprintCert(cert)
 
 	// Validate if we already loaded this certificate before
 	if _, ok := s.fingerprintMap[fingerprint]; ok {
@@ -103,7 +103,7 @@ func (s X509FileStore) RemoveCert(cert *x509.Certificate) error {
 		return errors.New("removing nil Certificate from X509Store")
 	}
 
-	fingerprint := FingerprintCert(cert)
+	fingerprint := fingerprintCert(cert)
 	delete(s.fingerprintMap, fingerprint)
 	filename := s.fileMap[fingerprint]
 	delete(s.fileMap, fingerprint)
@@ -170,8 +170,8 @@ func (s X509FileStore) GetCertificatePool() *x509.CertPool {
 	return pool
 }
 
-// GetCertificateBykID returns the certificate that matches a certain kID or error
-func (s X509FileStore) GetCertificateBykID(hexkID string) (*x509.Certificate, error) {
+// GetCertificateByFingerprint returns the certificate that matches a certain kID or error
+func (s X509FileStore) GetCertificateByFingerprint(hexkID string) (*x509.Certificate, error) {
 	// If it does not look like a hex encoded sha256 hash, error
 	if len(hexkID) != 64 {
 		return nil, errors.New("invalid Subject Key Identifier")
@@ -204,5 +204,5 @@ func (s X509FileStore) GetVerifyOptions(dnsName string) (x509.VerifyOptions, err
 }
 
 func fileName(cert *x509.Certificate) string {
-	return path.Join(cert.Subject.CommonName, string(FingerprintCert(cert)))
+	return path.Join(cert.Subject.CommonName, FingerprintCert(cert))
 }

--- a/trustmanager/x509filestore.go
+++ b/trustmanager/x509filestore.go
@@ -203,28 +203,6 @@ func (s X509FileStore) GetVerifyOptions(dnsName string) (x509.VerifyOptions, err
 	return opts, nil
 }
 
-func (s X509FileStore) Verify(dnsName string, certs ...*x509.Certificate) error {
-	// If we have no Certificates loaded return error (we don't want to rever to using
-	// system CAs).
-	if len(s.fingerprintMap) == 0 {
-		return errors.New("no root CAs available")
-	}
-
-	// TODO: determine which cert in rootCerts is the leaf and add
-	// the intermediates to verifyOpts.Intermediates
-	opts := x509.VerifyOptions{
-		DNSName: dnsName,
-		Roots:   s.GetCertificatePool(),
-	}
-
-	// TODO: assuming only one cert ever passed and that it's the leaf
-	chains, err := certs[0].Verify(opts)
-	if len(chains) == 0 || err != nil {
-		return errors.New("Certificate did not verify")
-	}
-	return nil
-}
-
 func fileName(cert *x509.Certificate) string {
 	return path.Join(cert.Subject.CommonName, string(FingerprintCert(cert)))
 }

--- a/trustmanager/x509memstore.go
+++ b/trustmanager/x509memstore.go
@@ -171,3 +171,27 @@ func (s X509MemStore) GetVerifyOptions(dnsName string) (x509.VerifyOptions, erro
 
 	return opts, nil
 }
+
+// TODO: Create a parent Store object that implements the shared methods
+// and gets embedded into this and the X509MemoryStore
+func (s X509MemStore) Verify(dnsName string, certs ...*x509.Certificate) error {
+	// If we have no Certificates loaded return error (we don't want to rever to using
+	// system CAs).
+	if len(s.fingerprintMap) == 0 {
+		return errors.New("no root CAs available")
+	}
+
+	// TODO: determine which cert in rootCerts is the leaf and add
+	// the intermediates to verifyOpts.Intermediates
+	opts := x509.VerifyOptions{
+		DNSName: dnsName,
+		Roots:   s.GetCertificatePool(),
+	}
+
+	// TODO: assuming only one cert ever passed and that it's the leaf
+	chains, err := certs[0].Verify(opts)
+	if len(chains) == 0 || err != nil {
+		return errors.New("Certificate did not verify")
+	}
+	return nil
+}

--- a/trustmanager/x509memstore.go
+++ b/trustmanager/x509memstore.go
@@ -171,27 +171,3 @@ func (s X509MemStore) GetVerifyOptions(dnsName string) (x509.VerifyOptions, erro
 
 	return opts, nil
 }
-
-// TODO: Create a parent Store object that implements the shared methods
-// and gets embedded into this and the X509MemoryStore
-func (s X509MemStore) Verify(dnsName string, certs ...*x509.Certificate) error {
-	// If we have no Certificates loaded return error (we don't want to rever to using
-	// system CAs).
-	if len(s.fingerprintMap) == 0 {
-		return errors.New("no root CAs available")
-	}
-
-	// TODO: determine which cert in rootCerts is the leaf and add
-	// the intermediates to verifyOpts.Intermediates
-	opts := x509.VerifyOptions{
-		DNSName: dnsName,
-		Roots:   s.GetCertificatePool(),
-	}
-
-	// TODO: assuming only one cert ever passed and that it's the leaf
-	chains, err := certs[0].Verify(opts)
-	if len(chains) == 0 || err != nil {
-		return errors.New("Certificate did not verify")
-	}
-	return nil
-}

--- a/trustmanager/x509memstore.go
+++ b/trustmanager/x509memstore.go
@@ -47,7 +47,7 @@ func (s X509MemStore) AddCert(cert *x509.Certificate) error {
 		return errors.New("certificate failed validation")
 	}
 
-	fingerprint := FingerprintCert(cert)
+	fingerprint := fingerprintCert(cert)
 
 	s.fingerprintMap[fingerprint] = cert
 	name := string(cert.RawSubject)
@@ -62,7 +62,7 @@ func (s X509MemStore) RemoveCert(cert *x509.Certificate) error {
 		return errors.New("removing nil Certificate to X509Store")
 	}
 
-	fingerprint := FingerprintCert(cert)
+	fingerprint := fingerprintCert(cert)
 	delete(s.fingerprintMap, fingerprint)
 	name := string(cert.RawSubject)
 
@@ -139,8 +139,8 @@ func (s X509MemStore) GetCertificatePool() *x509.CertPool {
 	return pool
 }
 
-// GetCertificateBykID returns the certificate that matches a certain kID or error
-func (s X509MemStore) GetCertificateBykID(hexkID string) (*x509.Certificate, error) {
+// GetCertificateByFingerprint returns the certificate that matches a certain kID or error
+func (s X509MemStore) GetCertificateByFingerprint(hexkID string) (*x509.Certificate, error) {
 	// If it does not look like a hex encoded sha256 hash, error
 	if len(hexkID) != 64 {
 		return nil, errors.New("invalid Subject Key Identifier")

--- a/trustmanager/x509memstore_test.go
+++ b/trustmanager/x509memstore_test.go
@@ -106,20 +106,20 @@ func TestRemoveCert(t *testing.T) {
 	}
 }
 
-func TestInexistentGetCertificateBykID(t *testing.T) {
+func TestInexistentGetCertificateByFingerprint(t *testing.T) {
 	store := NewX509MemStore()
 	err := store.AddCertFromFile("../fixtures/notary/root-ca.crt")
 	if err != nil {
 		t.Fatalf("failed to load certificate from file: %v", err)
 	}
 
-	_, err = store.GetCertificateBykID("4d06afd30b8bed131d2a84c97d00b37f422021598bfae34285ce98e77b708b5a")
+	_, err = store.GetCertificateByFingerprint("4d06afd30b8bed131d2a84c97d00b37f422021598bfae34285ce98e77b708b5a")
 	if err == nil {
 		t.Fatalf("no error returned for inexistent certificate")
 	}
 }
 
-func TestGetCertificateBykID(t *testing.T) {
+func TestGetCertificateByFingerprint(t *testing.T) {
 	b, err := ioutil.ReadFile("../fixtures/notary/root-ca.crt")
 	if err != nil {
 		t.Fatalf("couldn't load fixture: %v", err)
@@ -141,7 +141,7 @@ func TestGetCertificateBykID(t *testing.T) {
 	certFingerprint := FingerprintCert(cert)
 
 	// Tries to retrieve cert by Subject Key IDs
-	_, err = store.GetCertificateBykID(string(certFingerprint))
+	_, err = store.GetCertificateByFingerprint(certFingerprint)
 	if err != nil {
 		t.Fatalf("expected certificate in store: %s", certFingerprint)
 	}

--- a/trustmanager/x509memstore_test.go
+++ b/trustmanager/x509memstore_test.go
@@ -140,7 +140,7 @@ func TestGetCertificateBykID(t *testing.T) {
 
 	certFingerprint := FingerprintCert(cert)
 
-	// Tries to retreive cert by Subject Key IDs
+	// Tries to retrieve cert by Subject Key IDs
 	_, err = store.GetCertificateBykID(string(certFingerprint))
 	if err != nil {
 		t.Fatalf("expected certificate in store: %s", certFingerprint)

--- a/trustmanager/x509store.go
+++ b/trustmanager/x509store.go
@@ -14,6 +14,7 @@ type X509Store interface {
 	GetCertificates() []*x509.Certificate
 	GetCertificatePool() *x509.CertPool
 	GetVerifyOptions(dnsName string) (x509.VerifyOptions, error)
+	Verify(dnsName string, certs ...*x509.Certificate) error
 }
 
 type CertID string

--- a/trustmanager/x509store.go
+++ b/trustmanager/x509store.go
@@ -92,7 +92,7 @@ func Verify(s X509Store, dnsName string, certList []*x509.Certificate) error {
 	// Finally, let's call Verify on our leafCert with our fully configured options
 	chains, err := leafCert.Verify(opts)
 	if len(chains) == 0 || err != nil {
-		return fmt.Errorf("certificate validation failed not verify: %v", err)
+		return fmt.Errorf("certificate verification failed: %v", err)
 	}
 	return nil
 }

--- a/trustmanager/x509store.go
+++ b/trustmanager/x509store.go
@@ -14,7 +14,7 @@ type X509Store interface {
 	AddCertFromPEM(pemCerts []byte) error
 	AddCertFromFile(filename string) error
 	RemoveCert(cert *x509.Certificate) error
-	GetCertificateBykID(hexkID string) (*x509.Certificate, error)
+	GetCertificateByFingerprint(fingerprint string) (*x509.Certificate, error)
 	GetCertificates() []*x509.Certificate
 	GetCertificatePool() *x509.CertPool
 	GetVerifyOptions(dnsName string) (x509.VerifyOptions, error)

--- a/trustmanager/x509store.go
+++ b/trustmanager/x509store.go
@@ -1,6 +1,10 @@
 package trustmanager
 
-import "crypto/x509"
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+)
 
 const certExtension string = "crt"
 
@@ -14,7 +18,6 @@ type X509Store interface {
 	GetCertificates() []*x509.Certificate
 	GetCertificatePool() *x509.CertPool
 	GetVerifyOptions(dnsName string) (x509.VerifyOptions, error)
-	Verify(dnsName string, certs ...*x509.Certificate) error
 }
 
 type CertID string
@@ -33,4 +36,63 @@ type ValidatorFunc func(cert *x509.Certificate) bool
 // to be passed as a Validator
 func (vf ValidatorFunc) Validate(cert *x509.Certificate) bool {
 	return vf(cert)
+}
+
+// Verify operates on an X509Store and validates the existence of a chain of trust
+// between a leafCertificate and a CA present inside of the X509 Store.
+// It requires at least two certificates in certList, a leaf Certificate and an
+// intermediate CA certificate.
+func Verify(s X509Store, dnsName string, certList []*x509.Certificate) error {
+	// If we have no Certificates loaded return error (we don't want to revert to using
+	// system CAs).
+	if len(s.GetCertificates()) == 0 {
+		return errors.New("no root CAs available")
+	}
+
+	// At a minimum we should be provided a leaf cert and an intermediate.
+	if len(certList) < 2 {
+		return errors.New("certificate and at least one intermediate needed")
+	}
+
+	// Get the VerifyOptions from the keystore for a base dnsName
+	opts, err := s.GetVerifyOptions(dnsName)
+	if err != nil {
+		return err
+	}
+
+	// Create a Certificate Pool for our intermediate certificates
+	intPool := x509.NewCertPool()
+	var leafCert *x509.Certificate
+
+	// Iterate through all the certificates
+	for _, c := range certList {
+		// If the cert is a CA, we add it to the intermediates pool. If not, we call
+		// it the leaf cert
+		if c.IsCA {
+			intPool.AddCert(c)
+			continue
+		}
+		// Certificate is not a CA, it must be our leaf certificate.
+		// If we already found one, bail with error
+		if leafCert != nil {
+			return errors.New("more than one leaf certificate found")
+		}
+		leafCert = c
+	}
+
+	// We exited the loop with no leaf certificates
+	if leafCert == nil {
+		return errors.New("no leaf certificates found")
+	}
+
+	// We have one leaf certificate and at least one intermediate. Lets add this
+	// Cert Pool as the Intermediates list on our VerifyOptions
+	opts.Intermediates = intPool
+
+	// Finally, let's call Verify on our leafCert with our fully configured options
+	chains, err := leafCert.Verify(opts)
+	if len(chains) == 0 || err != nil {
+		return fmt.Errorf("certificate validation failed not verify: %v", err)
+	}
+	return nil
 }

--- a/trustmanager/x509store_test.go
+++ b/trustmanager/x509store_test.go
@@ -1,0 +1,155 @@
+package trustmanager
+
+import (
+	"crypto/x509"
+	"fmt"
+	"testing"
+)
+
+func TestVerifyLeafSuccessfully(t *testing.T) {
+	// Get root certificate
+	rootCA, err := LoadCertFromFile("../fixtures/notary/root-ca.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Get intermediate certificate
+	intermediateCA, err := LoadCertFromFile("../fixtures/notary/ca.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Get leaf certificate
+	leafCert, err := LoadCertFromFile("../fixtures/notary/secure.docker.com.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Create a store and add the CA root
+	store := NewX509MemStore()
+	err = store.AddCert(rootCA)
+	if err != nil {
+		t.Fatalf("failed to load certificate from file: %v", err)
+	}
+
+	// Get our certList with Leaf Cert and Intermediate
+	certList := []*x509.Certificate{leafCert, intermediateCA}
+
+	// Get the VerifyOptions from our Store
+	opts, err := store.GetVerifyOptions("secure.docker.com")
+	fmt.Println(opts)
+
+	// Try to find a valid chain for cert
+	err = Verify(store, "secure.docker.com", certList)
+	if err != nil {
+		t.Fatalf("expected to find a valid chain for this certificate: %v", err)
+	}
+}
+
+func TestVerifyLeafSuccessfullyWithMultipleIntermediates(t *testing.T) {
+	// Get root certificate
+	rootCA, err := LoadCertFromFile("../fixtures/notary/root-ca.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Get intermediate certificate
+	intermediateCA, err := LoadCertFromFile("../fixtures/notary/ca.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Get leaf certificate
+	leafCert, err := LoadCertFromFile("../fixtures/notary/secure.docker.com.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Create a store and add the CA root
+	store := NewX509MemStore()
+	err = store.AddCert(rootCA)
+	if err != nil {
+		t.Fatalf("failed to load certificate from file: %v", err)
+	}
+
+	// Get our certList with Leaf Cert and Intermediate
+	certList := []*x509.Certificate{leafCert, intermediateCA, intermediateCA, rootCA}
+
+	// Get the VerifyOptions from our Store
+	opts, err := store.GetVerifyOptions("secure.docker.com")
+	fmt.Println(opts)
+
+	// Try to find a valid chain for cert
+	err = Verify(store, "secure.docker.com", certList)
+	if err != nil {
+		t.Fatalf("expected to find a valid chain for this certificate: %v", err)
+	}
+}
+
+func TestVerifyLeafWithNoIntermediate(t *testing.T) {
+	// Get root certificate
+	rootCA, err := LoadCertFromFile("../fixtures/notary/root-ca.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Get leaf certificate
+	leafCert, err := LoadCertFromFile("../fixtures/notary/secure.docker.com.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Create a store and add the CA root
+	store := NewX509MemStore()
+	err = store.AddCert(rootCA)
+	if err != nil {
+		t.Fatalf("failed to load certificate from file: %v", err)
+	}
+
+	// Get our certList with Leaf Cert and Intermediate
+	certList := []*x509.Certificate{leafCert, leafCert}
+
+	// Get the VerifyOptions from our Store
+	opts, err := store.GetVerifyOptions("secure.docker.com")
+	fmt.Println(opts)
+
+	// Try to find a valid chain for cert
+	err = Verify(store, "secure.docker.com", certList)
+	if err == nil {
+		t.Fatalf("expected error due to more than one leaf certificate")
+	}
+}
+
+func TestVerifyLeafWithNoLeaf(t *testing.T) {
+	// Get root certificate
+	rootCA, err := LoadCertFromFile("../fixtures/notary/root-ca.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Get intermediate certificate
+	intermediateCA, err := LoadCertFromFile("../fixtures/notary/ca.crt")
+	if err != nil {
+		t.Fatalf("couldn't load fixture: %v", err)
+	}
+
+	// Create a store and add the CA root
+	store := NewX509MemStore()
+	err = store.AddCert(rootCA)
+	if err != nil {
+		t.Fatalf("failed to load certificate from file: %v", err)
+	}
+
+	// Get our certList with Leaf Cert and Intermediate
+	certList := []*x509.Certificate{intermediateCA, intermediateCA}
+
+	// Get the VerifyOptions from our Store
+	opts, err := store.GetVerifyOptions("secure.docker.com")
+	fmt.Println(opts)
+
+	// Try to find a valid chain for cert
+	err = Verify(store, "secure.docker.com", certList)
+	if err == nil {
+		t.Fatalf("expected error due to no leafs provided")
+	}
+}

--- a/trustmanager/x509utils.go
+++ b/trustmanager/x509utils.go
@@ -83,7 +83,11 @@ func loadCertFromPEM(pemBytes []byte) (*x509.Certificate, error) {
 	return nil, errors.New("no certificates found in PEM data")
 }
 
-func FingerprintCert(cert *x509.Certificate) CertID {
+func FingerprintCert(cert *x509.Certificate) string {
+	return string(fingerprintCert(cert))
+}
+
+func fingerprintCert(cert *x509.Certificate) CertID {
 	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
 	pemdata := string(pem.EncodeToMemory(&block))
 


### PR DESCRIPTION
As part of bootstrapping a TUF client, validate the downloaded root.json against our cert store. Per conversation with @NathanMcCauley the logic is as follows:

1. Parse root.json
2. Read Key IDs associated with the root role.
3. Read keys (from the root.json) associated with the root role key IDs.
4. Validate keys from root.json against local cert pool.
5. Using only keys that validated against cert pool, validate signatures on the root.json, requiring a threshold of 1.