### PR TITLE
Remove use of old version of Docker in circle build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ machine:
 
   post:
   # Install many go versions
-    - gvm install go1.3.3 -B --name=old
     - gvm install go1.4.2 -B --name=stable
 
   environment:


### PR DESCRIPTION
We don't need to build on go 1.3.x, especially if it is missing crypto functionality being used by notary or tuf