### PR TITLE
adding exec command that pipes into shell directly

### DIFF
--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -105,6 +105,7 @@ func main() {
 	cmdTufLookup.Flags().BoolVarP(&rawOutput, "raw", "", false, "Instructs notary lookup to output a non-pretty printed version of the targets list. Useful if you need to parse the list.")
 	cmdTufLookup.Flags().StringVarP(&remoteTrustServer, "remote", "r", "", "Remote trust server location")
 	NotaryCmd.AddCommand(cmdVerify)
+	NotaryCmd.AddCommand(cmdExec)
 
 	NotaryCmd.Execute()
 }


### PR DESCRIPTION
Allows you to stop doing this:
```
curl example.com/install.sh | notary verify example.com/install v1 | sh
```
And start doing this:
```
curl example.com/install.sh | notary exec example.com/install v1
```

Signed-off-by: Jeff Lindsay <progrium@gmail.com>