### PR TITLE
Fix default log level

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -33,7 +33,7 @@ var configFile string
 
 func init() {
 	// set default log level to Error
-	viper.SetDefault("logging.level", 2)
+	viper.SetDefault("logging", map[string]interface{}{"level": 2})
 
 	// Setup flags
 	flag.StringVar(&configFile, "config", "", "Path to configuration file")


### PR DESCRIPTION
Work around bug in viper configuration.
Viper will always use the default since it matches the whole key match first.
Setting the default to a map keeps the config file as the first matched item.
