### PR TITLE
compile the notary server binary statically 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ binaries: ${PREFIX}/bin/notary-server ${PREFIX}/bin/notary ${PREFIX}/bin/notary-
 
 define template
 mkdir -p ${PREFIX}/cross/$(1)/$(2);
-GOOS=$(1) GOARCH=$(2) go build -o ${PREFIX}/cross/$(1)/$(2)/notary -a -tags "static_build netgo" -installsuffix netgo ${GO_LDFLAGS_STATIC} ./cmd/notary;
+GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -o ${PREFIX}/cross/$(1)/$(2)/notary -a -tags "static_build netgo" -installsuffix netgo ${GO_LDFLAGS_STATIC} ./cmd/notary;
 endef
 
 cross:

--- a/notary-server-Dockerfile
+++ b/notary-server-Dockerfile
@@ -5,14 +5,18 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /go/src/github.com/docker/notary
-
-ENV GOPATH /go/src/github.com/docker/notary/Godeps/_workspace:$GOPATH
-
-RUN go install github.com/docker/notary/cmd/notary-server
-
 EXPOSE 4443
 
-WORKDIR /go/src/github.com/docker/notary
+ENV NOTARYPKG github.com/docker/notary
+ENV GOPATH /go/src/${NOTARYPKG}/Godeps/_workspace:$GOPATH
 
-CMD [ "notary-server", "-config", "cmd/notary-server/config.json" ]
+COPY . /go/src/github.com/docker/notary
+
+WORKDIR /go/src/${NOTARYPKG}
+
+RUN go install \
+    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit `git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion `cat NOTARY_VERSION`" \
+    ${NOTARYPKG}/cmd/notary-server
+
+ENTRYPOINT [ "notary-server" ]
+CMD [ "-config", "cmd/notary-server/config.json" ]

--- a/notary-signer-Dockerfile
+++ b/notary-signer-Dockerfile
@@ -21,16 +21,21 @@ RUN apt-get update && \
 # Initialize the SoftHSM2 token on slod 0, using PIN and SOPIN varaibles
 RUN softhsm2-util --init-token --slot 0 --label "test_token" --pin $NOTARY_SIGNER_PIN --so-pin $SOPIN
 
-# Copy the local repo to the expected go path
-COPY . /go/src/github.com/docker/notary
-
-ENV GOPATH /go/src/github.com/docker/notary/Godeps/_workspace:$GOPATH
-
-# Install notary-signer
-RUN go install github.com/docker/notary/cmd/notary-signer
+ENV NOTARYPKG github.com/docker/notary
+ENV GOPATH /go/src/${NOTARYPKG}/Godeps/_workspace:$GOPATH
 
 EXPOSE 4443
 
-WORKDIR /go/src/github.com/docker/notary
+# Copy the local repo to the expected go path
+COPY . /go/src/github.com/docker/notary
 
-ENTRYPOINT notary-signer -config=cmd/notary-signer/config.json -debug
+WORKDIR /go/src/${NOTARYPKG}
+
+# Install notary-signer
+RUN go install \
+    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit `git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion `cat NOTARY_VERSION`" \
+    ${NOTARYPKG}/cmd/notary-signer
+
+
+ENTRYPOINT [ "notary-signer" ]
+CMD [ "-config=cmd/notary-signer/config.json", "-debug" ]


### PR DESCRIPTION
compile the notary server binary statically in the notary server image so that it can then be copied from the container into a scratch docker image

ping @aaronlehmann then you can use `FROM scratch`

Signed-off-by: Jessica Frazelle <acidburn@docker.com>