### PR TITLE
Avoid printing "Passphrases do not match" when passphrase is too short

### DIFF
--- a/trustmanager/keyfilestore.go
+++ b/trustmanager/keyfilestore.go
@@ -112,10 +112,10 @@ func addKey(s LimitedFileStore, passphraseRetriever passphrase.Retriever, cached
 	}
 
 	attempts := 0
-	passphrase := ""
+	chosenPassphrase := ""
 	giveup := false
 	for {
-		passphrase, giveup, err = passphraseRetriever(name, alias, true, attempts)
+		chosenPassphrase, giveup, err = passphraseRetriever(name, alias, true, attempts)
 		if err != nil {
 			attempts++
 			continue
@@ -129,8 +129,8 @@ func addKey(s LimitedFileStore, passphraseRetriever passphrase.Retriever, cached
 		break
 	}
 
-	if passphrase != "" {
-		pemPrivKey, err = EncryptPrivateKey(privKey, passphrase)
+	if chosenPassphrase != "" {
+		pemPrivKey, err = EncryptPrivateKey(privKey, chosenPassphrase)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Also, wrap the passphrase instructions paragraph at 80 columns, and
change the passphrase variable name in addKey to avoid a conflict with
the package name.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>