### PR TITLE
Fix access controller resource type

### DIFF
--- a/utils/http.go
+++ b/utils/http.go
@@ -78,7 +78,7 @@ func buildAccessRecords(repo string, actions ...string) []auth.Access {
 	for _, action := range actions {
 		requiredAccess = append(requiredAccess, auth.Access{
 			Resource: auth.Resource{
-				Type: "repo",
+				Type: "repository",
 				Name: repo,
 			},
 			Action: action,


### PR DESCRIPTION
The token server returns tokens with the type as "repository" not "repo".

Example token body
```
{
  "access": [
    {
      "type": "repository",
      "name": "dmcgowan/busysleep2",
      "actions": [
        "pull",
        "push"
      ]
    }
  ],
  "aud": "notary.docker.io",
  "exp": 1436827486,
  "iat": 1436827186,
  "iss": "auth.docker.io",
  "jti": "7n6E3t3-EdKg1D_Cgbg0",
  "nbf": 1436827186,
  "sub": "dmcgowan"
}
```