### PR TITLE
Fix the staging deployment.

### DIFF
--- a/cmd/notary-server/config.json
+++ b/cmd/notary-server/config.json
@@ -1,8 +1,6 @@
 {
 	"server": {
-		"addr": ":4443",
-		"tls_cert_file": "./fixtures/notary-server.crt",
-		"tls_key_file": "./fixtures/notary-server.key"
+		"addr": ":4443"
 	},
 	"trust_service": {
 		"type": "local",
@@ -15,6 +13,6 @@
 	},
 	"storage": {
 		"backend": "mysql",
-		"db_url": "root:@tcp(localhost:3306)/test"
+		"db_url": "dockercondemo:dockercondemo@tcp(notarymysql:3306)/dockercondemo"
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@ notaryserver:
   links:
    - notarymysql
   ports:
-   - "8080:8080"
-   - "4443:4443"
+   - "8080"
+   - "4443"
+  environment:
+    SERVICE_NAME: notary
 notarysigner:
   volumes:
    - /dev/bus/usb/003/010:/dev/bus/usb/002/010

--- a/notary-server-Dockerfile
+++ b/notary-server-Dockerfile
@@ -13,4 +13,4 @@ EXPOSE 4443
 
 WORKDIR /go/src/github.com/docker/notary
 
-CMD [ "notary-server", "-config", "cmd/notary-server/dev-config.json" ]
+CMD [ "notary-server", "-config", "cmd/notary-server/config.json" ]


### PR DESCRIPTION
Add a service name and ephemeral ports to notary server.
Remove certs as TLS is terminated in the ELB.

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>