### PR TITLE
Move passphrase logic to its own package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/keystoremanager"
+	"github.com/docker/notary/pkg/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/endophage/gotuf"
 	tufclient "github.com/endophage/gotuf/client"
@@ -84,7 +85,7 @@ func NewTarget(targetName string, targetPath string) (*Target, error) {
 // It takes the base directory under where all the trust files will be stored
 // (usually ~/.docker/trust/).
 func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
-	passphraseRetriever trustmanager.PassphraseRetriever) (*NotaryRepository, error) {
+	passphraseRetriever passphrase.Retriever) (*NotaryRepository, error) {
 
 	keyStoreManager, err := keystoremanager.NewKeyStoreManager(baseDir, passphraseRetriever)
 	if err != nil {

--- a/keystoremanager/import_export.go
+++ b/keystoremanager/import_export.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/notary/pkg/passphrase"
 	"github.com/docker/notary/trustmanager"
 )
 
@@ -135,7 +136,7 @@ func addKeysToArchive(zipWriter *zip.Writer, newKeyStore *trustmanager.KeyFileSt
 
 // ExportAllKeys exports all keys to an io.Writer in zip format.
 // newPassphraseRetriever will be used to obtain passphrases to use to encrypt the existing keys.
-func (km *KeyStoreManager) ExportAllKeys(dest io.Writer, newPassphraseRetriever trustmanager.PassphraseRetriever) error {
+func (km *KeyStoreManager) ExportAllKeys(dest io.Writer, newPassphraseRetriever passphrase.Retriever) error {
 	tempBaseDir, err := ioutil.TempDir("", "notary-key-export-")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -280,7 +281,7 @@ func moveKeysByGUN(oldKeyStore, newKeyStore *trustmanager.KeyFileStore, gun stri
 // ExportKeysByGUN exports all keys associated with a specified GUN to an
 // io.Writer in zip format. passphraseRetriever is used to select new passphrases to use to
 // encrypt the keys.
-func (km *KeyStoreManager) ExportKeysByGUN(dest io.Writer, gun string, passphraseRetriever trustmanager.PassphraseRetriever) error {
+func (km *KeyStoreManager) ExportKeysByGUN(dest io.Writer, gun string, passphraseRetriever passphrase.Retriever) error {
 	tempBaseDir, err := ioutil.TempDir("", "notary-key-export-")
 	defer os.RemoveAll(tempBaseDir)
 

--- a/keystoremanager/keystoremanager.go
+++ b/keystoremanager/keystoremanager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/pkg/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/endophage/gotuf/data"
 	"github.com/endophage/gotuf/signed"
@@ -60,7 +61,7 @@ func (err ErrRootRotationFail) Error() string {
 
 // NewKeyStoreManager returns an initialized KeyStoreManager, or an error
 // if it fails to create the KeyFileStores or load certificates
-func NewKeyStoreManager(baseDir string, passphraseRetriever trustmanager.PassphraseRetriever) (*KeyStoreManager, error) {
+func NewKeyStoreManager(baseDir string, passphraseRetriever passphrase.Retriever) (*KeyStoreManager, error) {
 	nonRootKeysPath := filepath.Join(baseDir, privDir, nonRootKeysSubdir)
 	nonRootKeyStore, err := trustmanager.NewKeyFileStore(nonRootKeysPath, passphraseRetriever)
 	if err != nil {

--- a/pkg/passphrase/passphrase.go
+++ b/pkg/passphrase/passphrase.go
@@ -1,0 +1,109 @@
+// Package passphrase is a utility function for managing passphrase
+// for TUF and Notary keys.
+package passphrase
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/pkg/term"
+)
+
+// Retriever is a callback function that should retrieve a passphrase
+// for a given named key. If it should be treated as new passphrase (e.g. with
+// confirmation), createNew will be true. Attempts is passed in so that implementers
+// decide how many chances to give to a human, for example.
+type Retriever func(keyName, alias string, createNew bool, attempts int) (passphrase string, giveup bool, err error)
+
+// PromptRetriever returns a new Retriever which will provide a terminal prompt
+// to retrieve a passphrase. The passphrase will be cached such that subsequent
+// prompts will produce the same passphrase.
+func PromptRetriever() Retriever {
+	userEnteredTargetsSnapshotsPass := false
+	targetsSnapshotsPass := ""
+	userEnteredRootsPass := false
+	rootsPass := ""
+
+	return func(keyName string, alias string, createNew bool, numAttempts int) (string, bool, error) {
+
+		// First, check if we have a password cached for this alias.
+		if numAttempts == 0 {
+			if userEnteredTargetsSnapshotsPass && (alias == "snapshot" || alias == "targets") {
+				return targetsSnapshotsPass, false, nil
+			}
+			if userEnteredRootsPass && (alias == "root") {
+				return rootsPass, false, nil
+			}
+		}
+
+		if numAttempts > 3 && !createNew {
+			return "", true, errors.New("Too many attempts")
+		}
+
+		state, err := term.SaveState(0)
+		if err != nil {
+			return "", false, err
+		}
+		term.DisableEcho(0, state)
+		defer term.RestoreTerminal(0, state)
+
+		stdin := bufio.NewReader(os.Stdin)
+
+		if createNew {
+			fmt.Printf("Enter passphrase for new %s key with id %s: ", alias, keyName)
+		} else {
+			fmt.Printf("Enter key passphrase for %s key with id %s: ", alias, keyName)
+		}
+
+		passphrase, err := stdin.ReadBytes('\n')
+		fmt.Println()
+		if err != nil {
+			return "", false, err
+		}
+
+		retPass := strings.TrimSpace(string(passphrase))
+
+		if !createNew {
+			if alias == "snapshot" || alias == "targets" {
+				userEnteredTargetsSnapshotsPass = true
+				targetsSnapshotsPass = retPass
+			}
+			if alias == "root" {
+				userEnteredRootsPass = true
+				rootsPass = retPass
+			}
+			return retPass, false, nil
+		}
+
+		if len(retPass) < 8 {
+			fmt.Println("Please use a password manager to generate and store a good random passphrase.")
+			return "", false, errors.New("Passphrase too short")
+		}
+
+		fmt.Printf("Repeat passphrase for new %s key with id %s: ", alias, keyName)
+		confirmation, err := stdin.ReadBytes('\n')
+		fmt.Println()
+		if err != nil {
+			return "", false, err
+		}
+		confirmationStr := strings.TrimSpace(string(confirmation))
+
+		if retPass != confirmationStr {
+			return "", false, errors.New("The entered passphrases do not match")
+		}
+
+		if alias == "snapshot" || alias == "targets" {
+			userEnteredTargetsSnapshotsPass = true
+			targetsSnapshotsPass = retPass
+		}
+		if alias == "root" {
+			userEnteredRootsPass = true
+			rootsPass = retPass
+		}
+
+		return retPass, false, nil
+	}
+}

--- a/signer/api/rpc_api_test.go
+++ b/signer/api/rpc_api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/pkg/passphrase"
 	"github.com/docker/notary/signer"
 	"github.com/docker/notary/signer/api"
 	"github.com/docker/notary/trustmanager"
@@ -24,7 +25,7 @@ var (
 	sClient    pb.SignerClient
 	grpcServer *grpc.Server
 	void       *pb.Void
-	pr         trustmanager.PassphraseRetriever
+	pr         passphrase.Retriever
 )
 
 func init() {


### PR DESCRIPTION
The logic to retrieve passphrase is generic and may be used by directly by clients.