### PR TITLE
Convert the server DB tests to use GORM with SQLite3 instead of sqlmock

### DIFF
--- a/notarymysql/migrate.sql
+++ b/notarymysql/migrate.sql
@@ -1,18 +1,16 @@
 -- This migrates initial.sql to tables that are needed for GORM
 
 ALTER TABLE `tuf_files`
-ADD COLUMN `created_at` timestamp NULL AFTER `id`,
-ADD COLUMN `updated_at` timestamp NULL AFTER `created_at`,
-ADD COLUMN `deleted_at` timestamp NULL AFTER `updated_at`,
+ADD COLUMN `created_at` timestamp NULL DEFAULT NULL AFTER `id`,
+ADD COLUMN `updated_at` timestamp NULL DEFAULT NULL AFTER `created_at`,
+ADD COLUMN `deleted_at` timestamp NULL DEFAULT NULL AFTER `updated_at`,
 MODIFY `id` int(10) unsigned AUTO_INCREMENT;
 
 ALTER TABLE `timestamp_keys`
 ADD COLUMN `id` int(10) unsigned AUTO_INCREMENT FIRST,
-ADD COLUMN `created_at` timestamp NULL AFTER `id`,
-ADD COLUMN `updated_at` timestamp NULL AFTER `created_at`,
-ADD COLUMN `deleted_at` timestamp NULL AFTER `updated_at`,
+ADD COLUMN `created_at` timestamp NULL DEFAULT NULL AFTER `id`,
+ADD COLUMN `updated_at` timestamp NULL DEFAULT NULL AFTER `created_at`,
+ADD COLUMN `deleted_at` timestamp NULL DEFAULT NULL AFTER `updated_at`,
 DROP PRIMARY KEY,
 ADD PRIMARY KEY (`id`),
 ADD UNIQUE (`gun`);
-
-

--- a/notarymysql/migrate.sql
+++ b/notarymysql/migrate.sql
@@ -1,0 +1,18 @@
+-- This migrates initial.sql to tables that are needed for GORM
+
+ALTER TABLE `tuf_files`
+ADD COLUMN `created_at` timestamp NULL AFTER `id`,
+ADD COLUMN `updated_at` timestamp NULL AFTER `created_at`,
+ADD COLUMN `deleted_at` timestamp NULL AFTER `updated_at`,
+MODIFY `id` int(10) unsigned AUTO_INCREMENT;
+
+ALTER TABLE `timestamp_keys`
+ADD COLUMN `id` int(10) unsigned AUTO_INCREMENT FIRST,
+ADD COLUMN `created_at` timestamp NULL AFTER `id`,
+ADD COLUMN `updated_at` timestamp NULL AFTER `created_at`,
+ADD COLUMN `deleted_at` timestamp NULL AFTER `updated_at`,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (`id`),
+ADD UNIQUE (`gun`);
+
+

