### PR TITLE
Updates to notary for gotuf's split of PublicKey and PrivateKey interfaces

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -58,7 +58,7 @@
 		},
 		{
 			"ImportPath": "github.com/endophage/gotuf",
-			"Rev": "f81a3471fd94ba58e004ef9cd9bbbf81bfc565ed"
+			"Rev": "44944cf8926ed3bf246e3e6612e771d99352f648"
 		},
 		{
 			"ImportPath": "github.com/go-sql-driver/mysql",

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/data/types.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/data/types.go
@@ -125,13 +125,13 @@ func NewFileMeta(r io.Reader, hashAlgorithms ...string) (FileMeta, error) {
 }
 
 type Delegations struct {
-	Keys  map[string]*PublicKey `json:"keys"`
-	Roles []*Role               `json:"roles"`
+	Keys  map[string]PublicKey `json:"keys"`
+	Roles []*Role              `json:"roles"`
 }
 
 func NewDelegations() *Delegations {
 	return &Delegations{
-		Keys:  make(map[string]*PublicKey),
+		Keys:  make(map[string]PublicKey),
 		Roles: make([]*Role, 0),
 	}
 }

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/keys/db.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/keys/db.go
@@ -18,17 +18,17 @@ var (
 
 type KeyDB struct {
 	roles map[string]*data.Role
-	keys  map[string]data.Key
+	keys  map[string]data.PublicKey
 }
 
 func NewDB() *KeyDB {
 	return &KeyDB{
 		roles: make(map[string]*data.Role),
-		keys:  make(map[string]data.Key),
+		keys:  make(map[string]data.PublicKey),
 	}
 }
 
-func (db *KeyDB) AddKey(k data.Key) {
+func (db *KeyDB) AddKey(k data.PublicKey) {
 	db.keys[k.ID()] = k
 }
 
@@ -51,7 +51,7 @@ func (db *KeyDB) AddRole(r *data.Role) error {
 	return nil
 }
 
-func (db *KeyDB) GetKey(id string) data.Key {
+func (db *KeyDB) GetKey(id string) data.PublicKey {
 	return db.keys[id]
 }
 

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/ed25519.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/ed25519.go
@@ -10,17 +10,17 @@ import (
 
 // Ed25519 implements a simple in memory cryptosystem for ED25519 keys
 type Ed25519 struct {
-	keys map[string]*data.PrivateKey
+	keys map[string]data.PrivateKey
 }
 
 func NewEd25519() *Ed25519 {
 	return &Ed25519{
-		make(map[string]*data.PrivateKey),
+		make(map[string]data.PrivateKey),
 	}
 }
 
 // addKey allows you to add a private key
-func (e *Ed25519) addKey(k *data.PrivateKey) {
+func (e *Ed25519) addKey(k data.PrivateKey) {
 	e.keys[k.ID()] = k
 }
 
@@ -45,7 +45,7 @@ func (e *Ed25519) Sign(keyIDs []string, toSign []byte) ([]data.Signature, error)
 
 }
 
-func (e *Ed25519) Create(role string, algorithm data.KeyAlgorithm) (data.Key, error) {
+func (e *Ed25519) Create(role string, algorithm data.KeyAlgorithm) (data.PublicKey, error) {
 	if algorithm != data.ED25519Key {
 		return nil, errors.New("only ED25519 supported by this cryptoservice")
 	}
@@ -60,8 +60,8 @@ func (e *Ed25519) Create(role string, algorithm data.KeyAlgorithm) (data.Key, er
 	return public, nil
 }
 
-func (e *Ed25519) PublicKeys(keyIDs ...string) (map[string]*data.PublicKey, error) {
-	k := make(map[string]*data.PublicKey)
+func (e *Ed25519) PublicKeys(keyIDs ...string) (map[string]data.PublicKey, error) {
+	k := make(map[string]data.PublicKey)
 	for _, kID := range keyIDs {
 		if key, ok := e.keys[kID]; ok {
 			k[kID] = data.PublicKeyFromPrivate(key)
@@ -70,6 +70,6 @@ func (e *Ed25519) PublicKeys(keyIDs ...string) (map[string]*data.PublicKey, erro
 	return k, nil
 }
 
-func (e *Ed25519) GetKey(keyID string) data.Key {
+func (e *Ed25519) GetKey(keyID string) data.PublicKey {
 	return data.PublicKeyFromPrivate(e.keys[keyID])
 }

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/interface.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/interface.go
@@ -20,10 +20,10 @@ type KeyService interface {
 	// the private key into the appropriate signing service.
 	// The role isn't currently used for anything, but it's here to support
 	// future features
-	Create(role string, algorithm data.KeyAlgorithm) (data.Key, error)
+	Create(role string, algorithm data.KeyAlgorithm) (data.PublicKey, error)
 
 	// GetKey retrieves the public key if present, otherwise it returns nil
-	GetKey(keyID string) data.Key
+	GetKey(keyID string) data.PublicKey
 
 	// RemoveKey deletes the specified key
 	RemoveKey(keyID string) error
@@ -40,5 +40,5 @@ type CryptoService interface {
 // of this interface should verify signatures for one and only one
 // signing scheme.
 type Verifier interface {
-	Verify(key data.Key, sig []byte, msg []byte) error
+	Verify(key data.PublicKey, sig []byte, msg []byte) error
 }

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/sign.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/sign.go
@@ -7,7 +7,7 @@ import (
 
 // Sign takes a data.Signed and a key, calculated and adds the signature
 // to the data.Signed
-func Sign(service CryptoService, s *data.Signed, keys ...data.Key) error {
+func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
 	logrus.Debugf("sign called with %d keys", len(keys))
 	signatures := make([]data.Signature, 0, len(s.Signatures)+1)
 	keyIDMemb := make(map[string]struct{})

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/sign_test.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/sign_test.go
@@ -27,13 +27,13 @@ func (mts *MockCryptoService) Sign(keyIDs []string, _ []byte) ([]data.Signature,
 	return sigs, nil
 }
 
-func (mts *MockCryptoService) Create(_ string, _ data.KeyAlgorithm) (data.Key, error) {
-	return &mts.testKey, nil
+func (mts *MockCryptoService) Create(_ string, _ data.KeyAlgorithm) (data.PublicKey, error) {
+	return mts.testKey, nil
 }
 
-func (mts *MockCryptoService) GetKey(keyID string) data.Key {
+func (mts *MockCryptoService) GetKey(keyID string) data.PublicKey {
 	if keyID == "testID" {
-		return &mts.testKey
+		return mts.testKey
 	}
 	return nil
 }
@@ -48,7 +48,7 @@ var _ CryptoService = &MockCryptoService{}
 func TestBasicSign(t *testing.T) {
 	testKey, _ := pem.Decode([]byte(testKeyPEM1))
 	k := data.NewPublicKey(data.RSAKey, testKey.Bytes)
-	mockCryptoService := &MockCryptoService{testKey: *k}
+	mockCryptoService := &MockCryptoService{testKey: k}
 	key, err := mockCryptoService.Create("root", data.ED25519Key)
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +73,7 @@ func TestBasicSign(t *testing.T) {
 func TestReSign(t *testing.T) {
 	testKey, _ := pem.Decode([]byte(testKeyPEM1))
 	k := data.NewPublicKey(data.RSAKey, testKey.Bytes)
-	mockCryptoService := &MockCryptoService{testKey: *k}
+	mockCryptoService := &MockCryptoService{testKey: k}
 	testData := data.Signed{}
 
 	Sign(mockCryptoService, &testData, k)
@@ -117,7 +117,7 @@ func TestMultiSign(t *testing.T) {
 func TestCreate(t *testing.T) {
 	testKey, _ := pem.Decode([]byte(testKeyPEM1))
 	k := data.NewPublicKey(data.RSAKey, testKey.Bytes)
-	mockCryptoService := &MockCryptoService{testKey: *k}
+	mockCryptoService := &MockCryptoService{testKey: k}
 
 	key, err := mockCryptoService.Create("root", data.ED25519Key)
 

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verifiers.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verifiers.go
@@ -46,7 +46,7 @@ func RegisterVerifier(algorithm data.SigAlgorithm, v Verifier) {
 
 type Ed25519Verifier struct{}
 
-func (v Ed25519Verifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v Ed25519Verifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	var sigBytes [ed25519.SignatureSize]byte
 	if len(sig) != len(sigBytes) {
 		logrus.Infof("signature length is incorrect, must be %d, was %d.", ed25519.SignatureSize, len(sig))
@@ -79,7 +79,7 @@ func verifyPSS(key interface{}, digest, sig []byte) error {
 	return nil
 }
 
-func getRSAPubKey(key data.Key) (crypto.PublicKey, error) {
+func getRSAPubKey(key data.PublicKey) (crypto.PublicKey, error) {
 	algorithm := key.Algorithm()
 	var pubKey crypto.PublicKey
 
@@ -115,7 +115,7 @@ func getRSAPubKey(key data.Key) (crypto.PublicKey, error) {
 type RSAPSSVerifier struct{}
 
 // Verify does the actual check.
-func (v RSAPSSVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v RSAPSSVerifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	pubKey, err := getRSAPubKey(key)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (v RSAPSSVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
 // RSAPKCS1v15SVerifier checks RSA PKCS1v15 signatures
 type RSAPKCS1v15Verifier struct{}
 
-func (v RSAPKCS1v15Verifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v RSAPKCS1v15Verifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	pubKey, err := getRSAPubKey(key)
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ type RSAPyCryptoVerifier struct{}
 // Verify does the actual check.
 // N.B. We have not been able to make this work in a way that is compatible
 // with PyCrypto.
-func (v RSAPyCryptoVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v RSAPyCryptoVerifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	digest := sha256.Sum256(msg)
 
 	k, _ := pem.Decode([]byte(key.Public()))
@@ -177,7 +177,7 @@ func (v RSAPyCryptoVerifier) Verify(key data.Key, sig []byte, msg []byte) error 
 type ECDSAVerifier struct{}
 
 // Verify does the actual check.
-func (v ECDSAVerifier) Verify(key data.Key, sig []byte, msg []byte) error {
+func (v ECDSAVerifier) Verify(key data.PublicKey, sig []byte, msg []byte) error {
 	algorithm := key.Algorithm()
 	var pubKey crypto.PublicKey
 

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verifiers_test.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verifiers_test.go
@@ -30,7 +30,7 @@ const baseECDSAx509Key = `{"keytype":"ecdsa-x509","keyval":{"public":"LS0tLS1CRU
 
 func TestRSAPSSVerifier(t *testing.T) {
 	// Unmarshal our private RSA Key
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -54,7 +54,7 @@ func TestRSAPSSVerifier(t *testing.T) {
 
 func TestRSAPSSx509Verifier(t *testing.T) {
 	// Unmarshal our public RSA Key
-	var testRSAKey data.PublicKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -74,7 +74,7 @@ func TestRSAPSSx509Verifier(t *testing.T) {
 }
 
 func TestRSAPSSVerifierWithInvalidKeyType(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -94,7 +94,7 @@ func TestRSAPSSVerifierWithInvalidKeyType(t *testing.T) {
 }
 
 func TestRSAPSSVerifierWithInvalidKey(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -114,7 +114,7 @@ func TestRSAPSSVerifierWithInvalidKey(t *testing.T) {
 }
 
 func TestRSAPSSVerifierWithInvalidSignature(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -141,7 +141,7 @@ func TestRSAPSSVerifierWithInvalidSignature(t *testing.T) {
 
 func TestRSAPKCS1v15Verifier(t *testing.T) {
 	// Unmarshal our private RSA Key
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -165,7 +165,7 @@ func TestRSAPKCS1v15Verifier(t *testing.T) {
 
 func TestRSAPKCS1v15x509Verifier(t *testing.T) {
 	// Unmarshal our public RSA Key
-	var testRSAKey data.PublicKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -185,7 +185,7 @@ func TestRSAPKCS1v15x509Verifier(t *testing.T) {
 }
 
 func TestRSAPKCS1v15VerifierWithInvalidKeyType(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -205,7 +205,7 @@ func TestRSAPKCS1v15VerifierWithInvalidKeyType(t *testing.T) {
 }
 
 func TestRSAPKCS1v15VerifierWithInvalidKey(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -225,7 +225,7 @@ func TestRSAPKCS1v15VerifierWithInvalidKey(t *testing.T) {
 }
 
 func TestRSAPKCS1v15VerifierWithInvalidSignature(t *testing.T) {
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -251,7 +251,7 @@ func TestRSAPKCS1v15VerifierWithInvalidSignature(t *testing.T) {
 }
 
 func TestECDSAVerifier(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -273,7 +273,7 @@ func TestECDSAVerifier(t *testing.T) {
 }
 
 func TestECDSAx509Verifier(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -293,7 +293,7 @@ func TestECDSAx509Verifier(t *testing.T) {
 }
 
 func TestECDSAVerifierWithInvalidKeyType(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -313,7 +313,7 @@ func TestECDSAVerifierWithInvalidKeyType(t *testing.T) {
 }
 
 func TestECDSAVerifierWithInvalidKey(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -333,7 +333,7 @@ func TestECDSAVerifierWithInvalidKey(t *testing.T) {
 }
 
 func TestECDSAVerifierWithInvalidSignature(t *testing.T) {
-	var testECDSAKey data.PrivateKey
+	var testECDSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
@@ -358,7 +358,7 @@ func TestECDSAVerifierWithInvalidSignature(t *testing.T) {
 
 }
 
-func rsaPSSSign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
+func rsaPSSSign(privKey data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.RSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -378,7 +378,7 @@ func rsaPSSSign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) ([]by
 	return sig, nil
 }
 
-func rsaPKCS1v15Sign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
+func rsaPKCS1v15Sign(privKey data.PrivateKey, hash crypto.Hash, hashed []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.RSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -398,7 +398,7 @@ func rsaPKCS1v15Sign(privKey *data.PrivateKey, hash crypto.Hash, hashed []byte) 
 	return sig, nil
 }
 
-func ecdsaSign(privKey *data.PrivateKey, hashed []byte) ([]byte, error) {
+func ecdsaSign(privKey data.PrivateKey, hashed []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.ECDSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -432,7 +432,7 @@ func ecdsaSign(privKey *data.PrivateKey, hashed []byte) ([]byte, error) {
 // the test
 func signX509() {
 	// Unmarshal our private RSA Key
-	var testRSAKey data.PrivateKey
+	var testRSAKey data.TUFKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify.go
@@ -28,7 +28,7 @@ type signedMeta struct {
 }
 
 // VerifyRoot checks if a given root file is valid against a known set of keys.
-func VerifyRoot(s *data.Signed, minVersion int, keys map[string]*data.PublicKey, threshold int) ([]*data.PublicKey, error) {
+func VerifyRoot(s *data.Signed, minVersion int, keys map[string]data.PublicKey, threshold int) (data.PublicKey, error) {
 	if len(s.Signatures) == 0 {
 		return nil, ErrNoSignatures
 	}
@@ -57,7 +57,6 @@ func VerifyRoot(s *data.Signed, minVersion int, keys map[string]*data.PublicKey,
 			continue
 		}
 		valid[sig.KeyID] = struct{}{}
-
 	}
 	if len(valid) < threshold {
 		return nil, ErrRoleThreshold

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify_test.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify_test.go
@@ -22,7 +22,7 @@ func (VerifySuite) Test(c *C) {
 	cryptoService := NewEd25519()
 	type test struct {
 		name  string
-		keys  []data.Key
+		keys  []data.PublicKey
 		roles map[string]*data.Role
 		s     *data.Signed
 		ver   int
@@ -164,7 +164,7 @@ func (VerifySuite) Test(c *C) {
 			s := &data.Signed{Signed: b}
 			Sign(cryptoService, s, k)
 			t.s = s
-			t.keys = []data.Key{k}
+			t.keys = []data.PublicKey{k}
 		}
 		if t.roles == nil {
 			t.roles = map[string]*data.Role{

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/store/dbstore.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/store/dbstore.go
@@ -82,8 +82,8 @@ func (dbs *dbStore) Commit(metafiles map[string]json.RawMessage, consistent bool
 }
 
 // GetKeys returns private keys
-func (dbs *dbStore) GetKeys(role string) ([]*data.Key, error) {
-	keys := []*data.Key{}
+func (dbs *dbStore) GetKeys(role string) ([]data.PrivateKey, error) {
+	keys := []data.PrivateKey{}
 	var r *sql.Rows
 	var err error
 	sql := "SELECT `key` FROM `keys` WHERE `role` = ? AND `namespace` = ?;"
@@ -96,7 +96,7 @@ func (dbs *dbStore) GetKeys(role string) ([]*data.Key, error) {
 	defer r.Close()
 	for r.Next() {
 		var jsonStr string
-		key := new(data.Key)
+		key := new(data.TUFKey)
 		r.Scan(&jsonStr)
 		err := json.Unmarshal([]byte(jsonStr), key)
 		if err != nil {
@@ -108,7 +108,7 @@ func (dbs *dbStore) GetKeys(role string) ([]*data.Key, error) {
 }
 
 // SaveKey saves a new private key
-func (dbs *dbStore) SaveKey(role string, key *data.Key) error {
+func (dbs *dbStore) SaveKey(role string, key data.PrivateKey) error {
 	jsonBytes, err := json.Marshal(key)
 	if err != nil {
 		return fmt.Errorf("Could not JSON Marshal Key")

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/store/memorystore.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/store/memorystore.go
@@ -15,14 +15,14 @@ func MemoryStore(meta map[string]json.RawMessage, files map[string][]byte) Local
 	return &memoryStore{
 		meta:  meta,
 		files: files,
-		keys:  make(map[string][]*data.Key),
+		keys:  make(map[string][]data.PrivateKey),
 	}
 }
 
 type memoryStore struct {
 	meta  map[string]json.RawMessage
 	files map[string][]byte
-	keys  map[string][]*data.Key
+	keys  map[string][]data.PrivateKey
 }
 
 func (m *memoryStore) GetMeta(name string, size int64) (json.RawMessage, error) {
@@ -72,13 +72,13 @@ func (m *memoryStore) Commit(map[string]json.RawMessage, bool, map[string]data.H
 	return nil
 }
 
-func (m *memoryStore) GetKeys(role string) ([]*data.Key, error) {
+func (m *memoryStore) GetKeys(role string) ([]data.PrivateKey, error) {
 	return m.keys[role], nil
 }
 
-func (m *memoryStore) SaveKey(role string, key *data.Key) error {
+func (m *memoryStore) SaveKey(role string, key data.PrivateKey) error {
 	if _, ok := m.keys[role]; !ok {
-		m.keys[role] = make([]*data.Key, 0)
+		m.keys[role] = make([]data.PrivateKey, 0)
 	}
 	m.keys[role] = append(m.keys[role], key)
 	return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -306,7 +306,7 @@ func testAddListTarget(t *testing.T, rootType data.KeyAlgorithm) {
 	err = applyChangelist(repo.tufRepo, cl)
 	assert.NoError(t, err, "could not apply changelist")
 
-	var tempKey data.PrivateKey
+	var tempKey data.TUFKey
 	json.Unmarshal([]byte(timestampECDSAKeyJSON), &tempKey)
 
 	repo.KeyStoreManager.NonRootKeyStore().AddKey(filepath.Join(filepath.FromSlash(gun), tempKey.ID()), &tempKey)
@@ -426,7 +426,7 @@ func testValidateRootKey(t *testing.T, rootType data.KeyAlgorithm) {
 		if key, ok := decodedRoot.Keys[keyid]; !ok {
 			t.Fatal("key id not found in keys")
 		} else {
-			_, err := trustmanager.LoadCertFromPEM(key.Value.Public)
+			_, err := trustmanager.LoadCertFromPEM(key.Public())
 			assert.NoError(t, err, "key is not a valid cert")
 		}
 	}

--- a/cryptoservice/crypto_service.go
+++ b/cryptoservice/crypto_service.go
@@ -34,8 +34,8 @@ func NewCryptoService(gun string, keyStore trustmanager.KeyStore, passphrase str
 }
 
 // Create is used to generate keys for targets, snapshots and timestamps
-func (ccs *CryptoService) Create(role string, algorithm data.KeyAlgorithm) (data.Key, error) {
-	var privKey *data.PrivateKey
+func (ccs *CryptoService) Create(role string, algorithm data.KeyAlgorithm) (data.PublicKey, error) {
+	var privKey data.PrivateKey
 	var err error
 
 	switch algorithm {
@@ -68,7 +68,7 @@ func (ccs *CryptoService) Create(role string, algorithm data.KeyAlgorithm) (data
 }
 
 // GetKey returns a key by ID
-func (ccs *CryptoService) GetKey(keyID string) data.Key {
+func (ccs *CryptoService) GetKey(keyID string) data.PublicKey {
 	key, err := ccs.keyStore.GetKey(keyID)
 	if err != nil {
 		return nil
@@ -90,7 +90,7 @@ func (ccs *CryptoService) Sign(keyIDs []string, payload []byte) ([]data.Signatur
 		// ccs.gun will be empty if this is the root key
 		keyName := filepath.Join(ccs.gun, keyid)
 
-		var privKey *data.PrivateKey
+		var privKey data.PrivateKey
 		var err error
 
 		// Read PrivateKey from file and decrypt it if there is a passphrase.
@@ -142,7 +142,7 @@ func (ccs *CryptoService) Sign(keyIDs []string, payload []byte) ([]data.Signatur
 	return signatures, nil
 }
 
-func rsaSign(privKey *data.PrivateKey, message []byte) ([]byte, error) {
+func rsaSign(privKey data.PrivateKey, message []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.RSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -164,7 +164,7 @@ func rsaSign(privKey *data.PrivateKey, message []byte) ([]byte, error) {
 	return sig, nil
 }
 
-func ecdsaSign(privKey *data.PrivateKey, message []byte) ([]byte, error) {
+func ecdsaSign(privKey data.PrivateKey, message []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.ECDSAKey {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}
@@ -196,7 +196,7 @@ func ecdsaSign(privKey *data.PrivateKey, message []byte) ([]byte, error) {
 	return append(rBuf, sBuf...), nil
 }
 
-func ed25519Sign(privKey *data.PrivateKey, message []byte) ([]byte, error) {
+func ed25519Sign(privKey data.PrivateKey, message []byte) ([]byte, error) {
 	if privKey.Algorithm() != data.ED25519Key {
 		return nil, fmt.Errorf("private key type not supported: %s", privKey.Algorithm())
 	}

--- a/cryptoservice/unlocked_crypto_service.go
+++ b/cryptoservice/unlocked_crypto_service.go
@@ -17,12 +17,12 @@ import (
 // uses that private key, providing convinience methods for generation of
 // certificates.
 type UnlockedCryptoService struct {
-	PrivKey       *data.PrivateKey
+	PrivKey       data.PrivateKey
 	CryptoService signed.CryptoService
 }
 
 // NewUnlockedCryptoService creates an UnlockedCryptoService instance
-func NewUnlockedCryptoService(privKey *data.PrivateKey, cryptoService signed.CryptoService) *UnlockedCryptoService {
+func NewUnlockedCryptoService(privKey data.PrivateKey, cryptoService signed.CryptoService) *UnlockedCryptoService {
 	return &UnlockedCryptoService{
 		PrivKey:       privKey,
 		CryptoService: cryptoService,
@@ -35,7 +35,7 @@ func (ucs *UnlockedCryptoService) ID() string {
 }
 
 // PublicKey Returns the public key associated with the private key
-func (ucs *UnlockedCryptoService) PublicKey() *data.PublicKey {
+func (ucs *UnlockedCryptoService) PublicKey() data.PublicKey {
 	return data.PublicKeyFromPrivate(ucs.PrivKey)
 }
 

--- a/keystoremanager/import_export.go
+++ b/keystoremanager/import_export.go
@@ -206,7 +206,7 @@ func (km *KeyStoreManager) ImportKeysZip(zipReader zip.Reader, passphrase string
 	// an error (for example, wrong passphrase), without leaving the key
 	// store in an inconsistent state
 	newRootKeys := make(map[string][]byte)
-	newNonRootKeys := make(map[string]*data.PrivateKey)
+	newNonRootKeys := make(map[string]data.PrivateKey)
 
 	// Note that using / as a separator is okay here - the zip package
 	// guarantees that the separator will be /

--- a/keystoremanager/keystoremanager.go
+++ b/keystoremanager/keystoremanager.go
@@ -124,7 +124,7 @@ func (km *KeyStoreManager) AddTrustedCACert(cert *x509.Certificate) {
 // TODO(diogo): show not create keys manually, should use a cryptoservice instead
 func (km *KeyStoreManager) GenRootKey(algorithm, passphrase string) (string, error) {
 	var err error
-	var privKey *data.PrivateKey
+	var privKey data.PrivateKey
 
 	// We don't want external API callers to rely on internal TUF data types, so
 	// the API here should continue to receive a string algorithm, and ensure
@@ -196,7 +196,7 @@ func (km *KeyStoreManager) ValidateRoot(root *data.Signed, dnsName string) error
 		return err
 	}
 
-	certs := make(map[string]*data.PublicKey)
+	certs := make(map[string]data.PublicKey)
 	for _, keyID := range rootSigned.Roles["root"].KeyIDs {
 		// TODO(dlaw): currently assuming only one cert contained in
 		// public key entry. Need to fix when we want to pass in chains.

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -17,10 +17,10 @@ import (
 // found. It attempts to handle the race condition that may occur if 2 servers try to
 // create the key at the same time by simply querying the store a second time if it
 // receives a conflict when writing.
-func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.CryptoService, fallBackAlgorithm data.KeyAlgorithm) (*data.TUFKey, error) {
+func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.CryptoService, fallBackAlgorithm data.KeyAlgorithm) (data.PublicKey, error) {
 	keyAlgorithm, public, err := store.GetTimestampKey(gun)
 	if err == nil {
-		return data.NewTUFKey(keyAlgorithm, public, nil), nil
+		return data.NewPublicKey(keyAlgorithm, public), nil
 	}
 
 	if _, ok := err.(*storage.ErrNoKey); ok {
@@ -30,7 +30,7 @@ func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.
 		}
 		err = store.SetTimestampKey(gun, key.Algorithm(), key.Public())
 		if err == nil {
-			return data.NewTUFKey(key.Algorithm(), key.Public(), key.Private()), nil
+			return key, nil
 		}
 
 		if _, ok := err.(*storage.ErrTimestampKeyExists); ok {
@@ -38,7 +38,7 @@ func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.
 			if err != nil {
 				return nil, err
 			}
-			return data.NewTUFKey(keyAlgorithm, public, nil), nil
+			return data.NewPublicKey(keyAlgorithm, public), nil
 		}
 		return nil, err
 	}

--- a/signer/api/rsa_hardware_crypto_service.go
+++ b/signer/api/rsa_hardware_crypto_service.go
@@ -23,7 +23,7 @@ type RSAHardwareCryptoService struct {
 }
 
 // Create creates a key and returns its public components
-func (s *RSAHardwareCryptoService) Create(role string, algo data.KeyAlgorithm) (data.Key, error) {
+func (s *RSAHardwareCryptoService) Create(role string, algo data.KeyAlgorithm) (data.PublicKey, error) {
 	// For now generate random labels for keys
 	// (diogo): add link between keyID and label in database so we can support multiple keys
 	randomLabel := make([]byte, 32)
@@ -112,7 +112,7 @@ func (s *RSAHardwareCryptoService) RemoveKey(keyID string) error {
 }
 
 // GetKey returns the public components of a particular key
-func (s *RSAHardwareCryptoService) GetKey(keyID string) data.Key {
+func (s *RSAHardwareCryptoService) GetKey(keyID string) data.PublicKey {
 	return s.keys[keyID]
 }
 

--- a/signer/keys/keys.go
+++ b/signer/keys/keys.go
@@ -39,7 +39,7 @@ func (rsa *HSMRSAKey) Algorithm() data.KeyAlgorithm {
 // ID implements a method of the data.Key interface
 func (rsa *HSMRSAKey) ID() string {
 	if rsa.id == "" {
-		pubK := data.NewTUFKey(rsa.Algorithm(), rsa.Public(), nil)
+		pubK := data.NewPublicKey(rsa.Algorithm(), rsa.Public())
 		rsa.id = pubK.ID()
 	}
 	return rsa.id
@@ -50,7 +50,7 @@ func (rsa *HSMRSAKey) Public() []byte {
 	return rsa.public
 }
 
-// Private implements a method of the data.Key interface
+// Private implements a method of the data.PrivateKey interface
 func (rsa *HSMRSAKey) Private() []byte {
 	// Not possible to return private key bytes from a hardware device
 	return nil

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,14 +34,3 @@ type KeyManager interface {
 type Signer interface {
 	Sign(request *pb.SignatureRequest) (*pb.Signature, error)
 }
-
-// KeyDatabase is the interface that allows the implementation of multiple database backends
-type KeyDatabase interface {
-	KeyManager
-
-	// GetKey returns the private key to do signing operations
-	GetKey(keyID *pb.KeyID) (data.Key, error)
-
-	// AddKey allows the direct addition and removal of keys from the database
-	AddKey(key data.Key) error
-}

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -63,7 +63,7 @@ func (trust *NotarySigner) Sign(keyIDs []string, toSign []byte) ([]data.Signatur
 }
 
 // Create creates a remote key and returns the PublicKey associated with the remote private key
-func (trust *NotarySigner) Create(role string, algorithm data.KeyAlgorithm) (data.Key, error) {
+func (trust *NotarySigner) Create(role string, algorithm data.KeyAlgorithm) (data.PublicKey, error) {
 	publicKey, err := trust.kmClient.CreateKey(context.Background(), &pb.Algorithm{Algorithm: algorithm.String()})
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func (trust *NotarySigner) RemoveKey(keyid string) error {
 }
 
 // GetKey retrieves a key
-func (trust *NotarySigner) GetKey(keyid string) data.Key {
+func (trust *NotarySigner) GetKey(keyid string) data.PublicKey {
 	//TODO(aaronl): Not implemented yet
 	return nil
 }

--- a/trustmanager/keyfilestore.go
+++ b/trustmanager/keyfilestore.go
@@ -15,10 +15,10 @@ const (
 type KeyStore interface {
 	LimitedFileStore
 
-	AddKey(name string, privKey *data.PrivateKey) error
-	GetKey(name string) (*data.PrivateKey, error)
-	AddEncryptedKey(name string, privKey *data.PrivateKey, passphrase string) error
-	GetDecryptedKey(name string, passphrase string) (*data.PrivateKey, error)
+	AddKey(name string, privKey data.PrivateKey) error
+	GetKey(name string) (data.PrivateKey, error)
+	AddEncryptedKey(name string, privKey data.PrivateKey, passphrase string) error
+	GetDecryptedKey(name string, passphrase string) (data.PrivateKey, error)
 	ListKeys() []string
 }
 
@@ -44,23 +44,23 @@ func NewKeyFileStore(baseDir string) (*KeyFileStore, error) {
 }
 
 // AddKey stores the contents of a PEM-encoded private key as a PEM block
-func (s *KeyFileStore) AddKey(name string, privKey *data.PrivateKey) error {
+func (s *KeyFileStore) AddKey(name string, privKey data.PrivateKey) error {
 	return addKey(s, name, privKey)
 }
 
 // GetKey returns the PrivateKey given a KeyID
-func (s *KeyFileStore) GetKey(name string) (*data.PrivateKey, error) {
+func (s *KeyFileStore) GetKey(name string) (data.PrivateKey, error) {
 	return getKey(s, name)
 }
 
 // AddEncryptedKey stores the contents of a PEM-encoded private key as an encrypted PEM block
-func (s *KeyFileStore) AddEncryptedKey(name string, privKey *data.PrivateKey, passphrase string) error {
+func (s *KeyFileStore) AddEncryptedKey(name string, privKey data.PrivateKey, passphrase string) error {
 	return addEncryptedKey(s, name, privKey, passphrase)
 }
 
 // GetDecryptedKey decrypts and returns the PEM Encoded private key given a flename
 // and a passphrase
-func (s *KeyFileStore) GetDecryptedKey(name string, passphrase string) (*data.PrivateKey, error) {
+func (s *KeyFileStore) GetDecryptedKey(name string, passphrase string) (data.PrivateKey, error) {
 	return getDecryptedKey(s, name, passphrase)
 }
 
@@ -79,23 +79,23 @@ func NewKeyMemoryStore() *KeyMemoryStore {
 }
 
 // AddKey stores the contents of a PEM-encoded private key as a PEM block
-func (s *KeyMemoryStore) AddKey(name string, privKey *data.PrivateKey) error {
+func (s *KeyMemoryStore) AddKey(name string, privKey data.PrivateKey) error {
 	return addKey(s, name, privKey)
 }
 
 // GetKey returns the PrivateKey given a KeyID
-func (s *KeyMemoryStore) GetKey(name string) (*data.PrivateKey, error) {
+func (s *KeyMemoryStore) GetKey(name string) (data.PrivateKey, error) {
 	return getKey(s, name)
 }
 
 // AddEncryptedKey stores the contents of a PEM-encoded private key as an encrypted PEM block
-func (s *KeyMemoryStore) AddEncryptedKey(name string, privKey *data.PrivateKey, passphrase string) error {
+func (s *KeyMemoryStore) AddEncryptedKey(name string, privKey data.PrivateKey, passphrase string) error {
 	return addEncryptedKey(s, name, privKey, passphrase)
 }
 
 // GetDecryptedKey decrypts and returns the PEM Encoded private key given a flename
 // and a passphrase
-func (s *KeyMemoryStore) GetDecryptedKey(name string, passphrase string) (*data.PrivateKey, error) {
+func (s *KeyMemoryStore) GetDecryptedKey(name string, passphrase string) (data.PrivateKey, error) {
 	return getDecryptedKey(s, name, passphrase)
 }
 
@@ -106,7 +106,7 @@ func (s *KeyMemoryStore) ListKeys() []string {
 	return listKeys(s)
 }
 
-func addKey(s LimitedFileStore, name string, privKey *data.PrivateKey) error {
+func addKey(s LimitedFileStore, name string, privKey data.PrivateKey) error {
 	pemPrivKey, err := KeyToPEM(privKey)
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func addKey(s LimitedFileStore, name string, privKey *data.PrivateKey) error {
 	return s.Add(name, pemPrivKey)
 }
 
-func getKey(s LimitedFileStore, name string) (*data.PrivateKey, error) {
+func getKey(s LimitedFileStore, name string) (data.PrivateKey, error) {
 	keyBytes, err := s.Get(name)
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func getKey(s LimitedFileStore, name string) (*data.PrivateKey, error) {
 	return privKey, nil
 }
 
-func addEncryptedKey(s LimitedFileStore, name string, privKey *data.PrivateKey, passphrase string) error {
+func addEncryptedKey(s LimitedFileStore, name string, privKey data.PrivateKey, passphrase string) error {
 	encryptedPrivKey, err := EncryptPrivateKey(privKey, passphrase)
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func addEncryptedKey(s LimitedFileStore, name string, privKey *data.PrivateKey, 
 	return s.Add(name, encryptedPrivKey)
 }
 
-func getDecryptedKey(s LimitedFileStore, name string, passphrase string) (*data.PrivateKey, error) {
+func getDecryptedKey(s LimitedFileStore, name string, passphrase string) (data.PrivateKey, error) {
 	keyBytes, err := s.Get(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@diogomonica @endophage @NathanMcCauley 

Functions should now take data.PublicKey or data.PrivateKey instead of
data.Key.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>