### PR TITLE
Removed all references of GUN from filestore

### DIFF
--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -81,7 +81,7 @@ func keysRemove(cmd *cobra.Command, args []string) {
 	}
 
 	// We didn't find a certificate with this ID, let's try to see if we can find keys.
-	keyList := privKeyStore.ListGUN(gunOrID)
+	keyList := privKeyStore.ListDir(gunOrID)
 	if len(keyList) < 1 {
 		fatalf("no Private Keys found under Global Unique Name: %s", gunOrID)
 	}
@@ -99,7 +99,7 @@ func keysRemove(cmd *cobra.Command, args []string) {
 	}
 
 	// Remove all the keys under the Global Unique Name
-	err = privKeyStore.RemoveGUN(gunOrID)
+	err = privKeyStore.RemoveDir(gunOrID)
 	if err != nil {
 		fatalf("failed to remove all Private keys under Global Unique Name: %s", gunOrID)
 	}
@@ -163,7 +163,7 @@ func keysList(cmd *cobra.Command, args []string) {
 
 	fmt.Println("")
 	fmt.Println("# Signing keys: ")
-	for _, k := range privKeyStore.List() {
+	for _, k := range privKeyStore.ListAll() {
 		printKey(k)
 	}
 }

--- a/trustmanager/filestore_test.go
+++ b/trustmanager/filestore_test.go
@@ -89,7 +89,7 @@ func TestRemoveFile(t *testing.T) {
 	}
 }
 
-func TestRemoveGUN(t *testing.T) {
+func TestRemoveDir(t *testing.T) {
 	testName := "docker.com/diogomonica/"
 	testExt := "key"
 	perms := os.FileMode(0700)
@@ -115,8 +115,8 @@ func TestRemoveGUN(t *testing.T) {
 		perms:   perms,
 	}
 
-	// Call the RemoveGUN function
-	err = store.RemoveGUN(testName)
+	// Call the RemoveDir function
+	err = store.RemoveDir(testName)
 	if err != nil {
 		t.Fatalf("failed to remove directory: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestRemoveGUN(t *testing.T) {
 	}
 }
 
-func TestList(t *testing.T) {
+func TestListAll(t *testing.T) {
 	testName := "docker.com/notary/certificate"
 	testExt := "crt"
 	perms := os.FileMode(0755)
@@ -159,13 +159,13 @@ func TestList(t *testing.T) {
 	}
 
 	// Call the List function
-	files := store.List()
+	files := store.ListAll()
 	if len(files) != 10 {
 		t.Fatalf("expected 10 files in listing, got: %d", len(files))
 	}
 }
 
-func TestListGUN(t *testing.T) {
+func TestListDir(t *testing.T) {
 	testName := "docker.com/notary/certificate"
 	testExt := "crt"
 	perms := os.FileMode(0755)
@@ -196,16 +196,16 @@ func TestListGUN(t *testing.T) {
 		perms:   perms,
 	}
 
-	// Call the ListGUN function
-	files := store.ListGUN("docker.com/")
+	// Call the ListDir function
+	files := store.ListDir("docker.com/")
 	if len(files) != 10 {
 		t.Fatalf("expected 10 files in listing, got: %d", len(files))
 	}
-	files = store.ListGUN("docker.com/notary")
+	files = store.ListDir("docker.com/notary")
 	if len(files) != 10 {
 		t.Fatalf("expected 10 files in listing, got: %d", len(files))
 	}
-	files = store.ListGUN("fakedocker.com/")
+	files = store.ListDir("fakedocker.com/")
 	if len(files) != 0 {
 		t.Fatalf("expected 0 files in listing, got: %d", len(files))
 	}

--- a/trustmanager/x509utils.go
+++ b/trustmanager/x509utils.go
@@ -95,7 +95,7 @@ func FingerprintCert(cert *x509.Certificate) CertID {
 
 // loadCertsFromDir receives a store AddCertFromFile for each certificate found
 func loadCertsFromDir(s *X509FileStore) {
-	certFiles := s.fileStore.List()
+	certFiles := s.fileStore.ListAll()
 	for _, c := range certFiles {
 		s.AddCertFromFile(c)
 	}


### PR DESCRIPTION
@endophage removed GUN references for the FileStore as you requested.

The FileStore still does operations on directories (which might be sightly counterintuitive), but at least now it's explicit that you're removing a directory, and should pass a param accordingly.

This also bails if you pass a file, instead of a directory.

Signed-off-by: Diogo Monica <diogo@docker.com>
