### PR TITLE
Deploy notary on staging.

### DIFF
--- a/cmd/notary-server/stage-config.json
+++ b/cmd/notary-server/stage-config.json
@@ -1,0 +1,13 @@
+{
+	"server": {
+		"addr": ":4443"
+	},
+	"trust_service": {
+		"type": "local",
+		"hostname": "",
+		"port": ""
+	},
+	"logging": {
+		"level": 5
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ notary:
   links:
    - notarymysql
   ports:
-   - "8080:8080"
-   - "4443:4443"
+   - "8081"
+   - "4443"
+  environment:
+    SERVICE_NAME: notary
 #rufus:
 #  volumes:
 #   - /dev/bus/usb/003/010:/dev/bus/usb/002/010


### PR DESCRIPTION
Create a stage-config files without SSL keys as SSL is terminated
at the ELB.

Add a service name for correct routing from https://notary-stage.docker.io