### PR TITLE
Accept configuration parameters from environment variables

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -58,6 +58,12 @@ func main() {
 	viper.SetConfigType(strings.TrimPrefix(ext, "."))
 	viper.SetConfigName(strings.TrimSuffix(filename, ext))
 	viper.AddConfigPath(configPath)
+
+	// Automatically accept configuration options from the environment
+	viper.SetEnvPrefix("NOTARY_SERVER")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+
 	err := viper.ReadInConfig()
 	if err != nil {
 		logrus.Error("Viper Error: ", err.Error())


### PR DESCRIPTION
For example, trust_service.type becomes
NOTARY_SERVER_TRUST_SERVICE_TYPE.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>