### PR TITLE
Add ping endpoint

### DIFF
--- a/server/handlers/default.go
+++ b/server/handlers/default.go
@@ -23,9 +23,13 @@ import (
 // MainHandler is the default handler for the server
 func MainHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) *errors.HTTPError {
 	if r.Method == "GET" {
-		err := json.NewEncoder(w).Encode("{}")
+		_, err := w.Write([]byte("{}"))
 		if err != nil {
-			w.Write([]byte("{server_error: 'Could not parse error message'}"))
+			return &errors.HTTPError{
+				HTTPStatus: http.StatusInternalServerError,
+				Code:       9999,
+				Err:        err,
+			}
 		}
 	} else {
 		//w.WriteHeader(http.StatusNotFound)

--- a/server/server.go
+++ b/server/server.go
@@ -76,6 +76,7 @@ func Run(ctx context.Context, addr, tlsCertFile, tlsKeyFile string, trust signed
 
 	r := mux.NewRouter()
 	// TODO (endophage): use correct regexes for image and tag names
+	r.Methods("GET").Path("/v2/").Handler(hand(handlers.MainHandler))
 	r.Methods("POST").Path("/v2/{imageName:.*}/_trust/tuf/").Handler(hand(handlers.AtomicUpdateHandler, "push", "pull"))
 	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:(root|targets|snapshot)}.json").Handler(hand(handlers.GetHandler, "pull"))
 	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/timestamp.json").Handler(hand(handlers.GetTimestampHandler, "pull"))


### PR DESCRIPTION
Ping endpoint added so clients can get the list of authentication challenges before making an initial request.

The clients could be coded without a ping endpoint but that requires closer integration of the token auth with the client which does not currently exist. This is the fastest approach to get authentication functional.