### PR TITLE
Rename certificate stores to trustedCertificateStore and trustedCAStore

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -111,7 +111,7 @@ func (r *NotaryRepository) Initialize(uCryptoService *cryptoservice.UnlockedCryp
 	if err != nil {
 		return err
 	}
-	r.KeyStoreManager.CertificateStore().AddCert(rootCert)
+	r.KeyStoreManager.AddTrustedCert(rootCert)
 
 	// The root key gets stored in the TUF metadata X509 encoded, linking
 	// the tuf root.json to our X509 PKI.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -106,7 +106,7 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 
 	// Also expect a symlink from the key ID of the certificate key to this
 	// root key
-	certificates := repo.KeyStoreManager.CertificateStore().GetCertificates()
+	certificates := repo.KeyStoreManager.TrustedCertificateStore().GetCertificates()
 	assert.Len(t, certificates, 1, "unexpected number of certificates")
 
 	certID, err := trustmanager.FingerprintCert(certificates[0])


### PR DESCRIPTION
Add convenience methods to KeyStoreManager to add certs to both cert
stores.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>