--- a/server/storage/database_test.go
+++ b/server/storage/database_test.go
@@ -260,10 +260,6 @@ func TestMySQLGetCurrent(t *testing.T) {
 func TestMySQLDelete(t *testing.T) {
 	gormDB, dbStore := SetUpSQLite(t)
 
-	// Not testing deleting from an empty table, because that's not an error
-	// in SQLite3
-
-	// use UpdateCurrent to create one and test GetCurrent
 	tuf := SampleTUF(0)
 	query := gormDB.Create(&tuf)
 	assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")

--- a/server/storage/database_test.go
+++ b/server/storage/database_test.go
@@ -38,6 +38,25 @@ func (g GormTimestampKey) TableName() string {
 	return "timestamp_keys"
 }
 
+// SampleTUF returns a sample GormTUFFile with the given Version (ID will have
+// to be set independently)
+func SampleTUF(version int) GormTUFFile {
+	return GormTUFFile{
+		Gun:     "testGUN",
+		Role:    "root",
+		Version: version,
+		Data:    []byte("1"),
+	}
+}
+
+func SampleUpdate(version int) MetaUpdate {
+	return MetaUpdate{
+		Role:    "root",
+		Version: version,
+		Data:    []byte("1"),
+	}
+}
+
 // SetUpSQLite creates a sqlite database for testing
 func SetUpSQLite(t *testing.T) (*gorm.DB, *MySQLStorage) {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
@@ -68,79 +87,83 @@ func SetUpSQLite(t *testing.T) (*gorm.DB, *MySQLStorage) {
 	return &gormDB, NewMySQLStorage(db)
 }
 
-func TestMySQLUpdateCurrent(t *testing.T) {
+// TestMySQLUpdateCurrent asserts that UpdateCurrent will add a new TUF file
+// if no previous version existed.
+func TestMySQLUpdateCurrentNew(t *testing.T) {
 	gormDB, dbStore := SetUpSQLite(t)
 
-    // UpdateCurrent should succeed
-	update := MetaUpdate{
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	}
+	// Adding a new TUF file should succeed
+	err := dbStore.UpdateCurrent("testGUN", SampleUpdate(0))
+	assert.NoError(t, err, "Creating a row in an empty DB failed.")
+
+	// There should just be one row
+	var rows []GormTUFFile
+	query := gormDB.Model(&GormTUFFile{}).Find(&rows)
+	assert.NoError(t, query.Error)
+
+	expected := SampleTUF(0)
+	expected.ID = 1
+	assert.Equal(t, []GormTUFFile{expected}, rows)
+}
+
+// TestMySQLUpdateCurrentNewVersion asserts that UpdateCurrent will add a
+// new (higher) version of an existing TUF file
+func TestMySQLUpdateCurrentNewVersion(t *testing.T) {
+	gormDB, dbStore := SetUpSQLite(t)
+
+	// insert row
+	oldVersion := SampleTUF(0)
+	query := gormDB.Create(&oldVersion)
+	assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
+
+	// UpdateCurrent with a newer version should succeed
+	update := SampleUpdate(2)
 	err := dbStore.UpdateCurrent("testGUN", update)
 	assert.NoError(t, err, "Creating a row in an empty DB failed.")
 
-    // There should just be one row
-    var rows []GormTUFFile
-    query := gormDB.Model(&GormTUFFile{}).Find(&rows)
-    assert.NoError(t, query.Error)
-    assert.Equal(
-        t,
-        []GormTUFFile{
-            GormTUFFile{ID: 1, Gun: "testGUN", Role: "root", Version: 0,
-                Data: []byte("1")},
-        },
-        rows)
+	// There should just be one row
+	var rows []GormTUFFile
+	query = gormDB.Model(&GormTUFFile{}).Find(&rows)
+	assert.NoError(t, query.Error)
 
-	dbStore.DB.Close()
+	oldVersion.ID = 1
+	expected := SampleTUF(2)
+	expected.ID = 2
+	assert.Equal(t, []GormTUFFile{oldVersion, expected}, rows)
 }
 
-func TestMySQLUpdateCurrentError(t *testing.T) {
-    gormDB, dbStore := SetUpSQLite(t)
+// TestMySQLUpdateCurrentOldVersionError asserts that an error is raised if
+// trying to update to an older version of a TUF file.
+func TestMySQLUpdateCurrentOldVersionError(t *testing.T) {
+	gormDB, dbStore := SetUpSQLite(t)
 
-    // insert row
-    query := gormDB.Create(&GormTUFFile{
-        Gun:     "testGUN",
-        Role:    "root",
-        Version: 0,
-        Data:    []byte("1"),
-    })
-    assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
+	// insert row
+	newVersion := SampleTUF(3)
+	query := gormDB.Create(&newVersion)
+	assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
 
-    // UpdateCurrent should fail due to clash with prevoius row
-    update := MetaUpdate{
-        Role:    "root",
-        Version: 0,
-        Data:    []byte("1"),
-    }
-    err := dbStore.UpdateCurrent("testGUN", update)
-    assert.Error(t, err, "Error should not be nil")
-    assert.IsType(t, &ErrOldVersion{}, err,
-        "Expected ErrOldVersion error type, got: %v", err)
+	// UpdateCurrent should fail due to the version being lower than the
+	// previous row
+	err := dbStore.UpdateCurrent("testGUN", SampleUpdate(0))
+	assert.Error(t, err, "Error should not be nil")
+	assert.IsType(t, &ErrOldVersion{}, err,
+		"Expected ErrOldVersion error type, got: %v", err)
 
-    // There should just be one row
-    var rows []GormTUFFile
-    query = gormDB.Model(&GormTUFFile{}).Find(&rows)
-    assert.NoError(t, query.Error)
-    assert.Equal(
-        t,
-        []GormTUFFile{
-            GormTUFFile{ID: 1, Gun: "testGUN", Role: "root", Version: 0,
-                Data: []byte("1")},
-        },
-        rows)
+	// There should just be one row
+	var rows []GormTUFFile
+	query = gormDB.Model(&GormTUFFile{}).Find(&rows)
+	assert.NoError(t, query.Error)
 
-    dbStore.DB.Close()
+	newVersion.ID = 1
+	assert.Equal(t, []GormTUFFile{newVersion}, rows)
+
+	dbStore.DB.Close()
 }
 
 func TestMySQLUpdateMany(t *testing.T) {
 	gormDB, dbStore := SetUpSQLite(t)
 
-	update1 := MetaUpdate{
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	}
+	update1 := SampleUpdate(0)
 	update2 := MetaUpdate{
 		Role:    "targets",
 		Version: 1,
@@ -169,12 +192,7 @@ func TestMySQLUpdateMany(t *testing.T) {
 func TestMySQLUpdateManyDuplicateRollback(t *testing.T) {
 	gormDB, dbStore := SetUpSQLite(t)
 
-	update := MetaUpdate{
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	}
-
+	update := SampleUpdate(0)
 	err := dbStore.UpdateMany("testGUN", []MetaUpdate{update, update})
 	assert.Error(t, err, "There should be an error updating twice.")
 	// sqlite3 error and mysql error aren't compatible
@@ -199,12 +217,8 @@ func TestMySQLGetCurrent(t *testing.T) {
 	assert.Error(t, err, "There should be an error Getting an empty table")
 	assert.IsType(t, &ErrNotFound{}, err, "Should get a not found error")
 
-	query := gormDB.Create(&GormTUFFile{
-		Gun:     "testGUN",
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	})
+	tuf := SampleTUF(0)
+	query := gormDB.Create(&tuf)
 	assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
 
 	byt, err = dbStore.GetCurrent("testGUN", "root")
@@ -221,12 +235,8 @@ func TestMySQLDelete(t *testing.T) {
 	// in SQLite3
 
 	// use UpdateCurrent to create one and test GetCurrent
-	query := gormDB.Create(&GormTUFFile{
-		Gun:     "testGUN",
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	})
+	tuf := SampleTUF(0)
+	query := gormDB.Create(&tuf)
 	assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
 
 	err := dbStore.Delete("testGUN")

--- a/server/storage/database_test.go
+++ b/server/storage/database_test.go
@@ -2,87 +2,85 @@ package storage
 
 import (
 	"database/sql"
+	"io/ioutil"
+	"os"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/go-sql-driver/mysql"
+    "github.com/endophage/gotuf/data"
+	"github.com/jinzhu/gorm"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMySQLUpdateCurrent(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
-	update := MetaUpdate{
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	}
-	sqlmock.ExpectQuery("SELECT count\\(\\*\\) FROM `tuf_files` WHERE `gun`=\\? AND `role`=\\? AND `version`>=\\?\\;").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-	).WillReturnRows(sqlmock.RowsFromCSVString([]string{"count(*)"}, "0"))
-	sqlmock.ExpectExec("INSERT INTO `tuf_files` \\(`gun`, `role`, `version`, `data`\\) VALUES \\(\\?,\\?,\\?,\\?\\);").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-		update.Data,
-	).WillReturnResult(sqlmock.NewResult(0, 1))
-
-	err = s.UpdateCurrent(
-		"testGUN",
-		update,
-	)
-	assert.Nil(t, err, "UpdateCurrent errored unexpectedly: %v", err)
-
-	// There's a bug in the mock lib
-	//err = db.Close()
-	//assert.Nil(t, err, "Expectation not met: %v", err)
+// GormTUFFile represents a TUF file in the database
+type GormTUFFile struct {
+	ID      int    `sql:"AUTO_INCREMENT" gorm:"primary_key"`
+	Gun     string `sql:"type:varchar(255);not null"`
+	Role    string `sql:"type:varchar(255);not null"`
+	Version int
+	Data    []byte `sql:"type:longblob"`
 }
 
-func TestMySQLUpdateCurrentError(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
+// TableName sets a specific table name for GormTUFFile
+func (g GormTUFFile) TableName() string {
+	return "tuf_files"
+}
+
+// GormTimestampKey represents a single timestamp key in the database
+type GormTimestampKey struct {
+	Gun    string `sql:"type:varchar(255)" gorm:"primary key"`
+	Cipher string `sql:"type:varchar(30)"`
+	Public []byte `sql:"type:blob;not null"`
+}
+
+// TableName sets a specific table name for our GormTimestampKey
+func (g GormTimestampKey) TableName() string {
+	return "timestamp_keys"
+}
+
+// SetUpSQLite creates a sqlite database for testing
+func SetUpSQLite(t *testing.T) (*gorm.DB, *MySQLStorage) {
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	defer os.RemoveAll(tempBaseDir)
+
+	// We are using SQLite for the tests
+	db, err := sql.Open("sqlite3", tempBaseDir+"test_db")
+	assert.NoError(t, err)
+
+	// Create the DB tables
+	gormDB, _ := gorm.Open("sqlite3", db)
+	query := gormDB.CreateTable(&GormTUFFile{})
+	assert.NoError(t, query.Error)
+	query = gormDB.Model(&GormTUFFile{}).AddUniqueIndex(
+		"idx_gun", "gun", "role", "version")
+	assert.NoError(t, query.Error)
+	query = gormDB.CreateTable(&GormTimestampKey{})
+	assert.NoError(t, query.Error)
+
+	return &gormDB, NewMySQLStorage(db)
+}
+
+func TestMySQLUpdateCurrent(t *testing.T) {
+	_, dbStore := SetUpSQLite(t)
+
 	update := MetaUpdate{
 		Role:    "root",
 		Version: 0,
 		Data:    []byte("1"),
 	}
-	sqlmock.ExpectQuery("SELECT count\\(\\*\\) FROM `tuf_files` WHERE `gun`=\\? AND `role`=\\? AND `version`>=\\?\\;").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-	).WillReturnRows(sqlmock.RowsFromCSVString([]string{"count(*)"}, "0"))
-	sqlmock.ExpectExec("INSERT INTO `tuf_files` \\(`gun`, `role`, `version`, `data`\\) VALUES \\(\\?,\\?,\\?,\\?\\);").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-		update.Data,
-	).WillReturnError(
-		&mysql.MySQLError{
-			Number:  1022,
-			Message: "Duplicate key error",
-		},
-	)
+	err := dbStore.UpdateCurrent("testGUN", update)
+	assert.NoError(t, err, "Creating a row in an empty DB failed.")
 
-	err = s.UpdateCurrent(
-		"testGUN",
-		update,
-	)
-	assert.NotNil(t, err, "Error should not be nil")
-	assert.IsType(t, &ErrOldVersion{}, err, "Expected ErrOldVersion error type, got: %v", err)
-
-	// There's a bug in the mock lib
-	//err = db.Close()
-	//assert.Nil(t, err, "Expectation not met: %v", err)
+    err = dbStore.UpdateCurrent("testGUN", update)
+	assert.Error(t, err, "Error should not be nil")
+    assert.IsType(t, &ErrOldVersion{}, err,
+                  "Expected ErrOldVersion error type, got: %v", err)
+    dbStore.DB.Close()
 }
 
 func TestMySQLUpdateMany(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
+    _, dbStore := SetUpSQLite(t)
+
 	update1 := MetaUpdate{
 		Role:    "root",
 		Version: 0,
@@ -93,199 +91,113 @@ func TestMySQLUpdateMany(t *testing.T) {
 		Version: 1,
 		Data:    []byte("2"),
 	}
-	// start transation
-	sqlmock.ExpectBegin()
 
-	sqlmock.ExpectQuery("SELECT count\\(\\*\\) FROM `tuf_files` WHERE `gun`=\\? AND `role`=\\? AND `version`>=\\?\\;").WithArgs(
-		"testGUN",
-		update1.Role,
-		update1.Version,
-	).WillReturnRows(sqlmock.RowsFromCSVString([]string{"count(*)"}, "0"))
-	sqlmock.ExpectExec("INSERT INTO `tuf_files` \\(`gun`, `role`, `version`, `data`\\) VALUES \\(\\?,\\?,\\?,\\?\\);").WithArgs(
-		"testGUN",
-		update1.Role,
-		update1.Version,
-		update1.Data,
-	).WillReturnResult(sqlmock.NewResult(0, 1))
-
-	sqlmock.ExpectQuery("SELECT count\\(\\*\\) FROM `tuf_files` WHERE `gun`=\\? AND `role`=\\? AND `version`>=\\?\\;").WithArgs(
-		"testGUN",
-		update2.Role,
-		update2.Version,
-	).WillReturnRows(sqlmock.RowsFromCSVString([]string{"count(*)"}, "0"))
-	sqlmock.ExpectExec("INSERT INTO `tuf_files` \\(`gun`, `role`, `version`, `data`\\) VALUES \\(\\?,\\?,\\?,\\?\\);").WithArgs(
-		"testGUN",
-		update2.Role,
-		update2.Version,
-		update2.Data,
-	).WillReturnResult(sqlmock.NewResult(0, 1))
-
-	// expect commit
-	sqlmock.ExpectCommit()
-
-	err = s.UpdateMany(
-		"testGUN",
-		[]MetaUpdate{update1, update2},
-	)
-	assert.Nil(t, err, "UpdateMany errored unexpectedly: %v", err)
-
-	// There's a bug in the mock lib
-	//err = db.Close()
-	//assert.Nil(t, err, "Expectation not met: %v", err)
+    err := dbStore.UpdateMany("testGUN", []MetaUpdate{update1, update2})
+    assert.NoError(t, err, "UpdateMany errored unexpectedly: %v", err)
+    dbStore.DB.Close()
 }
 
-func TestMySQLUpdateManyRollback(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
-	update := MetaUpdate{
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	}
-	execError := mysql.MySQLError{}
-	// start transation
-	sqlmock.ExpectBegin()
 
-	sqlmock.ExpectQuery("SELECT count\\(\\*\\) FROM `tuf_files` WHERE `gun`=\\? AND `role`=\\? AND `version`>=\\?\\;").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-	).WillReturnRows(sqlmock.RowsFromCSVString([]string{"count(*)"}, "0"))
-	// insert first update
-	sqlmock.ExpectExec("INSERT INTO `tuf_files` \\(`gun`, `role`, `version`, `data`\\) VALUES \\(\\?,\\?,\\?,\\?\\);").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-		update.Data,
-	).WillReturnError(&execError)
+func TestMySQLUpdateManyDuplicateRollback(t *testing.T) {
+    _, dbStore := SetUpSQLite(t)
 
-	// expect commit
-	sqlmock.ExpectRollback()
+    update := MetaUpdate{
+        Role:    "root",
+        Version: 0,
+        Data:    []byte("1"),
+    }
 
-	err = s.UpdateMany(
-		"testGUN",
-		[]MetaUpdate{update},
-	)
-	assert.IsType(t, &execError, err, "UpdateMany returned wrong error type")
+    err := dbStore.UpdateMany("testGUN", []MetaUpdate{update, update})
+    assert.Error(t, err, "There should be an error updating twice.")
+    // sqlite3 error and mysql error aren't compatible
+    // assert.IsType(t, &ErrOldVersion{}, err,
+    //               "UpdateMany returned wrong error type")
 
-	err = db.Close()
-	assert.Nil(t, err, "Expectation not met: %v", err)
+    // the whole transaction should have rolled back, so there should be
+    // no entries.
+    byt, err := dbStore.GetCurrent("testGUN", "root")
+    assert.Nil(t, byt)
+    assert.Error(t, err, "There should be an error Getting any entries")
+    assert.IsType(t, &ErrNotFound{}, err, "Should get a not found error")
+
+    dbStore.DB.Close()
 }
 
-func TestMySQLUpdateManyDuplicate(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
-	update := MetaUpdate{
-		Role:    "root",
-		Version: 0,
-		Data:    []byte("1"),
-	}
-	execError := mysql.MySQLError{Number: 1022}
-	// start transation
-	sqlmock.ExpectBegin()
-
-	sqlmock.ExpectQuery("SELECT count\\(\\*\\) FROM `tuf_files` WHERE `gun`=\\? AND `role`=\\? AND `version`>=\\?\\;").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-	).WillReturnRows(sqlmock.RowsFromCSVString([]string{"count(*)"}, "0"))
-	// insert first update
-	sqlmock.ExpectExec("INSERT INTO `tuf_files` \\(`gun`, `role`, `version`, `data`\\) VALUES \\(\\?,\\?,\\?,\\?\\);").WithArgs(
-		"testGUN",
-		update.Role,
-		update.Version,
-		update.Data,
-	).WillReturnError(&execError)
-
-	// expect commit
-	sqlmock.ExpectRollback()
-
-	err = s.UpdateMany(
-		"testGUN",
-		[]MetaUpdate{update},
-	)
-	assert.IsType(t, &ErrOldVersion{}, err, "UpdateMany returned wrong error type")
-
-	err = db.Close()
-	assert.Nil(t, err, "Expectation not met: %v", err)
-}
 
 func TestMySQLGetCurrent(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
+    _, dbStore := SetUpSQLite(t)
 
-	sqlmock.ExpectQuery(
-		"SELECT `data` FROM `tuf_files` WHERE `gun`=\\? AND `role`=\\? ORDER BY `version` DESC LIMIT 1;",
-	).WithArgs("testGUN", "root").WillReturnRows(
-		sqlmock.RowsFromCSVString(
-			[]string{"data"},
-			"1",
-		),
-	)
+    byt, err := dbStore.GetCurrent("testGUN", "root")
+    assert.Nil(t, byt)
+    assert.Error(t, err, "There should be an error Getting an empty table")
+    assert.IsType(t, &ErrNotFound{}, err, "Should get a not found error")
 
-	byt, err := s.GetCurrent("testGUN", "root")
-	assert.Nil(t, err, "Expected nil error from GetCurrent")
-	assert.Equal(t, []byte("1"), byt, "Returned data was no correct")
+    // use UpdateCurrent to create one and test GetCurrent
+    update := MetaUpdate{
+        Role:    "root",
+        Version: 0,
+        Data:    []byte("1"),
+    }
+    err = dbStore.UpdateCurrent("testGUN", update)
+    assert.NoError(t, err, "Creating a row in an empty DB failed.")
 
-	// TODO(endophage): these two lines are breaking because there
-	//                  seems to be some problem with go-sqlmock
-	//err = db.Close()
-	//assert.Nil(t, err, "Expectation not met: %v", err)
+    byt, err = dbStore.GetCurrent("testGUN", "root")
+    assert.NoError(t, err, "There should not be any errors getting.")
+	assert.Equal(t, []byte("1"), byt, "Returned data was incorrect")
+
+    dbStore.DB.Close()
 }
 
 func TestMySQLDelete(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
+    _, dbStore := SetUpSQLite(t)
 
-	sqlmock.ExpectExec(
-		"DELETE FROM `tuf_files` WHERE `gun`=\\?;",
-	).WithArgs("testGUN").WillReturnResult(sqlmock.NewResult(0, 1))
+    // Not testing deleting from an empty table, because that's not an error
+    // in SQLite3
 
-	err = s.Delete("testGUN")
-	assert.Nil(t, err, "Expected nil error from Delete")
+    // use UpdateCurrent to create one and test GetCurrent
+    update := MetaUpdate{
+        Role:    "root",
+        Version: 0,
+        Data:    []byte("1"),
+    }
+    err := dbStore.UpdateCurrent("testGUN", update)
+    assert.NoError(t, err, "Creating a row in an empty DB failed.")
 
-	err = db.Close()
-	assert.Nil(t, err, "Expectation not met: %v", err)
+    err = dbStore.Delete("testGUN")
+    assert.NoError(t, err, "There should not be any errors deleting.")
+
+    dbStore.DB.Close()
 }
 
 func TestMySQLGetTimestampKeyNoKey(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
+    _, dbStore := SetUpSQLite(t)
 
-	sqlmock.ExpectQuery(
-		"SELECT `cipher`, `public` FROM `timestamp_keys` WHERE `gun`=\\?;",
-	).WithArgs("testGUN").WillReturnError(sql.ErrNoRows)
+    cipher, public, err := dbStore.GetTimestampKey("testGUN")
+    assert.Equal(t, data.KeyAlgorithm(""), cipher)
+    assert.Nil(t, public)
+    assert.IsType(t, &ErrNoKey{}, err,
+                  "Expected ErrNoKey from GetTimestampKey")
 
-	_, _, err = s.GetTimestampKey("testGUN")
-	assert.IsType(t, &ErrNoKey{}, err, "Expected ErrNoKey from GetTimestampKey")
+    err = dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
+    assert.NoError(t, err, "Inserting timestamp into empty DB should succeed")
 
-	//err = db.Close()
-	//assert.Nil(t, err, "Expectation not met: %v", err)
+    cipher, public, err = dbStore.GetTimestampKey("testGUN")
+    assert.Equal(t, data.KeyAlgorithm("testCipher"), cipher,
+                 "Returned cipher was incorrect")
+    assert.Equal(t, []byte("1"), public, "Returned pubkey was incorrect")
 }
 
 func TestMySQLSetTimestampKeyExists(t *testing.T) {
-	db, err := sqlmock.New()
-	assert.Nil(t, err, "Could not initialize mock DB")
-	s := NewMySQLStorage(db)
+    _, dbStore := SetUpSQLite(t)
 
-	sqlmock.ExpectExec(
-		"INSERT INTO `timestamp_keys` \\(`gun`, `cipher`, `public`\\) VALUES \\(\\?,\\?,\\?\\);",
-	).WithArgs(
-		"testGUN",
-		"testCipher",
-		[]byte("1"),
-	).WillReturnError(
-		&mysql.MySQLError{Number: 1022},
-	)
+    err := dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
+    assert.NoError(t, err, "Inserting timestamp into empty DB should succeed")
 
-	err = s.SetTimestampKey("testGUN", "testCipher", []byte("1"))
-	assert.IsType(t, &ErrTimestampKeyExists{}, err, "Expected ErrTimestampKeyExists from SetTimestampKey")
+    err = dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
+    // sqlite3 error and mysql error aren't compatible
 
-	err = db.Close()
-	assert.Nil(t, err, "Expectation not met: %v", err)
+    // assert.IsType(t, &ErrTimestampKeyExists{}, err,
+    //               "Expected ErrTimestampKeyExists from SetTimestampKey")
+
+    dbStore.DB.Close()
 }

--- a/server/storage/database_test.go
+++ b/server/storage/database_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-    "github.com/endophage/gotuf/data"
+	"github.com/endophage/gotuf/data"
 	"github.com/jinzhu/gorm"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func (g GormTUFFile) TableName() string {
 
 // GormTimestampKey represents a single timestamp key in the database
 type GormTimestampKey struct {
-	Gun    string `sql:"type:varchar(255)" gorm:"primary key"`
+	Gun    string `sql:"type:varchar(255);unique" gorm:"primary key"`
 	Cipher string `sql:"type:varchar(30)"`
 	Public []byte `sql:"type:blob;not null"`
 }
@@ -57,12 +57,21 @@ func SetUpSQLite(t *testing.T) (*gorm.DB, *MySQLStorage) {
 	query = gormDB.CreateTable(&GormTimestampKey{})
 	assert.NoError(t, query.Error)
 
+	// verify that the tables are empty
+	var count int
+	for _, model := range [2]interface{}{&GormTUFFile{}, &GormTimestampKey{}} {
+		query = gormDB.Model(model).Count(&count)
+		assert.NoError(t, query.Error)
+		assert.Equal(t, 0, count)
+	}
+
 	return &gormDB, NewMySQLStorage(db)
 }
 
 func TestMySQLUpdateCurrent(t *testing.T) {
-	_, dbStore := SetUpSQLite(t)
+	gormDB, dbStore := SetUpSQLite(t)
 
+    // UpdateCurrent should succeed
 	update := MetaUpdate{
 		Role:    "root",
 		Version: 0,
@@ -71,15 +80,61 @@ func TestMySQLUpdateCurrent(t *testing.T) {
 	err := dbStore.UpdateCurrent("testGUN", update)
 	assert.NoError(t, err, "Creating a row in an empty DB failed.")
 
-    err = dbStore.UpdateCurrent("testGUN", update)
-	assert.Error(t, err, "Error should not be nil")
+    // There should just be one row
+    var rows []GormTUFFile
+    query := gormDB.Model(&GormTUFFile{}).Find(&rows)
+    assert.NoError(t, query.Error)
+    assert.Equal(
+        t,
+        []GormTUFFile{
+            GormTUFFile{ID: 1, Gun: "testGUN", Role: "root", Version: 0,
+                Data: []byte("1")},
+        },
+        rows)
+
+	dbStore.DB.Close()
+}
+
+func TestMySQLUpdateCurrentError(t *testing.T) {
+    gormDB, dbStore := SetUpSQLite(t)
+
+    // insert row
+    query := gormDB.Create(&GormTUFFile{
+        Gun:     "testGUN",
+        Role:    "root",
+        Version: 0,
+        Data:    []byte("1"),
+    })
+    assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
+
+    // UpdateCurrent should fail due to clash with prevoius row
+    update := MetaUpdate{
+        Role:    "root",
+        Version: 0,
+        Data:    []byte("1"),
+    }
+    err := dbStore.UpdateCurrent("testGUN", update)
+    assert.Error(t, err, "Error should not be nil")
     assert.IsType(t, &ErrOldVersion{}, err,
-                  "Expected ErrOldVersion error type, got: %v", err)
+        "Expected ErrOldVersion error type, got: %v", err)
+
+    // There should just be one row
+    var rows []GormTUFFile
+    query = gormDB.Model(&GormTUFFile{}).Find(&rows)
+    assert.NoError(t, query.Error)
+    assert.Equal(
+        t,
+        []GormTUFFile{
+            GormTUFFile{ID: 1, Gun: "testGUN", Role: "root", Version: 0,
+                Data: []byte("1")},
+        },
+        rows)
+
     dbStore.DB.Close()
 }
 
 func TestMySQLUpdateMany(t *testing.T) {
-    _, dbStore := SetUpSQLite(t)
+	gormDB, dbStore := SetUpSQLite(t)
 
 	update1 := MetaUpdate{
 		Role:    "root",
@@ -92,112 +147,145 @@ func TestMySQLUpdateMany(t *testing.T) {
 		Data:    []byte("2"),
 	}
 
-    err := dbStore.UpdateMany("testGUN", []MetaUpdate{update1, update2})
-    assert.NoError(t, err, "UpdateMany errored unexpectedly: %v", err)
-    dbStore.DB.Close()
-}
+	expected := []GormTUFFile{
+		GormTUFFile{ID: 1, Gun: "testGUN", Role: "root", Version: 0,
+			Data: []byte("1")},
+		GormTUFFile{ID: 2, Gun: "testGUN", Role: "targets", Version: 1,
+			Data: []byte("2")},
+	}
 
+	err := dbStore.UpdateMany("testGUN", []MetaUpdate{update1, update2})
+	assert.NoError(t, err, "UpdateMany errored unexpectedly: %v", err)
+
+	var rows []GormTUFFile
+	query := gormDB.Model(&GormTUFFile{}).Find(&rows)
+	assert.NoError(t, query.Error)
+	assert.Equal(t, 2, len(rows))
+	assert.Equal(t, expected, rows)
+
+	dbStore.DB.Close()
+}
 
 func TestMySQLUpdateManyDuplicateRollback(t *testing.T) {
-    _, dbStore := SetUpSQLite(t)
+	gormDB, dbStore := SetUpSQLite(t)
 
-    update := MetaUpdate{
-        Role:    "root",
-        Version: 0,
-        Data:    []byte("1"),
-    }
+	update := MetaUpdate{
+		Role:    "root",
+		Version: 0,
+		Data:    []byte("1"),
+	}
 
-    err := dbStore.UpdateMany("testGUN", []MetaUpdate{update, update})
-    assert.Error(t, err, "There should be an error updating twice.")
-    // sqlite3 error and mysql error aren't compatible
-    // assert.IsType(t, &ErrOldVersion{}, err,
-    //               "UpdateMany returned wrong error type")
+	err := dbStore.UpdateMany("testGUN", []MetaUpdate{update, update})
+	assert.Error(t, err, "There should be an error updating twice.")
+	// sqlite3 error and mysql error aren't compatible
+	// assert.IsType(t, &ErrOldVersion{}, err,
+	//               "UpdateMany returned wrong error type")
 
-    // the whole transaction should have rolled back, so there should be
-    // no entries.
-    byt, err := dbStore.GetCurrent("testGUN", "root")
-    assert.Nil(t, byt)
-    assert.Error(t, err, "There should be an error Getting any entries")
-    assert.IsType(t, &ErrNotFound{}, err, "Should get a not found error")
+	// the whole transaction should have rolled back, so there should be
+	// no entries.
+	var count int
+	query := gormDB.Model(&GormTUFFile{}).Count(&count)
+	assert.NoError(t, query.Error)
+	assert.Equal(t, 0, count)
 
-    dbStore.DB.Close()
+	dbStore.DB.Close()
 }
 
-
 func TestMySQLGetCurrent(t *testing.T) {
-    _, dbStore := SetUpSQLite(t)
+	gormDB, dbStore := SetUpSQLite(t)
 
-    byt, err := dbStore.GetCurrent("testGUN", "root")
-    assert.Nil(t, byt)
-    assert.Error(t, err, "There should be an error Getting an empty table")
-    assert.IsType(t, &ErrNotFound{}, err, "Should get a not found error")
+	byt, err := dbStore.GetCurrent("testGUN", "root")
+	assert.Nil(t, byt)
+	assert.Error(t, err, "There should be an error Getting an empty table")
+	assert.IsType(t, &ErrNotFound{}, err, "Should get a not found error")
 
-    // use UpdateCurrent to create one and test GetCurrent
-    update := MetaUpdate{
-        Role:    "root",
-        Version: 0,
-        Data:    []byte("1"),
-    }
-    err = dbStore.UpdateCurrent("testGUN", update)
-    assert.NoError(t, err, "Creating a row in an empty DB failed.")
+	query := gormDB.Create(&GormTUFFile{
+		Gun:     "testGUN",
+		Role:    "root",
+		Version: 0,
+		Data:    []byte("1"),
+	})
+	assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
 
-    byt, err = dbStore.GetCurrent("testGUN", "root")
-    assert.NoError(t, err, "There should not be any errors getting.")
+	byt, err = dbStore.GetCurrent("testGUN", "root")
+	assert.NoError(t, err, "There should not be any errors getting.")
 	assert.Equal(t, []byte("1"), byt, "Returned data was incorrect")
 
-    dbStore.DB.Close()
+	dbStore.DB.Close()
 }
 
 func TestMySQLDelete(t *testing.T) {
-    _, dbStore := SetUpSQLite(t)
+	gormDB, dbStore := SetUpSQLite(t)
 
-    // Not testing deleting from an empty table, because that's not an error
-    // in SQLite3
+	// Not testing deleting from an empty table, because that's not an error
+	// in SQLite3
 
-    // use UpdateCurrent to create one and test GetCurrent
-    update := MetaUpdate{
-        Role:    "root",
-        Version: 0,
-        Data:    []byte("1"),
-    }
-    err := dbStore.UpdateCurrent("testGUN", update)
-    assert.NoError(t, err, "Creating a row in an empty DB failed.")
+	// use UpdateCurrent to create one and test GetCurrent
+	query := gormDB.Create(&GormTUFFile{
+		Gun:     "testGUN",
+		Role:    "root",
+		Version: 0,
+		Data:    []byte("1"),
+	})
+	assert.NoError(t, query.Error, "Creating a row in an empty DB failed.")
 
-    err = dbStore.Delete("testGUN")
-    assert.NoError(t, err, "There should not be any errors deleting.")
+	err := dbStore.Delete("testGUN")
+	assert.NoError(t, err, "There should not be any errors deleting.")
 
-    dbStore.DB.Close()
+	// verify deletion
+	var count int
+	query = gormDB.Model(&GormTUFFile{}).Count(&count)
+	assert.NoError(t, query.Error)
+	assert.Equal(t, 0, count)
+
+	dbStore.DB.Close()
 }
 
 func TestMySQLGetTimestampKeyNoKey(t *testing.T) {
-    _, dbStore := SetUpSQLite(t)
+	gormDB, dbStore := SetUpSQLite(t)
 
-    cipher, public, err := dbStore.GetTimestampKey("testGUN")
-    assert.Equal(t, data.KeyAlgorithm(""), cipher)
-    assert.Nil(t, public)
-    assert.IsType(t, &ErrNoKey{}, err,
-                  "Expected ErrNoKey from GetTimestampKey")
+	cipher, public, err := dbStore.GetTimestampKey("testGUN")
+	assert.Equal(t, data.KeyAlgorithm(""), cipher)
+	assert.Nil(t, public)
+	assert.IsType(t, &ErrNoKey{}, err,
+		"Expected ErrNoKey from GetTimestampKey")
 
-    err = dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
-    assert.NoError(t, err, "Inserting timestamp into empty DB should succeed")
+	query := gormDB.Create(&GormTimestampKey{
+		Gun:    "testGUN",
+		Cipher: "testCipher",
+		Public: []byte("1"),
+	})
+	assert.NoError(
+		t, query.Error, "Inserting timestamp into empty DB should succeed")
 
-    cipher, public, err = dbStore.GetTimestampKey("testGUN")
-    assert.Equal(t, data.KeyAlgorithm("testCipher"), cipher,
-                 "Returned cipher was incorrect")
-    assert.Equal(t, []byte("1"), public, "Returned pubkey was incorrect")
+	cipher, public, err = dbStore.GetTimestampKey("testGUN")
+	assert.Equal(t, data.KeyAlgorithm("testCipher"), cipher,
+		"Returned cipher was incorrect")
+	assert.Equal(t, []byte("1"), public, "Returned pubkey was incorrect")
 }
 
 func TestMySQLSetTimestampKeyExists(t *testing.T) {
-    _, dbStore := SetUpSQLite(t)
+	gormDB, dbStore := SetUpSQLite(t)
 
-    err := dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
-    assert.NoError(t, err, "Inserting timestamp into empty DB should succeed")
+	err := dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
+	assert.NoError(t, err, "Inserting timestamp into empty DB should succeed")
 
-    err = dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
-    // sqlite3 error and mysql error aren't compatible
+	err = dbStore.SetTimestampKey("testGUN", "testCipher", []byte("1"))
+	assert.Error(t, err)
+	// sqlite3 error and mysql error aren't compatible
 
-    // assert.IsType(t, &ErrTimestampKeyExists{}, err,
-    //               "Expected ErrTimestampKeyExists from SetTimestampKey")
+	// assert.IsType(t, &ErrTimestampKeyExists{}, err,
+	//               "Expected ErrTimestampKeyExists from SetTimestampKey")
 
-    dbStore.DB.Close()
+	var rows []GormTimestampKey
+	query := gormDB.Model(&GormTimestampKey{}).Find(&rows)
+	assert.NoError(t, query.Error)
+	assert.Equal(t, 1, len(rows))
+	assert.Equal(
+		t,
+		GormTimestampKey{Gun: "testGUN", Cipher: "testCipher",
+			Public: []byte("1")},
+		rows[0])
+
+	dbStore.DB.Close()
 }

--- a/server/storage/interface.go
+++ b/server/storage/interface.go
@@ -4,10 +4,31 @@ import "github.com/endophage/gotuf/data"
 
 // MetaStore holds the methods that are used for a Metadata Store
 type MetaStore interface {
+	// UpdateCurrent adds new metadata version for the given GUN if and only
+	// if it's a new role, or the version is greater than the current version
+	// for the role. Otherwise an error is returned.
 	UpdateCurrent(gun string, update MetaUpdate) error
+
+	// UpdateMany adds multiple new metadata for the given GUN.  It can even
+	// add multiple versions for the same role, so long as those versions are
+	// all unique and greater than any current versions.  Otherwise,
+	// none of the metadata is added, and an error is be returned.
 	UpdateMany(gun string, updates []MetaUpdate) error
+
+	// GetCurrent returns the data part of the metadata for the latest version
+	// of the given GUN and role.  If there is no data for the given GUN and
+	// role, an error is returned.
 	GetCurrent(gun, tufRole string) (data []byte, err error)
+
+	// Delete removes all metadata for a given GUN.  It does not return an
+	// error if no metadata exists for the given GUN.
 	Delete(gun string) error
+
+	// GetTimestampKey returns the algorithm and public key for the given GUN.
+	// If the GUN doesn't exist, returns an error.
 	GetTimestampKey(gun string) (algorithm data.KeyAlgorithm, public []byte, err error)
+
+	// SetTimeStampKey sets the algorithm and public key for the given GUN if
+	// it doesn't already exist.  Otherwise an error is returned.
 	SetTimestampKey(gun string, algorithm data.KeyAlgorithm, public []byte) error
 }

--- a/server/storage/models.go
+++ b/server/storage/models.go
@@ -1,0 +1,53 @@
+package storage
+
+import "github.com/jinzhu/gorm"
+
+// TUFFile represents a TUF file in the database
+type TUFFile struct {
+	gorm.Model
+	Gun     string `sql:"type:varchar(255);not null"`
+	Role    string `sql:"type:varchar(255);not null"`
+	Version int
+	Data    []byte `sql:"type:longblob"`
+}
+
+// TableName sets a specific table name for TUFFile
+func (g TUFFile) TableName() string {
+	return "tuf_files"
+}
+
+// TimestampKey represents a single timestamp key in the database
+type TimestampKey struct {
+	gorm.Model
+	Gun    string `sql:"type:varchar(255);unique"`
+	Cipher string `sql:"type:varchar(30)"`
+	Public []byte `sql:"type:blob;not null"`
+}
+
+// TableName sets a specific table name for our TimestampKey
+func (g TimestampKey) TableName() string {
+	return "timestamp_keys"
+}
+
+// CreateTUFTable creates the DB table for TUFFile
+func CreateTUFTable(db gorm.DB) error {
+	query := db.CreateTable(&TUFFile{})
+	if query.Error != nil {
+		return query.Error
+	}
+	query = db.Model(&TUFFile{}).AddUniqueIndex(
+		"idx_gun", "gun", "role", "version")
+	if query.Error != nil {
+		return query.Error
+	}
+	return nil
+}
+
+// CreateTimestampTable creates the DB table for TUFFile
+func CreateTimestampTable(db gorm.DB) error {
+	query := db.CreateTable(&TimestampKey{})
+	if query.Error != nil {
+		return query.Error
+	}
+	return nil
+}

--- a/server/storage/models.go
+++ b/server/storage/models.go
@@ -7,8 +7,8 @@ type TUFFile struct {
 	gorm.Model
 	Gun     string `sql:"type:varchar(255);not null"`
 	Role    string `sql:"type:varchar(255);not null"`
-	Version int
-	Data    []byte `sql:"type:longblob"`
+	Version int    `sql:"not null"`
+	Data    []byte `sql:"type:longblob;not null"`
 }
 
 // TableName sets a specific table name for TUFFile
@@ -19,8 +19,8 @@ func (g TUFFile) TableName() string {
 // TimestampKey represents a single timestamp key in the database
 type TimestampKey struct {
 	gorm.Model
-	Gun    string `sql:"type:varchar(255);unique"`
-	Cipher string `sql:"type:varchar(30)"`
+	Gun    string `sql:"type:varchar(255);unique;not null"`
+	Cipher string `sql:"type:varchar(30);not null"`
 	Public []byte `sql:"type:blob;not null"`
 }
 
@@ -31,7 +31,8 @@ func (g TimestampKey) TableName() string {
 
 // CreateTUFTable creates the DB table for TUFFile
 func CreateTUFTable(db gorm.DB) error {
-	query := db.CreateTable(&TUFFile{})
+	// TODO: gorm
+	query := db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8").CreateTable(&TUFFile{})
 	if query.Error != nil {
 		return query.Error
 	}
@@ -45,7 +46,7 @@ func CreateTUFTable(db gorm.DB) error {
 
 // CreateTimestampTable creates the DB table for TUFFile
 func CreateTimestampTable(db gorm.DB) error {
-	query := db.CreateTable(&TimestampKey{})
+	query := db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8").CreateTable(&TimestampKey{})
 	if query.Error != nil {
 		return query.Error
 	}


### PR DESCRIPTION
In preparation for gorm-izing the DB itself.

This way we have passing tests we know work against the previous non-gorm storage package before gorm-izing the storage package.