### PR TITLE
KeyStoreManager

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -106,7 +106,7 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 
 	// Also expect a symlink from the key ID of the certificate key to this
 	// root key
-	certificates := repo.certificateStore.GetCertificates()
+	certificates := repo.KeyStoreManager.CertificateStore().GetCertificates()
 	assert.Len(t, certificates, 1, "unexpected number of certificates")
 
 	certID, err := trustmanager.FingerprintCert(certificates[0])

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -91,7 +91,7 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 
 	// Look for keys in private. The filenames should match the key IDs
 	// in the private key store.
-	privKeyList := repo.privKeyStore.ListFiles(true)
+	privKeyList := repo.KeyStoreManager.NonRootKeyStore().ListFiles(true)
 	for _, privKeyName := range privKeyList {
 		_, err := os.Stat(privKeyName)
 		assert.NoError(t, err, "missing private key: %s", privKeyName)
@@ -309,7 +309,7 @@ func testAddListTarget(t *testing.T, rootType data.KeyAlgorithm) {
 	var tempKey data.PrivateKey
 	json.Unmarshal([]byte(timestampECDSAKeyJSON), &tempKey)
 
-	repo.privKeyStore.AddKey(filepath.Join(gun, tempKey.ID()), &tempKey)
+	repo.KeyStoreManager.NonRootKeyStore().AddKey(filepath.Join(gun, tempKey.ID()), &tempKey)
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/root.json", func(w http.ResponseWriter, r *http.Request) {
 		rootJSONFile := filepath.Join(tempBaseDir, "tuf", gun, "metadata", "root.json")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -63,10 +63,10 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 	repo, err := NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport)
 	assert.NoError(t, err, "error creating repo: %s", err)
 
-	rootKeyID, err := repo.GenRootKey(rootType.String(), "passphrase")
+	rootKeyID, err := repo.KeyStoreManager.GenRootKey(rootType.String(), "passphrase")
 	assert.NoError(t, err, "error generating root key: %s", err)
 
-	rootCryptoService, err := repo.GetRootCryptoService(rootKeyID, "passphrase")
+	rootCryptoService, err := repo.KeyStoreManager.GetRootCryptoService(rootKeyID, "passphrase")
 	assert.NoError(t, err, "error retrieving root key: %s", err)
 
 	err = repo.Initialize(rootCryptoService)
@@ -207,10 +207,10 @@ func testAddListTarget(t *testing.T, rootType data.KeyAlgorithm) {
 	repo, err := NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport)
 	assert.NoError(t, err, "error creating repository: %s", err)
 
-	rootKeyID, err := repo.GenRootKey(rootType.String(), "passphrase")
+	rootKeyID, err := repo.KeyStoreManager.GenRootKey(rootType.String(), "passphrase")
 	assert.NoError(t, err, "error generating root key: %s", err)
 
-	rootCryptoService, err := repo.GetRootCryptoService(rootKeyID, "passphrase")
+	rootCryptoService, err := repo.KeyStoreManager.GetRootCryptoService(rootKeyID, "passphrase")
 	assert.NoError(t, err, "error retreiving root key: %s", err)
 
 	err = repo.Initialize(rootCryptoService)
@@ -392,10 +392,10 @@ func testValidateRootKey(t *testing.T, rootType data.KeyAlgorithm) {
 	repo, err := NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport)
 	assert.NoError(t, err, "error creating repository: %s", err)
 
-	rootKeyID, err := repo.GenRootKey(rootType.String(), "passphrase")
+	rootKeyID, err := repo.KeyStoreManager.GenRootKey(rootType.String(), "passphrase")
 	assert.NoError(t, err, "error generating root key: %s", err)
 
-	rootCryptoService, err := repo.GetRootCryptoService(rootKeyID, "passphrase")
+	rootCryptoService, err := repo.KeyStoreManager.GetRootCryptoService(rootKeyID, "passphrase")
 	assert.NoError(t, err, "error retreiving root key: %s", err)
 
 	err = repo.Initialize(rootCryptoService)

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -110,7 +110,7 @@ func tufInit(cmd *cobra.Command, args []string) {
 		fatalf(err.Error())
 	}
 
-	keysList := nRepo.ListRootKeys()
+	keysList := nRepo.KeyStoreManager.RootKeyStore().ListKeys()
 	var passphrase string
 	var rootKeyID string
 	if len(keysList) < 1 {

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -119,7 +119,7 @@ func tufInit(cmd *cobra.Command, args []string) {
 		if err != nil {
 			fatalf(err.Error())
 		}
-		rootKeyID, err = nRepo.GenRootKey("ECDSA", passphrase)
+		rootKeyID, err = nRepo.KeyStoreManager.GenRootKey("ECDSA", passphrase)
 		if err != nil {
 			fatalf(err.Error())
 		}
@@ -133,7 +133,7 @@ func tufInit(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	rootCryptoService, err := nRepo.GetRootCryptoService(rootKeyID, passphrase)
+	rootCryptoService, err := nRepo.KeyStoreManager.GetRootCryptoService(rootKeyID, passphrase)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/cryptoservice/crypto_service.go
+++ b/cryptoservice/crypto_service.go
@@ -1,4 +1,4 @@
-package client
+package cryptoservice
 
 import (
 	"crypto"
@@ -13,6 +13,10 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary/trustmanager"
 	"github.com/endophage/gotuf/data"
+)
+
+const (
+	rsaKeySize = 2048 // Used for snapshots and targets keys
 )
 
 // CryptoService implements Sign and Create, holding a specific GUN and keystore to

--- a/cryptoservice/unlocked_crypto_service.go
+++ b/cryptoservice/unlocked_crypto_service.go
@@ -1,0 +1,83 @@
+package cryptoservice
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/docker/notary/trustmanager"
+	"github.com/endophage/gotuf/data"
+	"github.com/endophage/gotuf/signed"
+)
+
+// UnlockedCryptoService encapsulates a private key and a cryptoservice that
+// uses that private key, providing convinience methods for generation of
+// certificates.
+type UnlockedCryptoService struct {
+	PrivKey       *data.PrivateKey
+	CryptoService signed.CryptoService
+}
+
+// NewUnlockedCryptoService creates an UnlockedCryptoService instance
+func NewUnlockedCryptoService(privKey *data.PrivateKey, cryptoService signed.CryptoService) *UnlockedCryptoService {
+	return &UnlockedCryptoService{
+		PrivKey:       privKey,
+		CryptoService: cryptoService,
+	}
+}
+
+// ID gets a consistent ID based on the PrivateKey bytes and algorithm type
+func (ucs *UnlockedCryptoService) ID() string {
+	return ucs.PublicKey().ID()
+}
+
+// PublicKey Returns the public key associated with the private key
+func (ucs *UnlockedCryptoService) PublicKey() *data.PublicKey {
+	return data.PublicKeyFromPrivate(*ucs.PrivKey)
+}
+
+// GenerateCertificate generates an X509 Certificate from a template, given a GUN
+func (ucs *UnlockedCryptoService) GenerateCertificate(gun string) (*x509.Certificate, error) {
+	algorithm := ucs.PrivKey.Algorithm()
+	var publicKey crypto.PublicKey
+	var privateKey crypto.PrivateKey
+	var err error
+	switch algorithm {
+	case data.RSAKey:
+		var rsaPrivateKey *rsa.PrivateKey
+		rsaPrivateKey, err = x509.ParsePKCS1PrivateKey(ucs.PrivKey.Private())
+		privateKey = rsaPrivateKey
+		publicKey = rsaPrivateKey.Public()
+	case data.ECDSAKey:
+		var ecdsaPrivateKey *ecdsa.PrivateKey
+		ecdsaPrivateKey, err = x509.ParseECPrivateKey(ucs.PrivKey.Private())
+		privateKey = ecdsaPrivateKey
+		publicKey = ecdsaPrivateKey.Public()
+	default:
+		return nil, fmt.Errorf("only RSA or ECDSA keys are currently supported. Found: %s", algorithm)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse root key: %s (%v)", gun, err)
+	}
+
+	template, err := trustmanager.NewCertificate(gun)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the certificate template for: %s (%v)", gun, err)
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the certificate for: %s (%v)", gun, err)
+	}
+
+	// Encode the new certificate into PEM
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the certificate for key: %s (%v)", gun, err)
+	}
+
+	return cert, nil
+}

--- a/keystoremanager/keystoremanager.go
+++ b/keystoremanager/keystoremanager.go
@@ -1,0 +1,51 @@
+package keystoremanager
+
+import (
+	"path/filepath"
+
+	"github.com/docker/notary/trustmanager"
+)
+
+// KeyStoreManager is an abstraction around the root and non-root key stores
+type KeyStoreManager struct {
+	rootKeyStore    *trustmanager.KeyFileStore
+	nonRootKeyStore *trustmanager.KeyFileStore
+}
+
+const (
+	privDir        = "private"
+	rootKeysSubdir = "root_keys"
+)
+
+// NewKeyStoreManager returns an initialized KeyStoreManager, or an error
+// if it fails to create the KeyFileStores
+func NewKeyStoreManager(baseDir string) (*KeyStoreManager, error) {
+	nonRootKeyStore, err := trustmanager.NewKeyFileStore(filepath.Join(baseDir, privDir))
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the keystore that will hold all of our encrypted Root Private Keys
+	rootKeysPath := filepath.Join(baseDir, privDir, rootKeysSubdir)
+	rootKeyStore, err := trustmanager.NewKeyFileStore(rootKeysPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KeyStoreManager{
+		rootKeyStore:    rootKeyStore,
+		nonRootKeyStore: nonRootKeyStore,
+	}, nil
+}
+
+// RootKeyStore returns the root key store being managed by this
+// KeyStoreManager
+func (km *KeyStoreManager) RootKeyStore() *trustmanager.KeyFileStore {
+	return km.rootKeyStore
+}
+
+// NonRootKeyStore returns the non-root key store being managed by this
+// KeyStoreManager
+func (km *KeyStoreManager) NonRootKeyStore() *trustmanager.KeyFileStore {
+	return km.nonRootKeyStore
+}

--- a/keystoremanager/keystoremanager.go
+++ b/keystoremanager/keystoremanager.go
@@ -1,24 +1,37 @@
 package keystoremanager
 
 import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
 	"path/filepath"
+	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary/trustmanager"
+	"github.com/endophage/gotuf/data"
+	"github.com/endophage/gotuf/signed"
 )
 
-// KeyStoreManager is an abstraction around the root and non-root key stores
+// KeyStoreManager is an abstraction around the root and non-root key stores,
+// and related CA stores
 type KeyStoreManager struct {
 	rootKeyStore    *trustmanager.KeyFileStore
 	nonRootKeyStore *trustmanager.KeyFileStore
+
+	caStore          trustmanager.X509Store
+	certificateStore trustmanager.X509Store
 }
 
 const (
+	trustDir       = "trusted_certificates"
 	privDir        = "private"
 	rootKeysSubdir = "root_keys"
 )
 
 // NewKeyStoreManager returns an initialized KeyStoreManager, or an error
-// if it fails to create the KeyFileStores
+// if it fails to create the KeyFileStores or load certificates
 func NewKeyStoreManager(baseDir string) (*KeyStoreManager, error) {
 	nonRootKeyStore, err := trustmanager.NewKeyFileStore(filepath.Join(baseDir, privDir))
 	if err != nil {
@@ -32,9 +45,37 @@ func NewKeyStoreManager(baseDir string) (*KeyStoreManager, error) {
 		return nil, err
 	}
 
+	trustPath := filepath.Join(baseDir, trustDir)
+
+	// Load all CAs that aren't expired and don't use SHA1
+	caStore, err := trustmanager.NewX509FilteredFileStore(trustPath, func(cert *x509.Certificate) bool {
+		return cert.IsCA && cert.BasicConstraintsValid && cert.SubjectKeyId != nil &&
+			time.Now().Before(cert.NotAfter) &&
+			cert.SignatureAlgorithm != x509.SHA1WithRSA &&
+			cert.SignatureAlgorithm != x509.DSAWithSHA1 &&
+			cert.SignatureAlgorithm != x509.ECDSAWithSHA1
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Load all individual (non-CA) certificates that aren't expired and don't use SHA1
+	certificateStore, err := trustmanager.NewX509FilteredFileStore(trustPath, func(cert *x509.Certificate) bool {
+		return !cert.IsCA &&
+			time.Now().Before(cert.NotAfter) &&
+			cert.SignatureAlgorithm != x509.SHA1WithRSA &&
+			cert.SignatureAlgorithm != x509.DSAWithSHA1 &&
+			cert.SignatureAlgorithm != x509.ECDSAWithSHA1
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return &KeyStoreManager{
-		rootKeyStore:    rootKeyStore,
-		nonRootKeyStore: nonRootKeyStore,
+		rootKeyStore:     rootKeyStore,
+		nonRootKeyStore:  nonRootKeyStore,
+		caStore:          caStore,
+		certificateStore: certificateStore,
 	}, nil
 }
 
@@ -48,4 +89,98 @@ func (km *KeyStoreManager) RootKeyStore() *trustmanager.KeyFileStore {
 // KeyStoreManager
 func (km *KeyStoreManager) NonRootKeyStore() *trustmanager.KeyFileStore {
 	return km.nonRootKeyStore
+}
+
+// CertificateStore returns the certificate store being managed by this
+// KeyStoreManager
+func (km *KeyStoreManager) CertificateStore() trustmanager.X509Store {
+	return km.certificateStore
+}
+
+// CAStore returns the CA store being managed by this KeyStoreManager
+func (km *KeyStoreManager) CAStore() trustmanager.X509Store {
+	return km.caStore
+}
+
+/*
+ValidateRoot iterates over every root key included in the TUF data and
+attempts to validate the certificate by first checking for an exact match on
+the certificate store, and subsequently trying to find a valid chain on the
+caStore.
+
+When this is being used with a notary repository, the dnsName parameter should
+be the GUN associated with the repository.
+
+Example TUF Content for root role:
+"roles" : {
+  "root" : {
+    "threshold" : 1,
+      "keyids" : [
+        "e6da5c303d572712a086e669ecd4df7b785adfc844e0c9a7b1f21a7dfc477a38"
+      ]
+  },
+ ...
+}
+
+Example TUF Content for root key:
+"e6da5c303d572712a086e669ecd4df7b785adfc844e0c9a7b1f21a7dfc477a38" : {
+	"keytype" : "RSA",
+	"keyval" : {
+	  "private" : "",
+	  "public" : "Base64-encoded, PEM encoded x509 Certificate"
+	}
+}
+*/
+func (km *KeyStoreManager) ValidateRoot(root *data.Signed, dnsName string) error {
+	rootSigned := &data.Root{}
+	err := json.Unmarshal(root.Signed, rootSigned)
+	if err != nil {
+		return err
+	}
+
+	certs := make(map[string]*data.PublicKey)
+	for _, keyID := range rootSigned.Roles["root"].KeyIDs {
+		// TODO(dlaw): currently assuming only one cert contained in
+		// public key entry. Need to fix when we want to pass in chains.
+		k, _ := pem.Decode([]byte(rootSigned.Keys[keyID].Public()))
+		decodedCerts, err := x509.ParseCertificates(k.Bytes)
+		if err != nil {
+			logrus.Debugf("error while parsing root certificate with keyID: %s, %v", keyID, err)
+			continue
+		}
+		// TODO(diogo): Assuming that first certificate is the leaf-cert. Need to
+		// iterate over all decodedCerts and find a non-CA one (should be the last).
+		leafCert := decodedCerts[0]
+
+		leafID, err := trustmanager.FingerprintCert(leafCert)
+		if err != nil {
+			logrus.Debugf("error while fingerprinting root certificate with keyID: %s, %v", keyID, err)
+			continue
+		}
+
+		// Check to see if there is an exact match of this certificate.
+		// Checking the CommonName is not required since ID is calculated over
+		// Cert.Raw. It's included to prevent breaking logic with changes of how the
+		// ID gets computed.
+		_, err = km.certificateStore.GetCertificateByKeyID(leafID)
+		if err == nil && leafCert.Subject.CommonName == dnsName {
+			certs[keyID] = rootSigned.Keys[keyID]
+		}
+
+		// Check to see if this leafCertificate has a chain to one of the Root CAs
+		// of our CA Store.
+		certList := []*x509.Certificate{leafCert}
+		err = trustmanager.Verify(km.caStore, dnsName, certList)
+		if err == nil {
+			certs[keyID] = rootSigned.Keys[keyID]
+		}
+	}
+
+	if len(certs) < 1 {
+		return errors.New("could not validate the path to a trusted root")
+	}
+
+	_, err = signed.VerifyRoot(root, 0, certs, 1)
+
+	return err
 }


### PR DESCRIPTION
This structure encapsulates what used to be "rootKeyStore" "privKeyStore", and the certificate stores. These are being moved out of NotaryRepository, so that operations like listing keys, importing keys, and exporting keys aren't tied to a NotaryRepository structure.

This PR also moves the CryptoService and UnlockedCryptoService to a dedicated cryptoservice package.

Key import/export will be added in a subsequent PR.