### PR TITLE
gorm uses timestamp to represent time.Time, not datetime

### DIFF
--- a/notarymysql/initial.sql
+++ b/notarymysql/initial.sql
@@ -20,9 +20,9 @@ CREATE TABLE `timestamp_keys` (
 DROP TABLE IF EXISTS `private_keys`;
 CREATE TABLE `private_keys` (
 	`id` int(11) NOT NULL AUTO_INCREMENT,
-	`created_at` datetime NOT NULL,
-	`updated_at` datetime NOT NULL,
-	`deleted_at` datetime DEFAULT NULL,
+	`created_at` timestamp DEFAULT NULL,
+	`updated_at` timestamp DEFAULT NULL,
+	`deleted_at` timestamp DEFAULT NULL,
 	`key_id`  varchar(255) NOT NULL,
 	`encryption_alg`  varchar(255) NOT NULL,
 	`keywrap_alg`  varchar(255) NOT NULL,


### PR DESCRIPTION
Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)