### PR TITLE
Change NotaryRepository to honor the baseURL passed in

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -56,7 +55,6 @@ type NotaryRepository struct {
 	Gun              string
 	baseURL          string
 	tufRepoPath      string
-	transport        http.RoundTripper
 	caStore          trustmanager.X509Store
 	certificateStore trustmanager.X509Store
 	fileStore        store.MetadataStore
@@ -92,7 +90,7 @@ func NewTarget(targetName string, targetPath string) (*Target, error) {
 // NewClient is a helper method that returns a new notary Client, given a config
 // file. It makes the assumption that the base directory for the config file will
 // be the place where trust information is being cached locally.
-func NewNotaryRepository(baseDir, gun, baseURL string, transport http.RoundTripper) (*NotaryRepository, error) {
+func NewNotaryRepository(baseDir, gun, baseURL string) (*NotaryRepository, error) {
 	trustDir := filepath.Join(baseDir, trustDir)
 	rootKeysDir := filepath.Join(baseDir, rootKeysDir)
 
@@ -108,7 +106,6 @@ func NewNotaryRepository(baseDir, gun, baseURL string, transport http.RoundTripp
 		baseDir:      baseDir,
 		baseURL:      baseURL,
 		tufRepoPath:  filepath.Join(baseDir, tufDir, gun),
-		transport:    transport,
 		signer:       signer,
 		privKeyStore: privKeyStore,
 	}
@@ -134,7 +131,7 @@ func (r *NotaryRepository) Initialize(uSigner *UnlockedSigner) error {
 		return err
 	}
 
-	remote, err := getRemoteStore(r.Gun)
+	remote, err := getRemoteStore(r.baseURL, r.Gun)
 	rawTSKey, err := remote.GetKey("timestamp")
 	if err != nil {
 		return err
@@ -360,7 +357,7 @@ func (r *NotaryRepository) Publish(getPass passwordRetriever) error {
 		return err
 	}
 
-	remote, err := getRemoteStore(r.Gun)
+	remote, err := getRemoteStore(r.baseURL, r.Gun)
 	if err != nil {
 		return err
 	}
@@ -560,7 +557,7 @@ func (r *NotaryRepository) ValidateRoot(root *data.Signed) error {
 }
 
 func (r *NotaryRepository) bootstrapClient() (*tufclient.Client, error) {
-	remote, err := getRemoteStore(r.Gun)
+	remote, err := getRemoteStore(r.baseURL, r.Gun)
 	if err != nil {
 		return nil, err
 	}

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -11,9 +11,9 @@ import (
 )
 
 // Use this to initialize remote HTTPStores from the config settings
-func getRemoteStore(gun string) (store.RemoteStore, error) {
+func getRemoteStore(baseURL, gun string) (store.RemoteStore, error) {
 	return store.NewHTTPStore(
-		"https://notary:4443/v2/"+gun+"/_trust/tuf/",
+		baseURL+"/v2/"+gun+"/_trust/tuf/",
 		"",
 		"json",
 		"",

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 
 	"github.com/Sirupsen/logrus"
@@ -14,6 +13,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// FIXME: This should not be hardcoded
+const hardcodedBaseURL = "https://notary:4443"
 
 var remoteTrustServer string
 
@@ -76,8 +78,7 @@ func tufAdd(cmd *cobra.Command, args []string) {
 	targetName := args[1]
 	targetPath := args[2]
 
-	t := &http.Transport{}
-	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, "", t)
+	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, hardcodedBaseURL)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -100,9 +101,8 @@ func tufInit(cmd *cobra.Command, args []string) {
 	}
 
 	gun := args[0]
-	t := &http.Transport{}
 
-	nRepo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, "", t)
+	nRepo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, hardcodedBaseURL)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -131,8 +131,7 @@ func tufList(cmd *cobra.Command, args []string) {
 	}
 	gun := args[0]
 
-	t := &http.Transport{}
-	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, "", t)
+	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, hardcodedBaseURL)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -157,8 +156,7 @@ func tufLookup(cmd *cobra.Command, args []string) {
 	gun := args[0]
 	targetName := args[1]
 
-	t := &http.Transport{}
-	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, "", t)
+	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, hardcodedBaseURL)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -182,8 +180,7 @@ func tufPublish(cmd *cobra.Command, args []string) {
 
 	fmt.Println("Pushing changes to ", gun, ".")
 
-	t := &http.Transport{}
-	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, "", t)
+	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, hardcodedBaseURL)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -228,8 +225,7 @@ func verify(cmd *cobra.Command, args []string) {
 	//TODO (diogo): This code is copy/pasted from lookup.
 	gun := args[0]
 	targetName := args[1]
-	t := &http.Transport{}
-	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, "", t)
+	repo, err := notaryclient.NewNotaryRepository(viper.GetString("baseTrustDir"), gun, hardcodedBaseURL)
 	if err != nil {
 		fatalf(err.Error())
 	}


### PR DESCRIPTION
Remove "transport", because it's not used.

In the actual notary client, pass in a hard-coded URL for now (same one
previously hardcoded in getRemoteStore). In tests, create a trivial HTTP
server using net/http/httptest, which returns a timestamp.key file.