### PR TITLE
Use Makefile targets for test/pre to avoid duplication

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,15 +45,15 @@ test:
     - gvm use stable && go version
 
   # FMT
-    - gvm use stable && test -z "$(gofmt -s -l . | grep -v .pb. | grep -v Godeps/_workspace/src/ | tee /dev/stderr)":
+    - gvm use stable && make fmt:
         pwd: $BASE_STABLE
 
   # VET
-    - gvm use stable && test -z "$(go tool vet -printf=false . 2>&1 | grep -v Godeps/_workspace/src/ | tee /dev/stderr)":
+    - gvm use stable && make vet:
         pwd: $BASE_STABLE
 
   # LINT
-    - gvm use stable && test -z "$(golint ./... | grep -v .pb. | grep -v Godeps/_workspace/src/ | tee /dev/stderr)":
+    - gvm use stable && make lint:
         pwd: $BASE_STABLE
 
   override:


### PR DESCRIPTION
Thus, we will actually test that the Makefile works.

Doesn’t yet convert test/override because the two already differ and
it’s not immediately obvious to me which one to use.

This should help to avoid future regressions like #213 , (well, apart from not converting the actual test execution ☺).