### PR TITLE
Move key database to signer package

### DIFF
--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/signer"
 	"github.com/docker/notary/signer/api"
-	"github.com/docker/notary/trustmanager"
 	"github.com/endophage/gotuf/data"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/miekg/pkcs11"
@@ -141,7 +140,7 @@ func main() {
 
 	defaultAlias := viper.GetString(_DefaultAliasEnv)
 	logrus.Debug("Default Alias: ", defaultAlias)
-	keyStore, err := trustmanager.NewKeyDBStore(passphraseRetriever, defaultAlias, dbType, dbSQL)
+	keyStore, err := signer.NewKeyDBStore(passphraseRetriever, defaultAlias, dbType, dbSQL)
 	if err != nil {
 		log.Fatalf("failed to create a new keydbstore: %v", err)
 	}

--- a/signer/keydbstore.go
+++ b/signer/keydbstore.go
@@ -1,4 +1,4 @@
-package trustmanager
+package signer
 
 import (
 	"database/sql"
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/docker/notary/pkg/passphrase"
+	"github.com/docker/notary/trustmanager"
 	jose "github.com/dvsekhvalnov/jose2go"
 	"github.com/endophage/gotuf/data"
 	"github.com/jinzhu/gorm"
@@ -107,7 +108,7 @@ func (s *KeyDBStore) GetKey(name string) (data.PrivateKey, string, error) {
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return nil, "", ErrKeyNotFound{}
+		return nil, "", trustmanager.ErrKeyNotFound{}
 	}
 
 	// Get the passphrase to use for this key
@@ -146,7 +147,7 @@ func (s *KeyDBStore) RemoveKey(name string) error {
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return ErrKeyNotFound{}
+		return trustmanager.ErrKeyNotFound{}
 	}
 
 	// Delete the key from the database
@@ -160,7 +161,7 @@ func (s *KeyDBStore) RotateKeyPassphrase(name, newPassphraseAlias string) error 
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return ErrKeyNotFound{}
+		return trustmanager.ErrKeyNotFound{}
 	}
 
 	// Get the current passphrase to use for this key

--- a/signer/keydbstore_test.go
+++ b/signer/keydbstore_test.go
@@ -1,4 +1,4 @@
-package trustmanager
+package signer
 
 import (
 	"crypto/rand"
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/notary/trustmanager"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,7 +31,7 @@ func TestCreateRead(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 
-	testKey, err := GenerateECDSAKey(rand.Reader)
+	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err)
 
 	// We are using SQLite for the tests
@@ -69,10 +70,10 @@ func TestDoubleCreate(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 
-	testKey, err := GenerateECDSAKey(rand.Reader)
+	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err)
 
-	anotherTestKey, err := GenerateECDSAKey(rand.Reader)
+	anotherTestKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err)
 
 	// We are using SQLite for the tests
@@ -103,7 +104,7 @@ func TestCreateDelete(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 
-	testKey, err := GenerateECDSAKey(rand.Reader)
+	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err)
 
 	// We are using SQLite for the tests
@@ -134,7 +135,7 @@ func TestKeyRotation(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 
-	testKey, err := GenerateECDSAKey(rand.Reader)
+	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err)
 
 	// We are using SQLite for the tests


### PR DESCRIPTION
The key database is not generally used but only used by the signing service.
Move the implementation to the signer package to be imported by the signer.

ping @endophage 