### PR TITLE
Update expiration logic

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -87,7 +87,7 @@
 		},
 		{
 			"ImportPath": "github.com/endophage/gotuf",
-			"Rev": "5f508200b262dc8f56362523f621417853192812"
+			"Rev": "8898f45c7eff3f623777957c2541ff8088a06fe9"
 		},
 		{
 			"ImportPath": "github.com/go-sql-driver/mysql",

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify.go
@@ -22,9 +22,9 @@ var (
 )
 
 type signedMeta struct {
-	Type    string `json:"_type"`
-	Expires string `json:"expires"`
-	Version int    `json:"version"`
+	Type    string    `json:"_type"`
+	Expires time.Time `json:"expires"`
+	Version int       `json:"version"`
 }
 
 // VerifyRoot checks if a given root file is valid against a known set of keys.
@@ -85,7 +85,7 @@ func verifyMeta(s *data.Signed, role string, minVersion int) error {
 	}
 	if IsExpired(sm.Expires) {
 		logrus.Errorf("Metadata for %s expired", role)
-		return ErrExpired{Role: role, Expired: sm.Expires}
+		return ErrExpired{Role: role, Expired: sm.Expires.Format("Mon Jan 2 15:04:05 MST 2006")}
 	}
 	if sm.Version < minVersion {
 		return ErrLowVersion{sm.Version, minVersion}
@@ -94,15 +94,8 @@ func verifyMeta(s *data.Signed, role string, minVersion int) error {
 	return nil
 }
 
-var IsExpired = func(t string) bool {
-	ts, err := time.Parse(time.RFC3339, t)
-	if err != nil {
-		ts, err = time.Parse("2006-01-02 15:04:05 MST", t)
-		if err != nil {
-			return false
-		}
-	}
-	return ts.Sub(time.Now()) <= 0
+var IsExpired = func(t time.Time) bool {
+	return t.Before(time.Now())
 }
 
 func VerifySignatures(s *data.Signed, role string, db *keys.KeyDB) error {

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify_test.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/signed/verify_test.go
@@ -132,7 +132,7 @@ func Test(t *testing.T) {
 			role: "root",
 			name: "expired",
 			exp:  &expiredTime,
-			err:  ErrExpired{"root", expiredTime.Format("2006-01-02 15:04:05 MST")},
+			err:  ErrExpired{"root", expiredTime.Format("Mon Jan 2 15:04:05 MST 2006")},
 		},
 	}
 	for _, run := range tests {
@@ -151,7 +151,7 @@ func Test(t *testing.T) {
 		}
 		if run.keys == nil && run.s == nil {
 			k, _ := cryptoService.Create("root", data.ED25519Key)
-			meta := &signedMeta{Type: run.typ, Version: run.ver, Expires: run.exp.Format("2006-01-02 15:04:05 MST")}
+			meta := &signedMeta{Type: run.typ, Version: run.ver, Expires: *run.exp}
 
 			b, err := cjson.Marshal(meta)
 			assert.NoError(t, err)

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/store/errors.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/store/errors.go
@@ -5,9 +5,3 @@ type ErrMetaNotFound struct{}
 func (err ErrMetaNotFound) Error() string {
 	return "no trust data available"
 }
-
-type ErrKeyNotAvailable struct{}
-
-func (err ErrKeyNotAvailable) Error() string {
-	return "could not retrieve timestamp public key"
-}

--- a/Godeps/_workspace/src/github.com/endophage/gotuf/store/httpstore.go
+++ b/Godeps/_workspace/src/github.com/endophage/gotuf/store/httpstore.go
@@ -204,9 +204,6 @@ func (s HTTPStore) GetKey(role string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != 200 {
-		return nil, ErrKeyNotAvailable{}
-	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -3,7 +3,6 @@ package timestamp
 import (
 	"bytes"
 	"encoding/json"
-	"time"
 
 	"github.com/endophage/gotuf/data"
 	"github.com/endophage/gotuf/signed"
@@ -93,7 +92,7 @@ func GetOrCreateTimestamp(gun string, store storage.MetaStore, cryptoService sig
 
 // timestampExpired compares the current time to the expiry time of the timestamp
 func timestampExpired(ts *data.SignedTimestamp) bool {
-	return time.Now().After(ts.Signed.Expires)
+	return signed.IsExpired(ts.Signed.Expires)
 }
 
 func snapshotExpired(ts *data.SignedTimestamp, snapshot []byte) bool {


### PR DESCRIPTION
Makes use of an update in gotuf to properly check expirations. Notary will now use the gotuf expiration checking function directly.