### PR TITLE
Use canonical import paths instead of forked repo name

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
   environment:
   # Convenient shortcuts to "common" locations
     CHECKOUT: /home/ubuntu/$CIRCLE_PROJECT_REPONAME
-    BASE_DIR: src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+    BASE_DIR: src/github.com/docker/notary
   # Trick circle brainflat "no absolute path" behavior
     BASE_STABLE: ../../../$HOME/.gvm/pkgsets/stable/global/$BASE_DIR
   # Workaround Circle parsing dumb bugs and/or YAML wonkyness


### PR DESCRIPTION
The code referes to canonical import paths, so the code needs to be
available there even if CircleCI is building from a forked repository.

Otherwise the tests fail, e.g. https://circleci.com/gh/mtrmac/notary/3 vs. https://circleci.com/gh/mtrmac/notary/4 .