### PR TITLE
Fix example configuration file given in README.md

### DIFF
--- a/cmd/notary-server/README.md
+++ b/cmd/notary-server/README.md
@@ -59,7 +59,7 @@ The configuration file must be a json file with the following format:
         "addr": ":4443",
         "tls_cert_file": "./fixtures/notary.pem",
         "tls_key_file": "./fixtures/notary.key"
-    }
+    },
     "logging": {
         "level": 5
     }


### PR DESCRIPTION
The example configuration given in README.md is missing a comma character and doesn't form valid JSON. 

This PR adds the comma as required.