### PR TITLE
Add ChangeIterator interface for Changelists

### DIFF
--- a/client/changelist/changelist.go
+++ b/client/changelist/changelist.go
@@ -32,3 +32,28 @@ func (cl *memChangelist) Clear(archive string) error {
 func (cl *memChangelist) Close() error {
 	return nil
 }
+
+func (cl *memChangelist) NewIterator() (ChangeIterator, error) {
+	return &MemChangeListIterator{index: 0, collection: cl.changes}, nil
+}
+
+// MemChangeListIterator is a concrete instance of ChangeIterator
+type MemChangeListIterator struct {
+	index      int
+	collection []Change // Same type as memChangeList.changes
+}
+
+// Next returns the next Change
+func (m *MemChangeListIterator) Next() (item Change, err error) {
+	if m.index >= len(m.collection) {
+		return nil, IteratorBoundsError(m.index)
+	}
+	item = m.collection[m.index]
+	m.index++
+	return item, err
+}
+
+// HasNext indicates whether the iterator is exhausted
+func (m *MemChangeListIterator) HasNext() bool {
+	return m.index < len(m.collection)
+}

--- a/client/changelist/file_changelist_test.go
+++ b/client/changelist/file_changelist_test.go
@@ -3,6 +3,7 @@ package changelist
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,8 +11,6 @@ import (
 
 func TestAdd(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("/tmp", "test")
-	defer os.RemoveAll(tmpDir)
-
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -41,12 +40,31 @@ func TestAdd(t *testing.T) {
 
 	err = os.Remove(tmpDir) // will error if anything left in dir
 	assert.Nil(t, err, "Clear should have left the tmpDir empty")
+
+}
+func TestErrorConditions(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("/tmp", "test")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cl, err := NewFileChangelist(tmpDir)
+	// Attempt to unmarshall a bad JSON file. Note: causes a WARN on the console.
+	ioutil.WriteFile(path.Join(tmpDir, "broken_file.change"), []byte{5}, 0644)
+	noItems := cl.List()
+	assert.Len(t, noItems, 0, "List returns zero items on bad JSON file error")
+
+	os.RemoveAll(tmpDir)
+	err = cl.Clear("")
+	assert.Error(t, err, "Clear on missing change list should return err")
+
+	noItems = cl.List()
+	assert.Len(t, noItems, 0, "List returns zero items on directory read error")
 }
 
 func TestListOrder(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("/tmp", "test")
-	defer os.RemoveAll(tmpDir)
-
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -77,4 +95,75 @@ func TestListOrder(t *testing.T) {
 	assert.Equal(t, c2.Type(), cs[1].Type(), "Type 2 mismatch")
 	assert.Equal(t, c2.Path(), cs[1].Path(), "Path 2 mismatch")
 	assert.Equal(t, c2.Content(), cs[1].Content(), "Content 2 mismatch")
+}
+
+func TestFileChangeIterator(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("/tmp", "test")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cl, err := NewFileChangelist(tmpDir)
+	assert.Nil(t, err, "Error initializing fileChangelist")
+
+	it, err := cl.NewIterator()
+	assert.Nil(t, err, "Error initializing iterator")
+	assert.False(t, it.HasNext(), "HasNext returns false for empty ChangeList")
+
+	c1 := NewTufChange(ActionCreate, "t1", "target1", "test/targ1", []byte{1})
+	cl.Add(c1)
+
+	c2 := NewTufChange(ActionUpdate, "t2", "target2", "test/targ2", []byte{2})
+	cl.Add(c2)
+
+	c3 := NewTufChange(ActionUpdate, "t3", "target3", "test/targ3", []byte{3})
+	cl.Add(c3)
+
+	cs := cl.List()
+	index := 0
+	it, err = cl.NewIterator()
+	assert.Nil(t, err, "Error initializing iterator")
+	for it.HasNext() {
+		c, err := it.Next()
+		assert.Nil(t, err, "Next err should be false")
+		assert.Equal(t, c.Action(), cs[index].Action(), "Action mismatch")
+		assert.Equal(t, c.Scope(), cs[index].Scope(), "Scope mismatch")
+		assert.Equal(t, c.Type(), cs[index].Type(), "Type mismatch")
+		assert.Equal(t, c.Path(), cs[index].Path(), "Path mismatch")
+		assert.Equal(t, c.Content(), cs[index].Content(), "Content mismatch")
+		index++
+	}
+	assert.Equal(t, index, len(cs), "Iterator produced all data in ChangeList")
+
+	// negative test case: index out of range
+	_, err = it.Next()
+	assert.Error(t, err, "Next errors gracefully when exhausted")
+	var iterError IteratorBoundsError
+	assert.IsType(t, iterError, err, "IteratorBoundsError type")
+	assert.Regexp(t, "out of bounds", err, "Message for iterator bounds error")
+
+	// negative test case: changelist files missing
+	it, err = cl.NewIterator()
+	assert.Nil(t, err, "Error initializing iterator")
+	for it.HasNext() {
+		cl.Clear("")
+		_, err := it.Next()
+		assert.Error(t, err, "Next() error for missing changelist files")
+	}
+
+	// negative test case: bad JSON file to unmarshall via Next()
+	cl.Clear("")
+	ioutil.WriteFile(path.Join(tmpDir, "broken_file.change"), []byte{5}, 0644)
+	it, err = cl.NewIterator()
+	assert.Nil(t, err, "Error initializing iterator")
+	for it.HasNext() {
+		_, err := it.Next()
+		assert.Error(t, err, "Next should indicate error for bad JSON file")
+	}
+
+	// negative test case: changelist directory does not exist
+	os.RemoveAll(tmpDir)
+	it, err = cl.NewIterator()
+	assert.Error(t, err, "Initializing iterator without underlying file store")
 }

--- a/client/changelist/interface.go
+++ b/client/changelist/interface.go
@@ -18,6 +18,10 @@ type Changelist interface {
 	// Close syncronizes any pending writes to the underlying
 	// storage and closes the file/connection
 	Close() error
+
+	// NewIterator returns an iterator for walking through the list
+	// of changes currently stored
+	NewIterator() (ChangeIterator, error)
 }
 
 const (
@@ -56,4 +60,11 @@ type Change interface {
 	// to be inserted or merged. In the case of a "delete"
 	// action, it will be nil.
 	Content() []byte
+}
+
+// ChangeIterator is the interface for iterating across collections of
+// TUF Change items
+type ChangeIterator interface {
+	Next() (Change, error)
+	HasNext() bool
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -26,9 +26,16 @@ func getRemoteStore(baseURL, gun string, rt http.RoundTripper) (store.RemoteStor
 }
 
 func applyChangelist(repo *tuf.TufRepo, cl changelist.Changelist) error {
-	changes := cl.List()
-	logrus.Debugf("applying %d changes", len(changes))
-	for _, c := range changes {
+	it, err := cl.NewIterator()
+	if err != nil {
+		return err
+	}
+	index := 0
+	for it.HasNext() {
+		c, err := it.Next()
+		if err != nil {
+			return err
+		}
 		switch c.Scope() {
 		case changelist.ScopeTargets:
 			err := applyTargetsChange(repo, c)
@@ -38,7 +45,9 @@ func applyChangelist(repo *tuf.TufRepo, cl changelist.Changelist) error {
 		default:
 			logrus.Debug("scope not supported: ", c.Scope())
 		}
+		index++
 	}
+	logrus.Debugf("applied %d change(s)", index)
 	return nil
 }
 


### PR DESCRIPTION
    + Ref https://github.com/docker/notary/issues/144
    + Create ChangeIterator interface
    + Implement ChangeIterator interface for memChangeList
    + Implement ChangeIterator interface for fileChangeList
    + Add iterator test case to changelist_test
    + Add iterator test case to file_changelist_test
    + Change func applyChangelist to use iterator per PR comment
    + Remove redundant defer statement in file_changelist_test.go (PR comment)
    + Change Next error check to simple array bounds check (PR comment)
    + Add negative unit test cases to increase code coverage