### PR TITLE
ErrSigVerifyFail isn't used, we should be retrying on ErrRoleThreshol…

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -63,7 +63,7 @@
 		},
 		{
 			"ImportPath": "github.com/endophage/gotuf",
-			"Rev": "c5ce5d38779dff6653e1b74905302656502e6d48"
+			"Rev": "374908abc8af7e953a2813c5c2b3944ab625ca68"
 		},
 		{
 			"ImportPath": "github.com/go-sql-driver/mysql",

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/client/client.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/client/client.go
@@ -51,7 +51,7 @@ func (c *Client) Update() error {
 	err := c.update()
 	if err != nil {
 		switch err.(type) {
-		case tuf.ErrSigVerifyFail, signed.ErrExpired, tuf.ErrLocalRootExpired:
+		case signed.ErrRoleThreshold, signed.ErrExpired, tuf.ErrLocalRootExpired:
 			logrus.Debug("retryable error occurred. Root will be downloaded and another update attempted")
 			if err := c.downloadRoot(); err != nil {
 				logrus.Errorf("client Update (Root):", err)

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/errors.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/errors.go
@@ -21,3 +21,9 @@ type ErrLowVersion struct {
 func (e ErrLowVersion) Error() string {
 	return fmt.Sprintf("version %d is lower than current version %d", e.Actual, e.Current)
 }
+
+type ErrRoleThreshold struct{}
+
+func (e ErrRoleThreshold) Error() string {
+	return "valid signatures did not meet threshold"
+}

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify.go
@@ -13,13 +13,12 @@ import (
 )
 
 var (
-	ErrMissingKey    = errors.New("tuf: missing key")
-	ErrNoSignatures  = errors.New("tuf: data has no signatures")
-	ErrInvalid       = errors.New("tuf: signature verification failed")
-	ErrWrongMethod   = errors.New("tuf: invalid signature type")
-	ErrUnknownRole   = errors.New("tuf: unknown role")
-	ErrRoleThreshold = errors.New("tuf: valid signatures did not meet threshold")
-	ErrWrongType     = errors.New("tuf: meta file has wrong type")
+	ErrMissingKey   = errors.New("tuf: missing key")
+	ErrNoSignatures = errors.New("tuf: data has no signatures")
+	ErrInvalid      = errors.New("tuf: signature verification failed")
+	ErrWrongMethod  = errors.New("tuf: invalid signature type")
+	ErrUnknownRole  = errors.New("tuf: unknown role")
+	ErrWrongType    = errors.New("tuf: meta file has wrong type")
 )
 
 type signedMeta struct {
@@ -66,7 +65,7 @@ func VerifyRoot(s *data.Signed, minVersion int, keys map[string]data.PublicKey) 
 		// threshold of 1 so return on first success
 		return verifyMeta(s, "root", minVersion)
 	}
-	return ErrRoleThreshold
+	return ErrRoleThreshold{}
 }
 
 func Verify(s *data.Signed, role string, minVersion int, db *keys.KeyDB) error {
@@ -117,7 +116,7 @@ func VerifySignatures(s *data.Signed, role string, db *keys.KeyDB) error {
 	}
 
 	if roleData.Threshold < 1 {
-		return ErrRoleThreshold
+		return ErrRoleThreshold{}
 	}
 	logrus.Debugf("%s role has key IDs: %s", role, strings.Join(roleData.KeyIDs, ","))
 
@@ -158,7 +157,7 @@ func VerifySignatures(s *data.Signed, role string, db *keys.KeyDB) error {
 
 	}
 	if len(valid) < roleData.Threshold {
-		return ErrRoleThreshold
+		return ErrRoleThreshold{}
 	}
 
 	return nil

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify_test.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify_test.go
@@ -52,7 +52,7 @@ func Test(t *testing.T) {
 		{
 			name: "key missing from role",
 			mut:  func(t *test) { t.roles["root"].KeyIDs = nil },
-			err:  ErrRoleThreshold,
+			err:  ErrRoleThreshold{},
 		},
 		//	{
 		//		name: "invalid signature",
@@ -62,7 +62,7 @@ func Test(t *testing.T) {
 		{
 			name: "not enough signatures",
 			mut:  func(t *test) { t.roles["root"].Threshold = 2 },
-			err:  ErrRoleThreshold,
+			err:  ErrRoleThreshold{},
 		},
 		{
 			name: "exactly enough signatures",
@@ -82,7 +82,7 @@ func Test(t *testing.T) {
 				t.roles["root"].Threshold = 2
 				t.s.Signatures = append(t.s.Signatures, t.s.Signatures[0])
 			},
-			err: ErrRoleThreshold,
+			err: ErrRoleThreshold{},
 		},
 		{
 			name: "unknown key",
@@ -98,7 +98,7 @@ func Test(t *testing.T) {
 				Sign(cryptoService, t.s, k)
 				t.roles["root"].Threshold = 2
 			},
-			err: ErrRoleThreshold,
+			err: ErrRoleThreshold{},
 		},
 		{
 			name: "unknown keys in db",
@@ -116,7 +116,7 @@ func Test(t *testing.T) {
 				t.keys = append(t.keys, k)
 				t.roles["root"].Threshold = 2
 			},
-			err: ErrRoleThreshold,
+			err: ErrRoleThreshold{},
 		},
 		{
 			name: "wrong type",


### PR DESCRIPTION
…d which means we didn't have enough keys to validate the signatures

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)