### PR TITLE
Import and export symlinks in keystore

### DIFF
--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -258,8 +258,8 @@ func keysExport(cmd *cobra.Command, args []string) {
 	exportFile.Close()
 
 	if err != nil {
-		fatalf("error exporting keys: %v", err)
 		os.Remove(exportFilename)
+		fatalf("error exporting keys: %v", err)
 	}
 }
 
@@ -298,8 +298,8 @@ func keysExportRoot(cmd *cobra.Command, args []string) {
 	}
 	exportFile.Close()
 	if err != nil {
-		fatalf("error exporting root key: %v", err)
 		os.Remove(exportFilename)
+		fatalf("error exporting root key: %v", err)
 	}
 }
 

--- a/keystoremanager/import_export_test.go
+++ b/keystoremanager/import_export_test.go
@@ -100,6 +100,10 @@ func TestImportExportZip(t *testing.T) {
 	// Iterate through the files in the archive, checking that the files
 	// exist and are encrypted with the expected passphrase.
 	for _, f := range zipReader.File {
+		if keystoremanager.IsZipSymlink(f) {
+			continue
+		}
+
 		expectedPassphrase, present := passphraseByFile[f.Name]
 		if !present {
 			t.Fatalf("unexpected file %s in zip file", f.Name)
@@ -171,6 +175,35 @@ func TestImportExportZip(t *testing.T) {
 	rootKeyFilename := rootCryptoService.ID() + "_root.key"
 	_, err = os.Stat(filepath.Join(tempBaseDir2, "private", "root_keys", rootKeyFilename))
 	assert.NoError(t, err, "missing root key")
+
+	// Look for symlinks in the new repo matching symlinks in the old repo
+	numSymlinks := 0
+
+	oldRootKeyStore := repo.KeyStoreManager.RootKeyStore()
+	newRootKeyStore := repo2.KeyStoreManager.RootKeyStore()
+
+	for _, relKeyPath := range oldRootKeyStore.ListFiles(true) {
+		fullKeyPath := filepath.Join(oldRootKeyStore.BaseDir(), relKeyPath)
+
+		fi, err := os.Lstat(fullKeyPath)
+		assert.NoError(t, err, "lstat failed")
+
+		if (fi.Mode() & os.ModeSymlink) != 0 {
+			numSymlinks++
+
+			oldTarget, err := os.Readlink(fullKeyPath)
+			assert.NoError(t, err, "readlink failed on old repo")
+
+			newTarget, err := os.Readlink(filepath.Join(newRootKeyStore.BaseDir(), relKeyPath))
+			assert.NoError(t, err, "symlink not found in new repo")
+
+			assert.Equal(t, oldTarget, newTarget, "symlink targets do not match")
+		}
+	}
+
+	if numSymlinks == 0 {
+		t.Fatal("no symlinks found in original repo")
+	}
 }
 
 func TestImportExportGUN(t *testing.T) {

--- a/trustmanager/filestore.go
+++ b/trustmanager/filestore.go
@@ -189,7 +189,7 @@ func (f *SimpleFileStore) genFileName(name string) string {
 	return fmt.Sprintf("%s.%s", name, f.fileExt)
 }
 
-// Link creates a symlink beetween the ID of the certificate used by a repository
+// Link creates a symlink between the ID of the certificate used by a repository
 // and the ID of the root key that is being used.
 // We use full path for the source and local for the destination to use relative
 // path for the symlink


### PR DESCRIPTION
- Export symlinks by encoding them in the zip file.

- Detect symlinks in a zip file on import and create them on the local
  filesystem.

- Add test coverage.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>