### PR TITLE
Notary cli auth

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -76,6 +76,16 @@
 			"Rev": "fed58bd2d3c096055c0e69c2fb86c9a4965d1b8b"
 		},
 		{
+			"ImportPath": "github.com/docker/distribution/registry/client/auth",
+			"Comment": "v2.0.0-353-gfed58bd",
+			"Rev": "fed58bd2d3c096055c0e69c2fb86c9a4965d1b8b"
+		},
+		{
+			"ImportPath": "github.com/docker/distribution/registry/client/transport",
+			"Comment": "v2.0.0-353-gfed58bd",
+			"Rev": "fed58bd2d3c096055c0e69c2fb86c9a4965d1b8b"
+		},
+		{
 			"ImportPath": "github.com/docker/distribution/uuid",
 			"Comment": "v2.0.0-353-gfed58bd",
 			"Rev": "fed58bd2d3c096055c0e69c2fb86c9a4965d1b8b"

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/api_version.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/api_version.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// APIVersion represents a version of an API including its
+// type and version number.
+type APIVersion struct {
+	// Type refers to the name of a specific API specification
+	// such as "registry"
+	Type string
+
+	// Version is the version of the API specification implemented,
+	// This may omit the revision number and only include
+	// the major and minor version, such as "2.0"
+	Version string
+}
+
+// String returns the string formatted API Version
+func (v APIVersion) String() string {
+	return v.Type + "/" + v.Version
+}
+
+// APIVersions gets the API versions out of an HTTP response using the provided
+// version header as the key for the HTTP header.
+func APIVersions(resp *http.Response, versionHeader string) []APIVersion {
+	versions := []APIVersion{}
+	if versionHeader != "" {
+		for _, supportedVersions := range resp.Header[http.CanonicalHeaderKey(versionHeader)] {
+			for _, version := range strings.Fields(supportedVersions) {
+				versions = append(versions, ParseAPIVersion(version))
+			}
+		}
+	}
+	return versions
+}
+
+// ParseAPIVersion parses an API version string into an APIVersion
+// Format (Expected, not enforced):
+// API version string = <API type> '/' <API version>
+// API type = [a-z][a-z0-9]*
+// API version = [0-9]+(\.[0-9]+)?
+// TODO(dmcgowan): Enforce format, add error condition, remove unknown type
+func ParseAPIVersion(versionStr string) APIVersion {
+	idx := strings.IndexRune(versionStr, '/')
+	if idx == -1 {
+		return APIVersion{
+			Type:    "unknown",
+			Version: versionStr,
+		}
+	}
+	return APIVersion{
+		Type:    strings.ToLower(versionStr[:idx]),
+		Version: versionStr[idx+1:],
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/authchallenge.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/authchallenge.go
@@ -1,0 +1,219 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Challenge carries information from a WWW-Authenticate response header.
+// See RFC 2617.
+type Challenge struct {
+	// Scheme is the auth-scheme according to RFC 2617
+	Scheme string
+
+	// Parameters are the auth-params according to RFC 2617
+	Parameters map[string]string
+}
+
+// ChallengeManager manages the challenges for endpoints.
+// The challenges are pulled out of HTTP responses. Only
+// responses which expect challenges should be added to
+// the manager, since a non-unauthorized request will be
+// viewed as not requiring challenges.
+type ChallengeManager interface {
+	// GetChallenges returns the challenges for the given
+	// endpoint URL.
+	GetChallenges(endpoint string) ([]Challenge, error)
+
+	// AddResponse adds the response to the challenge
+	// manager. The challenges will be parsed out of
+	// the WWW-Authenicate headers and added to the
+	// URL which was produced the response. If the
+	// response was authorized, any challenges for the
+	// endpoint will be cleared.
+	AddResponse(resp *http.Response) error
+}
+
+// NewSimpleChallengeManager returns an instance of
+// ChallengeManger which only maps endpoints to challenges
+// based on the responses which have been added the
+// manager. The simple manager will make no attempt to
+// perform requests on the endpoints or cache the responses
+// to a backend.
+func NewSimpleChallengeManager() ChallengeManager {
+	return simpleChallengeManager{}
+}
+
+type simpleChallengeManager map[string][]Challenge
+
+func (m simpleChallengeManager) GetChallenges(endpoint string) ([]Challenge, error) {
+	challenges := m[endpoint]
+	return challenges, nil
+}
+
+func (m simpleChallengeManager) AddResponse(resp *http.Response) error {
+	challenges := ResponseChallenges(resp)
+	if resp.Request == nil {
+		return fmt.Errorf("missing request reference")
+	}
+	urlCopy := url.URL{
+		Path:   resp.Request.URL.Path,
+		Host:   resp.Request.URL.Host,
+		Scheme: resp.Request.URL.Scheme,
+	}
+	m[urlCopy.String()] = challenges
+
+	return nil
+}
+
+// Octet types from RFC 2616.
+type octetType byte
+
+var octetTypes [256]octetType
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+// ResponseChallenges returns a list of authorization challenges
+// for the given http Response. Challenges are only checked if
+// the response status code was a 401.
+func ResponseChallenges(resp *http.Response) []Challenge {
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Parse the WWW-Authenticate Header and store the challenges
+		// on this endpoint object.
+		return parseAuthHeader(resp.Header)
+	}
+
+	return nil
+}
+
+func parseAuthHeader(header http.Header) []Challenge {
+	challenges := []Challenge{}
+	for _, h := range header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		v, p := parseValueAndParams(h)
+		if v != "" {
+			challenges = append(challenges, Challenge{Scheme: v, Parameters: p})
+		}
+	}
+	return challenges
+}
+
+func parseValueAndParams(header string) (value string, params map[string]string) {
+	params = make(map[string]string)
+	value, s := expectToken(header)
+	if value == "" {
+		return
+	}
+	value = strings.ToLower(value)
+	s = "," + skipSpace(s)
+	for strings.HasPrefix(s, ",") {
+		var pkey string
+		pkey, s = expectToken(skipSpace(s[1:]))
+		if pkey == "" {
+			return
+		}
+		if !strings.HasPrefix(s, "=") {
+			return
+		}
+		var pvalue string
+		pvalue, s = expectTokenOrQuoted(s[1:])
+		if pvalue == "" {
+			return
+		}
+		pkey = strings.ToLower(pkey)
+		params[pkey] = pvalue
+		s = skipSpace(s)
+	}
+	return
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectToken(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isToken == 0 {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectTokenOrQuoted(s string) (value string, rest string) {
+	if !strings.HasPrefix(s, "\"") {
+		return expectToken(s)
+	}
+	s = s[1:]
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return s[:i], s[i+1:]
+		case '\\':
+			p := make([]byte, len(s)-1)
+			j := copy(p, s[:i])
+			escape := true
+			for i = i + 1; i < len(s); i++ {
+				b := s[i]
+				switch {
+				case escape:
+					escape = false
+					p[j] = b
+					j++
+				case b == '\\':
+					escape = true
+				case b == '"':
+					return string(p[:j]), s[i+1:]
+				default:
+					p[j] = b
+					j++
+				}
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/authchallenge_test.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/authchallenge_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAuthChallengeParse(t *testing.T) {
+	header := http.Header{}
+	header.Add("WWW-Authenticate", `Bearer realm="https://auth.example.com/token",service="registry.example.com",other=fun,slashed="he\"\l\lo"`)
+
+	challenges := parseAuthHeader(header)
+	if len(challenges) != 1 {
+		t.Fatalf("Unexpected number of auth challenges: %d, expected 1", len(challenges))
+	}
+	challenge := challenges[0]
+
+	if expected := "bearer"; challenge.Scheme != expected {
+		t.Fatalf("Unexpected scheme: %s, expected: %s", challenge.Scheme, expected)
+	}
+
+	if expected := "https://auth.example.com/token"; challenge.Parameters["realm"] != expected {
+		t.Fatalf("Unexpected param: %s, expected: %s", challenge.Parameters["realm"], expected)
+	}
+
+	if expected := "registry.example.com"; challenge.Parameters["service"] != expected {
+		t.Fatalf("Unexpected param: %s, expected: %s", challenge.Parameters["service"], expected)
+	}
+
+	if expected := "fun"; challenge.Parameters["other"] != expected {
+		t.Fatalf("Unexpected param: %s, expected: %s", challenge.Parameters["other"], expected)
+	}
+
+	if expected := "he\"llo"; challenge.Parameters["slashed"] != expected {
+		t.Fatalf("Unexpected param: %s, expected: %s", challenge.Parameters["slashed"], expected)
+	}
+
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/session.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/session.go
@@ -1,0 +1,255 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/distribution/registry/client/transport"
+)
+
+// AuthenticationHandler is an interface for authorizing a request from
+// params from a "WWW-Authenicate" header for a single scheme.
+type AuthenticationHandler interface {
+	// Scheme returns the scheme as expected from the "WWW-Authenicate" header.
+	Scheme() string
+
+	// AuthorizeRequest adds the authorization header to a request (if needed)
+	// using the parameters from "WWW-Authenticate" method. The parameters
+	// values depend on the scheme.
+	AuthorizeRequest(req *http.Request, params map[string]string) error
+}
+
+// CredentialStore is an interface for getting credentials for
+// a given URL
+type CredentialStore interface {
+	// Basic returns basic auth for the given URL
+	Basic(*url.URL) (string, string)
+}
+
+// NewAuthorizer creates an authorizer which can handle multiple authentication
+// schemes. The handlers are tried in order, the higher priority authentication
+// methods should be first. The challengeMap holds a list of challenges for
+// a given root API endpoint (for example "https://registry-1.docker.io/v2/").
+func NewAuthorizer(manager ChallengeManager, handlers ...AuthenticationHandler) transport.RequestModifier {
+	return &endpointAuthorizer{
+		challenges: manager,
+		handlers:   handlers,
+	}
+}
+
+type endpointAuthorizer struct {
+	challenges ChallengeManager
+	handlers   []AuthenticationHandler
+	transport  http.RoundTripper
+}
+
+func (ea *endpointAuthorizer) ModifyRequest(req *http.Request) error {
+	v2Root := strings.Index(req.URL.Path, "/v2/")
+	if v2Root == -1 {
+		return nil
+	}
+
+	ping := url.URL{
+		Host:   req.URL.Host,
+		Scheme: req.URL.Scheme,
+		Path:   req.URL.Path[:v2Root+4],
+	}
+
+	pingEndpoint := ping.String()
+
+	challenges, err := ea.challenges.GetChallenges(pingEndpoint)
+	if err != nil {
+		return err
+	}
+
+	if len(challenges) > 0 {
+		for _, handler := range ea.handlers {
+			for _, challenge := range challenges {
+				if challenge.Scheme != handler.Scheme() {
+					continue
+				}
+				if err := handler.AuthorizeRequest(req, challenge.Parameters); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+type tokenHandler struct {
+	header    http.Header
+	creds     CredentialStore
+	scope     tokenScope
+	transport http.RoundTripper
+
+	tokenLock       sync.Mutex
+	tokenCache      string
+	tokenExpiration time.Time
+}
+
+// tokenScope represents the scope at which a token will be requested.
+// This represents a specific action on a registry resource.
+type tokenScope struct {
+	Resource string
+	Scope    string
+	Actions  []string
+}
+
+func (ts tokenScope) String() string {
+	return fmt.Sprintf("%s:%s:%s", ts.Resource, ts.Scope, strings.Join(ts.Actions, ","))
+}
+
+// NewTokenHandler creates a new AuthenicationHandler which supports
+// fetching tokens from a remote token server.
+func NewTokenHandler(transport http.RoundTripper, creds CredentialStore, scope string, actions ...string) AuthenticationHandler {
+	return &tokenHandler{
+		transport: transport,
+		creds:     creds,
+		scope: tokenScope{
+			Resource: "repository",
+			Scope:    scope,
+			Actions:  actions,
+		},
+	}
+}
+
+func (th *tokenHandler) client() *http.Client {
+	return &http.Client{
+		Transport: th.transport,
+		Timeout:   15 * time.Second,
+	}
+}
+
+func (th *tokenHandler) Scheme() string {
+	return "bearer"
+}
+
+func (th *tokenHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	if err := th.refreshToken(params); err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", th.tokenCache))
+
+	return nil
+}
+
+func (th *tokenHandler) refreshToken(params map[string]string) error {
+	th.tokenLock.Lock()
+	defer th.tokenLock.Unlock()
+	now := time.Now()
+	if now.After(th.tokenExpiration) {
+		token, err := th.fetchToken(params)
+		if err != nil {
+			return err
+		}
+		th.tokenCache = token
+		th.tokenExpiration = now.Add(time.Minute)
+	}
+
+	return nil
+}
+
+type tokenResponse struct {
+	Token string `json:"token"`
+}
+
+func (th *tokenHandler) fetchToken(params map[string]string) (token string, err error) {
+	//log.Debugf("Getting bearer token with %s for %s", challenge.Parameters, ta.auth.Username)
+	realm, ok := params["realm"]
+	if !ok {
+		return "", errors.New("no realm specified for token auth challenge")
+	}
+
+	// TODO(dmcgowan): Handle empty scheme
+
+	realmURL, err := url.Parse(realm)
+	if err != nil {
+		return "", fmt.Errorf("invalid token auth challenge realm: %s", err)
+	}
+
+	req, err := http.NewRequest("GET", realmURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	reqParams := req.URL.Query()
+	service := params["service"]
+	scope := th.scope.String()
+
+	if service != "" {
+		reqParams.Add("service", service)
+	}
+
+	for _, scopeField := range strings.Fields(scope) {
+		reqParams.Add("scope", scopeField)
+	}
+
+	if th.creds != nil {
+		username, password := th.creds.Basic(realmURL)
+		if username != "" && password != "" {
+			reqParams.Add("account", username)
+			req.SetBasicAuth(username, password)
+		}
+	}
+
+	req.URL.RawQuery = reqParams.Encode()
+
+	resp, err := th.client().Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token auth attempt for registry: %s request failed with status: %d %s", req.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	tr := new(tokenResponse)
+	if err = decoder.Decode(tr); err != nil {
+		return "", fmt.Errorf("unable to decode token response: %s", err)
+	}
+
+	if tr.Token == "" {
+		return "", errors.New("authorization server did not include a token in the response")
+	}
+
+	return tr.Token, nil
+}
+
+type basicHandler struct {
+	creds CredentialStore
+}
+
+// NewBasicHandler creaters a new authentiation handler which adds
+// basic authentication credentials to a request.
+func NewBasicHandler(creds CredentialStore) AuthenticationHandler {
+	return &basicHandler{
+		creds: creds,
+	}
+}
+
+func (*basicHandler) Scheme() string {
+	return "basic"
+}
+
+func (bh *basicHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	if bh.creds != nil {
+		username, password := bh.creds.Basic(req.URL)
+		if username != "" && password != "" {
+			req.SetBasicAuth(username, password)
+			return nil
+		}
+	}
+	return errors.New("no basic auth credentials")
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/session_test.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/client/auth/session_test.go
@@ -1,0 +1,311 @@
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/distribution/testutil"
+)
+
+func testServer(rrm testutil.RequestResponseMap) (string, func()) {
+	h := testutil.NewHandler(rrm)
+	s := httptest.NewServer(h)
+	return s.URL, s.Close
+}
+
+type testAuthenticationWrapper struct {
+	headers   http.Header
+	authCheck func(string) bool
+	next      http.Handler
+}
+
+func (w *testAuthenticationWrapper) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" || !w.authCheck(auth) {
+		h := rw.Header()
+		for k, values := range w.headers {
+			h[k] = values
+		}
+		rw.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	w.next.ServeHTTP(rw, r)
+}
+
+func testServerWithAuth(rrm testutil.RequestResponseMap, authenticate string, authCheck func(string) bool) (string, func()) {
+	h := testutil.NewHandler(rrm)
+	wrapper := &testAuthenticationWrapper{
+
+		headers: http.Header(map[string][]string{
+			"X-API-Version":       {"registry/2.0"},
+			"X-Multi-API-Version": {"registry/2.0", "registry/2.1", "trust/1.0"},
+			"WWW-Authenticate":    {authenticate},
+		}),
+		authCheck: authCheck,
+		next:      h,
+	}
+
+	s := httptest.NewServer(wrapper)
+	return s.URL, s.Close
+}
+
+// ping pings the provided endpoint to determine its required authorization challenges.
+// If a version header is provided, the versions will be returned.
+func ping(manager ChallengeManager, endpoint, versionHeader string) ([]APIVersion, error) {
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := manager.AddResponse(resp); err != nil {
+		return nil, err
+	}
+
+	return APIVersions(resp, versionHeader), err
+}
+
+type testCredentialStore struct {
+	username string
+	password string
+}
+
+func (tcs *testCredentialStore) Basic(*url.URL) (string, string) {
+	return tcs.username, tcs.password
+}
+
+func TestEndpointAuthorizeToken(t *testing.T) {
+	service := "localhost.localdomain"
+	repo1 := "some/registry"
+	repo2 := "other/registry"
+	scope1 := fmt.Sprintf("repository:%s:pull,push", repo1)
+	scope2 := fmt.Sprintf("repository:%s:pull,push", repo2)
+	tokenMap := testutil.RequestResponseMap([]testutil.RequestResponseMapping{
+		{
+			Request: testutil.Request{
+				Method: "GET",
+				Route:  fmt.Sprintf("/token?scope=%s&service=%s", url.QueryEscape(scope1), service),
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusOK,
+				Body:       []byte(`{"token":"statictoken"}`),
+			},
+		},
+		{
+			Request: testutil.Request{
+				Method: "GET",
+				Route:  fmt.Sprintf("/token?scope=%s&service=%s", url.QueryEscape(scope2), service),
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusOK,
+				Body:       []byte(`{"token":"badtoken"}`),
+			},
+		},
+	})
+	te, tc := testServer(tokenMap)
+	defer tc()
+
+	m := testutil.RequestResponseMap([]testutil.RequestResponseMapping{
+		{
+			Request: testutil.Request{
+				Method: "GET",
+				Route:  "/v2/hello",
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusAccepted,
+			},
+		},
+	})
+
+	authenicate := fmt.Sprintf("Bearer realm=%q,service=%q", te+"/token", service)
+	validCheck := func(a string) bool {
+		return a == "Bearer statictoken"
+	}
+	e, c := testServerWithAuth(m, authenicate, validCheck)
+	defer c()
+
+	challengeManager1 := NewSimpleChallengeManager()
+	versions, err := ping(challengeManager1, e+"/v2/", "x-api-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("Unexpected version count: %d, expected 1", len(versions))
+	}
+	if check := (APIVersion{Type: "registry", Version: "2.0"}); versions[0] != check {
+		t.Fatalf("Unexpected api version: %#v, expected %#v", versions[0], check)
+	}
+	transport1 := transport.NewTransport(nil, NewAuthorizer(challengeManager1, NewTokenHandler(nil, nil, repo1, "pull", "push")))
+	client := &http.Client{Transport: transport1}
+
+	req, _ := http.NewRequest("GET", e+"/v2/hello", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Error sending get request: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("Unexpected status code: %d, expected %d", resp.StatusCode, http.StatusAccepted)
+	}
+
+	badCheck := func(a string) bool {
+		return a == "Bearer statictoken"
+	}
+	e2, c2 := testServerWithAuth(m, authenicate, badCheck)
+	defer c2()
+
+	challengeManager2 := NewSimpleChallengeManager()
+	versions, err = ping(challengeManager2, e+"/v2/", "x-multi-api-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(versions) != 3 {
+		t.Fatalf("Unexpected version count: %d, expected 3", len(versions))
+	}
+	if check := (APIVersion{Type: "registry", Version: "2.0"}); versions[0] != check {
+		t.Fatalf("Unexpected api version: %#v, expected %#v", versions[0], check)
+	}
+	if check := (APIVersion{Type: "registry", Version: "2.1"}); versions[1] != check {
+		t.Fatalf("Unexpected api version: %#v, expected %#v", versions[1], check)
+	}
+	if check := (APIVersion{Type: "trust", Version: "1.0"}); versions[2] != check {
+		t.Fatalf("Unexpected api version: %#v, expected %#v", versions[2], check)
+	}
+	transport2 := transport.NewTransport(nil, NewAuthorizer(challengeManager2, NewTokenHandler(nil, nil, repo2, "pull", "push")))
+	client2 := &http.Client{Transport: transport2}
+
+	req, _ = http.NewRequest("GET", e2+"/v2/hello", nil)
+	resp, err = client2.Do(req)
+	if err != nil {
+		t.Fatalf("Error sending get request: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("Unexpected status code: %d, expected %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func TestEndpointAuthorizeTokenBasic(t *testing.T) {
+	service := "localhost.localdomain"
+	repo := "some/fun/registry"
+	scope := fmt.Sprintf("repository:%s:pull,push", repo)
+	username := "tokenuser"
+	password := "superSecretPa$$word"
+
+	tokenMap := testutil.RequestResponseMap([]testutil.RequestResponseMapping{
+		{
+			Request: testutil.Request{
+				Method: "GET",
+				Route:  fmt.Sprintf("/token?account=%s&scope=%s&service=%s", username, url.QueryEscape(scope), service),
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusOK,
+				Body:       []byte(`{"token":"statictoken"}`),
+			},
+		},
+	})
+
+	authenicate1 := fmt.Sprintf("Basic realm=localhost")
+	basicCheck := func(a string) bool {
+		return a == fmt.Sprintf("Basic %s", basicAuth(username, password))
+	}
+	te, tc := testServerWithAuth(tokenMap, authenicate1, basicCheck)
+	defer tc()
+
+	m := testutil.RequestResponseMap([]testutil.RequestResponseMapping{
+		{
+			Request: testutil.Request{
+				Method: "GET",
+				Route:  "/v2/hello",
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusAccepted,
+			},
+		},
+	})
+
+	authenicate2 := fmt.Sprintf("Bearer realm=%q,service=%q", te+"/token", service)
+	bearerCheck := func(a string) bool {
+		return a == "Bearer statictoken"
+	}
+	e, c := testServerWithAuth(m, authenicate2, bearerCheck)
+	defer c()
+
+	creds := &testCredentialStore{
+		username: username,
+		password: password,
+	}
+
+	challengeManager := NewSimpleChallengeManager()
+	_, err := ping(challengeManager, e+"/v2/", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport1 := transport.NewTransport(nil, NewAuthorizer(challengeManager, NewTokenHandler(nil, creds, repo, "pull", "push"), NewBasicHandler(creds)))
+	client := &http.Client{Transport: transport1}
+
+	req, _ := http.NewRequest("GET", e+"/v2/hello", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Error sending get request: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("Unexpected status code: %d, expected %d", resp.StatusCode, http.StatusAccepted)
+	}
+}
+
+func TestEndpointAuthorizeBasic(t *testing.T) {
+	m := testutil.RequestResponseMap([]testutil.RequestResponseMapping{
+		{
+			Request: testutil.Request{
+				Method: "GET",
+				Route:  "/v2/hello",
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusAccepted,
+			},
+		},
+	})
+
+	username := "user1"
+	password := "funSecretPa$$word"
+	authenicate := fmt.Sprintf("Basic realm=localhost")
+	validCheck := func(a string) bool {
+		return a == fmt.Sprintf("Basic %s", basicAuth(username, password))
+	}
+	e, c := testServerWithAuth(m, authenicate, validCheck)
+	defer c()
+	creds := &testCredentialStore{
+		username: username,
+		password: password,
+	}
+
+	challengeManager := NewSimpleChallengeManager()
+	_, err := ping(challengeManager, e+"/v2/", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport1 := transport.NewTransport(nil, NewAuthorizer(challengeManager, NewBasicHandler(creds)))
+	client := &http.Client{Transport: transport1}
+
+	req, _ := http.NewRequest("GET", e+"/v2/hello", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Error sending get request: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("Unexpected status code: %d, expected %d", resp.StatusCode, http.StatusAccepted)
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/client/transport/http_reader.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/client/transport/http_reader.go
@@ -1,0 +1,172 @@
+package transport
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+// ReadSeekCloser combines io.ReadSeeker with io.Closer.
+type ReadSeekCloser interface {
+	io.ReadSeeker
+	io.Closer
+}
+
+// NewHTTPReadSeeker handles reading from an HTTP endpoint using a GET
+// request. When seeking and starting a read from a non-zero offset
+// the a "Range" header will be added which sets the offset.
+// TODO(dmcgowan): Move this into a separate utility package
+func NewHTTPReadSeeker(client *http.Client, url string, size int64) ReadSeekCloser {
+	return &httpReadSeeker{
+		client: client,
+		url:    url,
+		size:   size,
+	}
+}
+
+type httpReadSeeker struct {
+	client *http.Client
+	url    string
+
+	size int64
+
+	rc     io.ReadCloser // remote read closer
+	brd    *bufio.Reader // internal buffered io
+	offset int64
+	err    error
+}
+
+func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
+	if hrs.err != nil {
+		return 0, hrs.err
+	}
+
+	rd, err := hrs.reader()
+	if err != nil {
+		return 0, err
+	}
+
+	n, err = rd.Read(p)
+	hrs.offset += int64(n)
+
+	// Simulate io.EOF error if we reach filesize.
+	if err == nil && hrs.offset >= hrs.size {
+		err = io.EOF
+	}
+
+	return n, err
+}
+
+func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	if hrs.err != nil {
+		return 0, hrs.err
+	}
+
+	var err error
+	newOffset := hrs.offset
+
+	switch whence {
+	case os.SEEK_CUR:
+		newOffset += int64(offset)
+	case os.SEEK_END:
+		newOffset = hrs.size + int64(offset)
+	case os.SEEK_SET:
+		newOffset = int64(offset)
+	}
+
+	if newOffset < 0 {
+		err = errors.New("cannot seek to negative position")
+	} else {
+		if hrs.offset != newOffset {
+			hrs.reset()
+		}
+
+		// No problems, set the offset.
+		hrs.offset = newOffset
+	}
+
+	return hrs.offset, err
+}
+
+func (hrs *httpReadSeeker) Close() error {
+	if hrs.err != nil {
+		return hrs.err
+	}
+
+	// close and release reader chain
+	if hrs.rc != nil {
+		hrs.rc.Close()
+	}
+
+	hrs.rc = nil
+	hrs.brd = nil
+
+	hrs.err = errors.New("httpLayer: closed")
+
+	return nil
+}
+
+func (hrs *httpReadSeeker) reset() {
+	if hrs.err != nil {
+		return
+	}
+	if hrs.rc != nil {
+		hrs.rc.Close()
+		hrs.rc = nil
+	}
+}
+
+func (hrs *httpReadSeeker) reader() (io.Reader, error) {
+	if hrs.err != nil {
+		return nil, hrs.err
+	}
+
+	if hrs.rc != nil {
+		return hrs.brd, nil
+	}
+
+	// If the offset is great than or equal to size, return a empty, noop reader.
+	if hrs.offset >= hrs.size {
+		return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
+	}
+
+	req, err := http.NewRequest("GET", hrs.url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if hrs.offset > 0 {
+		// TODO(stevvooe): Get this working correctly.
+
+		// If we are at different offset, issue a range request from there.
+		req.Header.Add("Range", "1-")
+		// TODO: get context in here
+		// context.GetLogger(hrs.context).Infof("Range: %s", req.Header.Get("Range"))
+	}
+
+	resp, err := hrs.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case resp.StatusCode == 200:
+		hrs.rc = resp.Body
+	default:
+		defer resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status resolving reader: %v", resp.Status)
+	}
+
+	if hrs.brd == nil {
+		hrs.brd = bufio.NewReader(hrs.rc)
+	} else {
+		hrs.brd.Reset(hrs.rc)
+	}
+
+	return hrs.brd, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/client/transport/transport.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/client/transport/transport.go
@@ -1,0 +1,147 @@
+package transport
+
+import (
+	"io"
+	"net/http"
+	"sync"
+)
+
+// RequestModifier represents an object which will do an inplace
+// modification of an HTTP request.
+type RequestModifier interface {
+	ModifyRequest(*http.Request) error
+}
+
+type headerModifier http.Header
+
+// NewHeaderRequestModifier returns a new RequestModifier which will
+// add the given headers to a request.
+func NewHeaderRequestModifier(header http.Header) RequestModifier {
+	return headerModifier(header)
+}
+
+func (h headerModifier) ModifyRequest(req *http.Request) error {
+	for k, s := range http.Header(h) {
+		req.Header[k] = append(req.Header[k], s...)
+	}
+
+	return nil
+}
+
+// NewTransport creates a new transport which will apply modifiers to
+// the request on a RoundTrip call.
+func NewTransport(base http.RoundTripper, modifiers ...RequestModifier) http.RoundTripper {
+	return &transport{
+		Modifiers: modifiers,
+		Base:      base,
+	}
+}
+
+// transport is an http.RoundTripper that makes HTTP requests after
+// copying and modifying the request
+type transport struct {
+	Modifiers []RequestModifier
+	Base      http.RoundTripper
+
+	mu     sync.Mutex                      // guards modReq
+	modReq map[*http.Request]*http.Request // original -> modified
+}
+
+// RoundTrip authorizes and authenticates the request with an
+// access token. If no token exists or token is expired,
+// tries to refresh/fetch a new token.
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := cloneRequest(req)
+	for _, modifier := range t.Modifiers {
+		if err := modifier.ModifyRequest(req2); err != nil {
+			return nil, err
+		}
+	}
+
+	t.setModReq(req, req2)
+	res, err := t.base().RoundTrip(req2)
+	if err != nil {
+		t.setModReq(req, nil)
+		return nil, err
+	}
+	res.Body = &onEOFReader{
+		rc: res.Body,
+		fn: func() { t.setModReq(req, nil) },
+	}
+	return res, nil
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base().(canceler); ok {
+		t.mu.Lock()
+		modReq := t.modReq[req]
+		delete(t.modReq, req)
+		t.mu.Unlock()
+		cr.CancelRequest(modReq)
+	}
+}
+
+func (t *transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+func (t *transport) setModReq(orig, mod *http.Request) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.modReq == nil {
+		t.modReq = make(map[*http.Request]*http.Request)
+	}
+	if mod == nil {
+		delete(t.modReq, orig)
+	} else {
+		t.modReq[orig] = mod
+	}
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+
+	return r2
+}
+
+type onEOFReader struct {
+	rc io.ReadCloser
+	fn func()
+}
+
+func (r *onEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+func (r *onEOFReader) Close() error {
+	err := r.rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *onEOFReader) runFunc() {
+	if fn := r.fn; fn != nil {
+		fn()
+		r.fn = nil
+	}
+}


### PR DESCRIPTION
Supersedes https://github.com/docker/notary/pull/162

Adds token auth capabilities to notary cli. For any interactions that require a user to be authenticated (private repos, pushes, etc...) the user will always be asked for username and password (@thaJeztah, no caching of credentials :-).

~~Authentication is enabled with the `--auth` or short form `-a` flags. Valid values are "token" to enable docker style token authentication, or "" to disable authentication. We plan to support HTTP basic auth at some point in the future but it is not an immediate requirement.~~ As @dmcgowan points out below, auth is required or not by the server and there's not point in having a CLI flag, it just confuses things. It has been removed.