### PR TITLE
Use the random reader passed as argument to GenerateED25519Key.

### DIFF
--- a/trustmanager/x509utils.go
+++ b/trustmanager/x509utils.go
@@ -351,7 +351,7 @@ func GenerateECDSAKey(random io.Reader) (data.PrivateKey, error) {
 // PrivateKey. The serialization format we use is just the public key bytes
 // followed by the private key bytes
 func GenerateED25519Key(random io.Reader) (data.PrivateKey, error) {
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	pub, priv, err := ed25519.GenerateKey(random)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Rather than the global source.

Signed-off-by: David Calavera <david.calavera@gmail.com>