### PR TITLE
Adding support for encrypted files to filestore

### DIFF
--- a/cmd/notary/cli_crypto_service.go
+++ b/cmd/notary/cli_crypto_service.go
@@ -32,7 +32,7 @@ func (ccs *cliCryptoService) Create(role string) (*data.PublicKey, error) {
 		return nil, err
 	}
 
-	// PEM ENcode the certificate, which will be put directly inside of TUF's root.json
+	// PEM Encode the certificate, which will be put directly inside of TUF's root.json
 	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}
 	pemdata := pem.EncodeToMemory(&block)
 

--- a/trustmanager/filestore.go
+++ b/trustmanager/filestore.go
@@ -108,7 +108,6 @@ func (f *fileStore) AddEncrypted(name string, plaintext []byte, passphrase strin
 	}
 
 	// Generate random nonce for GCM
-	fmt.Println(gcm.NonceSize())
 	nonce := make([]byte, NonceSize)
 	_, err = rand.Read(nonce)
 	if err != nil {

--- a/trustmanager/filestore.go
+++ b/trustmanager/filestore.go
@@ -164,8 +164,8 @@ func (f *fileStore) GetEncrypted(name string, passphrase string) ([]byte, error)
 	}
 
 	// Get the salt from the first SaltSize bytes in data
-	salt := make([]byte, SaltSize)
-	copy(salt, data[:SaltSize])
+	salt := data[:SaltSize]
+	data = data[SaltSize:]
 
 	// With the salt, we can generate key derived from passphrase
 	derivedKey, err := scrypt.Key([]byte(passphrase), salt, 16384, 8, 1, KeySize)
@@ -184,11 +184,11 @@ func (f *fileStore) GetEncrypted(name string, passphrase string) ([]byte, error)
 	}
 
 	// Get the nonce from the next NonceSize bytes in data
-	nonce := make([]byte, gcm.NonceSize())
-	copy(nonce, data[SaltSize:SaltSize+gcm.NonceSize()])
+	nonce := data[:gcm.NonceSize()]
+	data = data[gcm.NonceSize():]
 
 	// Decrypt the data and return plaintext
-	outData, err := gcm.Open(nil, nonce, data[SaltSize+gcm.NonceSize():], nil)
+	outData, err := gcm.Open(nil, nonce, data, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/trustmanager/filestore.go
+++ b/trustmanager/filestore.go
@@ -15,8 +15,14 @@ import (
 const visible os.FileMode = 0755
 const private os.FileMode = 0700
 const encryptedExt string = "enc"
-const SaltSize int = 32
-const KeySize int = 32
+
+const (
+	SaltSize = 32
+	KeySize  = 32
+	ScryptN  = 32768
+	ScryptR  = 8
+	ScryptP  = 1
+)
 
 // FileStore is the interface for all FileStores
 type FileStore interface {
@@ -83,7 +89,7 @@ func (f *fileStore) AddEncrypted(name string, data []byte, passphrase string) er
 	}
 
 	// With the salt, generate key derived from passphrase
-	derivedKey, err := scrypt.Key([]byte(passphrase), salt, 16384, 8, 1, KeySize)
+	derivedKey, err := scrypt.Key([]byte(passphrase), salt, ScryptN, ScryptR, ScryptP, KeySize)
 	if err != nil {
 		return err
 	}
@@ -168,7 +174,7 @@ func (f *fileStore) GetEncrypted(name string, passphrase string) ([]byte, error)
 	data = data[SaltSize:]
 
 	// With the salt, we can generate key derived from passphrase
-	derivedKey, err := scrypt.Key([]byte(passphrase), salt, 16384, 8, 1, KeySize)
+	derivedKey, err := scrypt.Key([]byte(passphrase), salt, ScryptN, ScryptR, ScryptP, KeySize)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
@NathanMcCauley @endophage adds support for encrypted files in filestore. The main goal is to encrypt root keys in a future PR.

Signed-off-by: Diogo Monica <diogo@docker.com>