### PR TITLE
Add a unit test for publish

### DIFF
--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -139,7 +139,7 @@ func tufInit(cmd *cobra.Command, args []string) {
 		fatalf(err.Error())
 	}
 
-	nRepo.Initialize(rootCryptoService)
+	err = nRepo.Initialize(rootCryptoService)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -88,7 +88,7 @@ func Run(ctx context.Context, addr, tlsCertFile, tlsKeyFile string, trust signed
 		Handler: r,
 	}
 
-	logrus.Error("[Notary Server] : Starting on ", addr)
+	logrus.Info("[Notary Server] : Starting on ", addr)
 
 	err = svr.Serve(lsnr)
 


### PR DESCRIPTION
@diogomonica @NathanMcCauley 

This instantiates a temporary server, publishes some targets to it, and
makes sure we can pull back the correct targets from the server.

Also fixes a few problems with the client unit tests, error reporting in
the client, and logging in the server.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>