### PR TITLE
Import/export

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -95,7 +95,7 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper) (*N
 		gun:             gun,
 		baseDir:         baseDir,
 		baseURL:         baseURL,
-		tufRepoPath:     filepath.Join(baseDir, tufDir, gun),
+		tufRepoPath:     filepath.Join(baseDir, tufDir, filepath.FromSlash(gun)),
 		cryptoService:   cryptoService,
 		roundTrip:       rt,
 		KeyStoreManager: keyStoreManager,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -75,7 +75,7 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 	// Inspect contents of the temporary directory
 	expectedDirs := []string{
 		"private",
-		filepath.Join("private", gun),
+		filepath.Join("private", "tuf_keys", gun),
 		filepath.Join("private", "root_keys"),
 		"trusted_certificates",
 		filepath.Join("trusted_certificates", gun),

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -75,13 +75,13 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 	// Inspect contents of the temporary directory
 	expectedDirs := []string{
 		"private",
-		filepath.Join("private", "tuf_keys", gun),
+		filepath.Join("private", "tuf_keys", filepath.FromSlash(gun)),
 		filepath.Join("private", "root_keys"),
 		"trusted_certificates",
-		filepath.Join("trusted_certificates", gun),
+		filepath.Join("trusted_certificates", filepath.FromSlash(gun)),
 		"tuf",
-		filepath.Join("tuf", gun, "metadata"),
-		filepath.Join("tuf", gun, "targets"),
+		filepath.Join("tuf", filepath.FromSlash(gun), "metadata"),
+		filepath.Join("tuf", filepath.FromSlash(gun), "targets"),
 	}
 	for _, dir := range expectedDirs {
 		fi, err := os.Stat(filepath.Join(tempBaseDir, dir))
@@ -118,16 +118,16 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 	assert.Equal(t, rootKeyFilename, actualDest, "symlink to root key has wrong destination")
 
 	// There should be a trusted certificate
-	_, err = os.Stat(filepath.Join(tempBaseDir, "trusted_certificates", gun, certID+".crt"))
+	_, err = os.Stat(filepath.Join(tempBaseDir, "trusted_certificates", filepath.FromSlash(gun), certID+".crt"))
 	assert.NoError(t, err, "missing trusted certificate")
 
 	// Sanity check the TUF metadata files. Verify that they exist, the JSON is
 	// well-formed, and the signatures exist. For the root.json file, also check
 	// that the root, snapshot, and targets key IDs are present.
 	expectedTUFMetadataFiles := []string{
-		filepath.Join("tuf", gun, "metadata", "root.json"),
-		filepath.Join("tuf", gun, "metadata", "snapshot.json"),
-		filepath.Join("tuf", gun, "metadata", "targets.json"),
+		filepath.Join("tuf", filepath.FromSlash(gun), "metadata", "root.json"),
+		filepath.Join("tuf", filepath.FromSlash(gun), "metadata", "snapshot.json"),
+		filepath.Join("tuf", filepath.FromSlash(gun), "metadata", "targets.json"),
 	}
 	for _, filename := range expectedTUFMetadataFiles {
 		fullPath := filepath.Join(tempBaseDir, filename)
@@ -225,7 +225,7 @@ func testAddListTarget(t *testing.T, rootType data.KeyAlgorithm) {
 	assert.NoError(t, err, "error adding target")
 
 	// Look for the changelist file
-	changelistDirPath := filepath.Join(tempBaseDir, "tuf", gun, "changelist")
+	changelistDirPath := filepath.Join(tempBaseDir, "tuf", filepath.FromSlash(gun), "changelist")
 
 	changelistDir, err := os.Open(changelistDirPath)
 	assert.NoError(t, err, "could not open changelist directory")
@@ -299,7 +299,7 @@ func testAddListTarget(t *testing.T, rootType data.KeyAlgorithm) {
 	// Apply the changelist. Normally, this would be done by Publish
 
 	// load the changelist for this repo
-	cl, err := changelist.NewFileChangelist(filepath.Join(tempBaseDir, "tuf", gun, "changelist"))
+	cl, err := changelist.NewFileChangelist(filepath.Join(tempBaseDir, "tuf", filepath.FromSlash(gun), "changelist"))
 	assert.NoError(t, err, "could not open changelist")
 
 	// apply the changelist to the repo
@@ -309,10 +309,10 @@ func testAddListTarget(t *testing.T, rootType data.KeyAlgorithm) {
 	var tempKey data.PrivateKey
 	json.Unmarshal([]byte(timestampECDSAKeyJSON), &tempKey)
 
-	repo.KeyStoreManager.NonRootKeyStore().AddKey(filepath.Join(gun, tempKey.ID()), &tempKey)
+	repo.KeyStoreManager.NonRootKeyStore().AddKey(filepath.Join(filepath.FromSlash(gun), tempKey.ID()), &tempKey)
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/root.json", func(w http.ResponseWriter, r *http.Request) {
-		rootJSONFile := filepath.Join(tempBaseDir, "tuf", gun, "metadata", "root.json")
+		rootJSONFile := filepath.Join(tempBaseDir, "tuf", filepath.FromSlash(gun), "metadata", "root.json")
 		rootFileBytes, err := ioutil.ReadFile(rootJSONFile)
 		assert.NoError(t, err)
 		fmt.Fprint(w, string(rootFileBytes))
@@ -401,7 +401,7 @@ func testValidateRootKey(t *testing.T, rootType data.KeyAlgorithm) {
 	err = repo.Initialize(rootCryptoService)
 	assert.NoError(t, err, "error creating repository: %s", err)
 
-	rootJSONFile := filepath.Join(tempBaseDir, "tuf", gun, "metadata", "root.json")
+	rootJSONFile := filepath.Join(tempBaseDir, "tuf", filepath.FromSlash(gun), "metadata", "root.json")
 
 	jsonBytes, err := ioutil.ReadFile(rootJSONFile)
 	assert.NoError(t, err, "error reading TUF metadata file %s: %s", rootJSONFile, err)

--- a/keystoremanager/export_test.go
+++ b/keystoremanager/export_test.go
@@ -1,0 +1,116 @@
+package keystoremanager_test
+
+import (
+	"archive/zip"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/trustmanager"
+	"github.com/endophage/gotuf/data"
+	"github.com/stretchr/testify/assert"
+)
+
+const timestampECDSAKeyJSON = `
+{"keytype":"ecdsa","keyval":{"public":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgl3rzMPMEKhS1k/AX16MM4PdidpjJr+z4pj0Td+30QnpbOIARgpyR1PiFztU8BZlqG3cUazvFclr2q/xHvfrqw==","private":"MHcCAQEEIDqtcdzU7H3AbIPSQaxHl9+xYECt7NpK7B1+6ep5cv9CoAoGCCqGSM49AwEHoUQDQgAEgl3rzMPMEKhS1k/AX16MM4PdidpjJr+z4pj0Td+30QnpbOIARgpyR1PiFztU8BZlqG3cUazvFclr2q/xHvfrqw=="}}`
+
+func createTestServer(t *testing.T) (*httptest.Server, *http.ServeMux) {
+	mux := http.NewServeMux()
+	// TUF will request /v2/docker.com/notary/_trust/tuf/timestamp.key
+	// Return a canned timestamp.key
+	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/timestamp.key", func(w http.ResponseWriter, r *http.Request) {
+		// Also contains the private key, but for the purpose of this
+		// test, we don't care
+		fmt.Fprint(w, timestampECDSAKeyJSON)
+	})
+
+	ts := httptest.NewServer(mux)
+
+	return ts, mux
+}
+
+func TestExportKeys(t *testing.T) {
+	gun := "docker.com/notary"
+	// Temporary directory where test files will be created
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	defer os.RemoveAll(tempBaseDir)
+
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+
+	ts, _ := createTestServer(t)
+	defer ts.Close()
+
+	repo, err := client.NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport)
+	assert.NoError(t, err, "error creating repo: %s", err)
+
+	rootKeyID, err := repo.KeyStoreManager.GenRootKey(data.ECDSAKey.String(), "oldPassphrase")
+	assert.NoError(t, err, "error generating root key: %s", err)
+
+	rootCryptoService, err := repo.KeyStoreManager.GetRootCryptoService(rootKeyID, "oldPassphrase")
+	assert.NoError(t, err, "error retrieving root key: %s", err)
+
+	err = repo.Initialize(rootCryptoService)
+	assert.NoError(t, err, "error creating repository: %s", err)
+
+	tempZipFile, err := ioutil.TempFile("", "notary-test-export-")
+	tempZipFilePath := tempZipFile.Name()
+	defer os.Remove(tempZipFilePath)
+
+	err = repo.KeyStoreManager.ExportAllKeys(tempZipFile, "exportPassphrase")
+	tempZipFile.Close()
+	assert.NoError(t, err)
+
+	// Check the contents of the zip file
+	zipReader, err := zip.OpenReader(tempZipFilePath)
+	assert.NoError(t, err, "could not open zip file")
+	defer zipReader.Close()
+
+	// Map of files to expect in the zip file, with the passphrases
+	passphraseByFile := make(map[string]string)
+
+	// Add keys in private to the map. These should use the new passphrase
+	// because they were formerly unencrypted.
+	privKeyList := repo.KeyStoreManager.NonRootKeyStore().ListFiles(false)
+	for _, privKeyName := range privKeyList {
+		relName := strings.TrimPrefix(privKeyName, tempBaseDir+string(filepath.Separator))
+		passphraseByFile[relName] = "exportPassphrase"
+	}
+
+	// Add root key to the map. This will use the old passphrase because it
+	// won't be reencrypted.
+	relRootKey := filepath.Join("private", "root_keys", rootCryptoService.ID()+".key")
+	passphraseByFile[relRootKey] = "oldPassphrase"
+
+	// Iterate through the files in the archive, checking that the files
+	// exist and are encrypted with the expected passphrase.
+	for _, f := range zipReader.File {
+		expectedPassphrase, present := passphraseByFile[f.Name]
+		if !present {
+			t.Fatalf("unexpected file %s in zip file", f.Name)
+		}
+
+		delete(passphraseByFile, f.Name)
+
+		rc, err := f.Open()
+		assert.NoError(t, err, "could not open file inside zip archive")
+
+		pemBytes, err := ioutil.ReadAll(rc)
+		assert.NoError(t, err, "could not read file from zip")
+
+		_, err = trustmanager.ParsePEMPrivateKey(pemBytes, expectedPassphrase)
+		assert.NoError(t, err, "PEM not encrypted with the expected passphrase")
+
+		rc.Close()
+	}
+
+	// Are there any keys that didn't make it to the zip?
+	for fileNotFound, _ := range passphraseByFile {
+		t.Fatalf("%s not found in zip", fileNotFound)
+	}
+}

--- a/keystoremanager/import_export.go
+++ b/keystoremanager/import_export.go
@@ -1,0 +1,147 @@
+package keystoremanager
+
+import (
+	"archive/zip"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/notary/trustmanager"
+)
+
+func moveKeysWithNewPassphrase(oldKeyStore, newKeyStore *trustmanager.KeyFileStore, outputPassphrase string) error {
+	// List all files but no symlinks
+	for _, f := range oldKeyStore.ListFiles(false) {
+		fullKeyPath := strings.TrimSpace(strings.TrimSuffix(f, filepath.Ext(f)))
+		relKeyPath := strings.TrimPrefix(fullKeyPath, oldKeyStore.BaseDir())
+		relKeyPath = strings.TrimPrefix(relKeyPath, string(filepath.Separator))
+
+		pemBytes, err := oldKeyStore.Get(relKeyPath)
+		if err != nil {
+			return err
+		}
+
+		block, _ := pem.Decode(pemBytes)
+		if block == nil {
+			return errors.New("no valid private key found")
+		}
+
+		if !x509.IsEncryptedPEMBlock(block) {
+			// Key is not encrypted. Parse it, and add it
+			// to the temporary store as an encrypted key.
+			privKey, err := trustmanager.ParsePEMPrivateKey(pemBytes, "")
+			if err != nil {
+				return err
+			}
+			err = newKeyStore.AddEncryptedKey(relKeyPath, privKey, outputPassphrase)
+		} else {
+			// Encrypted key - pass it through without
+			// decrypting
+			err = newKeyStore.Add(relKeyPath, pemBytes)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addKeysToArchive(zipWriter *zip.Writer, newKeyStore *trustmanager.KeyFileStore, tempBaseDir string, dedup map[string]struct{}) error {
+	// List all files but no symlinks
+	for _, fullKeyPath := range newKeyStore.ListFiles(false) {
+		if _, present := dedup[fullKeyPath]; present {
+			continue
+		}
+		dedup[fullKeyPath] = struct{}{}
+
+		relKeyPath := strings.TrimPrefix(fullKeyPath, tempBaseDir)
+		relKeyPath = strings.TrimPrefix(relKeyPath, string(filepath.Separator))
+
+		fi, err := os.Stat(fullKeyPath)
+		if err != nil {
+			return err
+		}
+
+		infoHeader, err := zip.FileInfoHeader(fi)
+		if err != nil {
+			return err
+		}
+
+		infoHeader.Name = relKeyPath
+		zipFileEntryWriter, err := zipWriter.CreateHeader(infoHeader)
+		if err != nil {
+			return err
+		}
+
+		fileContents, err := ioutil.ReadFile(fullKeyPath)
+		if err != nil {
+			return err
+		}
+		if _, err = zipFileEntryWriter.Write(fileContents); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ExportAllKeys exports all keys to an io.Writer in zip format.
+// outputPassphrase is the new passphrase to use to encrypt the existing keys.
+// If blank, the keys will not be encrypted. Note that keys which are already
+// encrypted are not re-encrypted. They will be included in the zip with their
+// original encryption.
+func (km *KeyStoreManager) ExportAllKeys(dest io.Writer, outputPassphrase string) error {
+	tempBaseDir, err := ioutil.TempDir("", "notary-key-export-")
+	defer os.RemoveAll(tempBaseDir)
+
+	// Create temporary keystores to use as a staging area
+	tempNonRootKeysPath := filepath.Join(tempBaseDir, privDir)
+	tempNonRootKeyStore, err := trustmanager.NewKeyFileStore(tempNonRootKeysPath)
+	if err != nil {
+		return err
+	}
+
+	tempRootKeysPath := filepath.Join(tempBaseDir, privDir, rootKeysSubdir)
+	tempRootKeyStore, err := trustmanager.NewKeyFileStore(tempRootKeysPath)
+	if err != nil {
+		return err
+	}
+
+	if err := moveKeysWithNewPassphrase(km.rootKeyStore, tempRootKeyStore, outputPassphrase); err != nil {
+		return err
+	}
+	if err := moveKeysWithNewPassphrase(km.nonRootKeyStore, tempNonRootKeyStore, outputPassphrase); err != nil {
+		return err
+	}
+
+	zipWriter := zip.NewWriter(dest)
+
+	// Root and non-root stores overlap, so we need to dedup files
+	dedup := make(map[string]struct{})
+
+	if err := addKeysToArchive(zipWriter, tempRootKeyStore, tempBaseDir, dedup); err != nil {
+		return err
+	}
+	if err := addKeysToArchive(zipWriter, tempNonRootKeyStore, tempBaseDir, dedup); err != nil {
+		return err
+	}
+
+	zipWriter.Close()
+
+	return nil
+}
+
+// ImportZip imports keys from a zip file provided as an io.Reader. The keys
+// in the root_keys directory are left encrypted, but the other keys are
+// decrypted with the specified passphrase.
+func (km *KeyStoreManager) ImportZip(zip io.Reader, passphrase string) error {
+	// TODO(aaronl)
+	return nil
+}

--- a/keystoremanager/import_export.go
+++ b/keystoremanager/import_export.go
@@ -16,6 +16,36 @@ import (
 	"github.com/endophage/gotuf/data"
 )
 
+// ExportRootKey exports the specified root key to an io.Writer in PEM format.
+// The key's existing encryption is preserved.
+func (km *KeyStoreManager) ExportRootKey(dest io.Writer, keyID string) error {
+	pemBytes, err := km.rootKeyStore.Get(keyID)
+	if err != nil {
+		return err
+	}
+
+	_, err = dest.Write(pemBytes)
+	return err
+}
+
+// ImportRootKey imports a root in PEM format key from an io.Reader
+// The key's existing encryption is preserved. The keyID parameter is
+// necessary because otherwise we'd need the passphrase to decrypt the key
+// in order to compute the ID.
+func (km *KeyStoreManager) ImportRootKey(source io.Reader, keyID string) error {
+	pemBytes, err := ioutil.ReadAll(source)
+	if err != nil {
+		return err
+	}
+
+	err = km.rootKeyStore.Add(keyID, pemBytes)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
 func moveKeysWithNewPassphrase(oldKeyStore, newKeyStore *trustmanager.KeyFileStore, outputPassphrase string) error {
 	// List all files but no symlinks
 	for _, f := range oldKeyStore.ListFiles(false) {

--- a/keystoremanager/keystoremanager.go
+++ b/keystoremanager/keystoremanager.go
@@ -29,16 +29,18 @@ type KeyStoreManager struct {
 }
 
 const (
-	trustDir       = "trusted_certificates"
-	privDir        = "private"
-	rootKeysSubdir = "root_keys"
-	rsaRootKeySize = 4096 // Used for new root keys
+	trustDir          = "trusted_certificates"
+	privDir           = "private"
+	rootKeysSubdir    = "root_keys"
+	nonRootKeysSubdir = "tuf_keys"
+	rsaRootKeySize    = 4096 // Used for new root keys
 )
 
 // NewKeyStoreManager returns an initialized KeyStoreManager, or an error
 // if it fails to create the KeyFileStores or load certificates
 func NewKeyStoreManager(baseDir string) (*KeyStoreManager, error) {
-	nonRootKeyStore, err := trustmanager.NewKeyFileStore(filepath.Join(baseDir, privDir))
+	nonRootKeysPath := filepath.Join(baseDir, privDir, nonRootKeysSubdir)
+	nonRootKeyStore, err := trustmanager.NewKeyFileStore(nonRootKeysPath)
 	if err != nil {
 		return nil, err
 	}

--- a/trustmanager/filestore.go
+++ b/trustmanager/filestore.go
@@ -20,6 +20,7 @@ type FileStore interface {
 	ListFiles(symlinks bool) []string
 	ListDir(directoryName string, symlinks bool) []string
 	Link(src, dst string) error
+	BaseDir() string
 }
 
 // SimpleFileStore implements FileStore
@@ -163,6 +164,11 @@ func (f *SimpleFileStore) Link(oldname, newname string) error {
 		f.genFileName(oldname),
 		f.genFilePath(newname),
 	)
+}
+
+// BaseDir returns the base directory of the filestore
+func (f *SimpleFileStore) BaseDir() string {
+	return f.baseDir
 }
 
 // CreateDirectory uses createDirectory to create a chmod 755 Directory

--- a/trustmanager/x509filestore.go
+++ b/trustmanager/x509filestore.go
@@ -85,7 +85,11 @@ func (s X509FileStore) addNamedCert(cert *x509.Certificate) error {
 	certBytes := CertToPEM(cert)
 
 	// Save the file to disk if not already there.
-	if _, err := os.Stat(s.fileStore.GetPath(fileName)); os.IsNotExist(err) {
+	filePath, err := s.fileStore.GetPath(fileName)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		if err := s.fileStore.Add(fileName, certBytes); err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds key import and export features

There are functions to export all keys (to a zip file), keys by GUN (to a zip file), and a specific root key (as PEM). There are corresponding functions to import from a zip or PEM file.

This PR also moves non-root keys to a `tuf_keys` subdirectory, so that the root and non-root keystores don't overlap on the filesystem.