### PR TITLE
Add support for 'notary status' command 

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -564,6 +564,30 @@ func testPublish(t *testing.T, rootType data.KeyAlgorithm) {
 
 	changelistDir.Close()
 
+	// Test loading changelist
+	changes := make(map[string]changelist.Change)
+	cl, err := repo.GetChangelist()
+	assert.NoError(t, err, "could not get changelist for repo")
+
+	assert.Len(t, cl.List(), 2, "Wrong number of changes returned from changelist")
+	for _, ch := range cl.List() {
+		changes[ch.Path()] = ch
+	}
+
+	currentChange := changes["current"]
+	assert.NotNil(t, currentChange, "Expected changelist to contain a change for path 'current'")
+	assert.EqualValues(t, changelist.ActionCreate, currentChange.Action())
+	assert.Equal(t, "targets", currentChange.Scope())
+	assert.Equal(t, "target", currentChange.Type())
+	assert.Equal(t, "current", currentChange.Path())
+
+	latestChange := changes["latest"]
+	assert.NotNil(t, latestChange, "Expected changelist to contain a change for path 'latest'")
+	assert.EqualValues(t, changelist.ActionCreate, latestChange.Action())
+	assert.Equal(t, "targets", latestChange.Scope())
+	assert.Equal(t, "target", latestChange.Type())
+	assert.Equal(t, "latest", latestChange.Path())
+
 	// Now test Publish
 	err = repo.Publish()
 	assert.NoError(t, err)

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -103,6 +103,7 @@ func main() {
 	cmdTufList.Flags().StringVarP(&remoteTrustServer, "server", "s", serverURL, "Remote trust server location")
 	notaryCmd.AddCommand(cmdTufAdd)
 	notaryCmd.AddCommand(cmdTufRemove)
+	notaryCmd.AddCommand(cmdTufStatus)
 	notaryCmd.AddCommand(cmdTufPublish)
 	cmdTufPublish.Flags().StringVarP(&remoteTrustServer, "server", "s", serverURL, "Remote trust server location")
 	notaryCmd.AddCommand(cmdTufLookup)


### PR DESCRIPTION
The status command will display output in the form:

```
$ notary status com/testing
Unpublished changes for com/testing:

action    scope     type        path
----------------------------------------------------
create    targets   target      README.md

$ notary status com/testing2
No unpublished changes for com/testing2
```


Signed-off-by: Ryan Cox <ryan.a.cox@gmail.com>