### PR TITLE
Mention where the notary binary is

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ docker-compose build
 docker-compose up -d
 ```
 
+The `notary` binary can be found in `./bin/notary`.
+
 First, lets initiate a notary collection called `example.com/scripts`
 
 ```sh


### PR DESCRIPTION
Normally go users expect binaries to be put in $GOPATH/bin, so it's worth mentioning where the binaries are output to.