### PR TITLE
Healthchecks for notary-server

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 
   post:
   # Install many go versions
-    - gvm install go1.4.2 -B --name=stable
+    - gvm install go1.5.1 -B --name=stable
 
   environment:
   # Convenient shortcuts to "common" locations

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -113,21 +113,20 @@ func main() {
 			viper.GetString("trust_service.port"),
 			viper.GetString("trust_service.tls_ca_file"),
 		)
+		minute := 1 * time.Minute
 		health.RegisterPeriodicFunc(
 			"Trust operational",
 			// If the trust service fails, the server is degraded but not
 			// exactly unheatlthy, so always return healthy and just log an
 			// error.
 			func() error {
-				logrus.Info("Getting health")
-				err := trust.(*signer.NotarySigner).CheckHealth(5)
-				logrus.Info("Got health")
+				err := trust.(*signer.NotarySigner).CheckHealth(minute)
 				if err != nil {
 					logrus.Error("Trust not fully operational: ", err.Error())
 				}
 				return nil
 			},
-			time.Second*5)
+			minute)
 	} else {
 		logrus.Info("Using local signing service")
 		trust = signed.NewEd25519()

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -108,11 +108,12 @@ func main() {
 	var trust signed.CryptoService
 	if viper.GetString("trust_service.type") == "remote" {
 		logrus.Info("Using remote signing service")
-		trust = signer.NewNotarySigner(
+		notarySigner := signer.NewNotarySigner(
 			viper.GetString("trust_service.hostname"),
 			viper.GetString("trust_service.port"),
 			viper.GetString("trust_service.tls_ca_file"),
 		)
+		trust = notarySigner
 		minute := 1 * time.Minute
 		health.RegisterPeriodicFunc(
 			"Trust operational",
@@ -120,7 +121,7 @@ func main() {
 			// exactly unheatlthy, so always return healthy and just log an
 			// error.
 			func() error {
-				err := trust.(*signer.NotarySigner).CheckHealth(minute)
+				err := notarySigner.CheckHealth(minute)
 				if err != nil {
 					logrus.Error("Trust not fully operational: ", err.Error())
 				}

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -114,10 +114,10 @@ func main() {
 			viper.GetString("trust_service.tls_ca_file"),
 		)
 		health.RegisterPeriodicFunc(
-			"Key Manager Healthy", trust.(*signer.NotarySigner).KMHealth,
+			"Key manager operational", trust.(*signer.NotarySigner).KMHealth,
 			time.Second*60)
 		health.RegisterPeriodicFunc(
-			"Signer Healthy", trust.(*signer.NotarySigner).SHealth,
+			"Signer operational", trust.(*signer.NotarySigner).SHealth,
 			time.Second*60)
 	} else {
 		logrus.Info("Using local signing service")
@@ -133,7 +133,7 @@ func main() {
 			return // not strictly needed but let's be explicit
 		}
 		health.RegisterPeriodicFunc(
-			"DB Operation", store.CheckHealth, time.Second*60)
+			"DB operational", store.CheckHealth, time.Second*60)
 		ctx = context.WithValue(ctx, "metaStore", store)
 	} else {
 		logrus.Debug("Using memory backend")

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -115,10 +115,19 @@ func main() {
 		)
 		health.RegisterPeriodicFunc(
 			"Trust operational",
+			// If the trust service fails, the server is degraded but not
+			// exactly unheatlthy, so always return healthy and just log an
+			// error.
 			func() error {
-				return trust.(*signer.NotarySigner).CheckHealth(60)
+				logrus.Info("Getting health")
+				err := trust.(*signer.NotarySigner).CheckHealth(5)
+				logrus.Info("Got health")
+				if err != nil {
+					logrus.Error("Trust not fully operational: ", err.Error())
+				}
+				return nil
 			},
-			time.Second*60)
+			time.Second*5)
 	} else {
 		logrus.Info("Using local signing service")
 		trust = signed.NewEd25519()

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -114,10 +114,10 @@ func main() {
 			viper.GetString("trust_service.tls_ca_file"),
 		)
 		health.RegisterPeriodicFunc(
-			"Key manager operational", trust.(*signer.NotarySigner).KMHealth,
-			time.Second*60)
-		health.RegisterPeriodicFunc(
-			"Signer operational", trust.(*signer.NotarySigner).SHealth,
+			"Trust operational",
+			func() error {
+				return trust.(*signer.NotarySigner).CheckHealth(60)
+			},
 			time.Second*60)
 	} else {
 		logrus.Info("Using local signing service")

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -158,8 +158,10 @@ func main() {
 	cryptoServices[data.ECDSAKey] = cryptoService
 
 	//RPC server setup
-	kms := &api.KeyManagementServer{CryptoServices: cryptoServices}
-	ss := &api.SignerServer{CryptoServices: cryptoServices}
+	kms := &api.KeyManagementServer{CryptoServices: cryptoServices,
+		HealthChecker: health.CheckStatus}
+	ss := &api.SignerServer{CryptoServices: cryptoServices,
+		HealthChecker: health.CheckStatus}
 
 	rpcAddr := viper.GetString("server.grpc_addr")
 	lis, err := net.Listen("tcp", rpcAddr)

--- a/notary-server-Dockerfile
+++ b/notary-server-Dockerfile
@@ -19,4 +19,4 @@ RUN go install \
     ${NOTARYPKG}/cmd/notary-server
 
 ENTRYPOINT [ "notary-server" ]
-CMD [ "-config", "cmd/notary-server/config.json", "-debug"]
+CMD [ "-config", "cmd/notary-server/config.json" ]

--- a/notary-server-Dockerfile
+++ b/notary-server-Dockerfile
@@ -19,4 +19,4 @@ RUN go install \
     ${NOTARYPKG}/cmd/notary-server
 
 ENTRYPOINT [ "notary-server" ]
-CMD [ "-config", "cmd/notary-server/config.json" ]
+CMD [ "-config", "cmd/notary-server/config.json", "-debug"]

--- a/notary-signer-Dockerfile
+++ b/notary-signer-Dockerfile
@@ -38,4 +38,4 @@ RUN go install \
 
 
 ENTRYPOINT [ "notary-signer" ]
-CMD [ "-config=cmd/notary-signer/config.json", "-debug" ]
+CMD [ "-config=cmd/notary-signer/config.json" ]

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -1,6 +1,7 @@
 package signer
 
 import (
+	"errors"
 	"net"
 
 	"github.com/Sirupsen/logrus"
@@ -84,4 +85,28 @@ func (trust *NotarySigner) GetKey(keyid string) data.PublicKey {
 		return nil
 	}
 	return data.NewPublicKey(data.KeyAlgorithm(publicKey.KeyInfo.Algorithm.Algorithm), publicKey.PublicKey)
+}
+
+// KMHealth returns the health of the KeyManagement RPC service.
+func (trust *NotarySigner) KMHealth() error {
+	status, err := trust.kmClient.CheckHealth(context.Background(), &pb.Void{})
+	if err != nil {
+		return err
+	}
+	if len(status.Status) > 0 {
+		return errors.New("KeyManagement not healthy")
+	}
+	return nil
+}
+
+// SHealth returns the health of the Signer RPC service.
+func (trust *NotarySigner) SHealth() error {
+	status, err := trust.sClient.CheckHealth(context.Background(), &pb.Void{})
+	if err != nil {
+		return err
+	}
+	if len(status.Status) > 0 {
+		return errors.New("Signer not healthy")
+	}
+	return nil
 }

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+// The only thing needed from grpc.ClientConn - specifying an interface
+// so that the connection can be stubbed out in tests.
 type checkableConnectionState interface {
 	State() grpc.ConnectivityState
 }

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -1,7 +1,6 @@
 package signer
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -120,7 +119,7 @@ func (trust *NotarySigner) checkServiceHealth(
 	// Do not bother starting checking at all if the connection is broken.
 	if trust.clientConn.State() != grpc.Idle &&
 		trust.clientConn.State() != grpc.Ready {
-		return errors.New("Not currently connected to trust server.")
+		return fmt.Errorf("Not currently connected to trust server.")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -14,8 +14,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// The only thing needed from grpc.ClientConn - specifying an interface
-// so that the connection can be stubbed out in tests.
+// The only thing needed from grpc.ClientConn is it's state.
 type checkableConnectionState interface {
 	State() grpc.ConnectivityState
 }

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -2,7 +2,9 @@ package signer
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	pb "github.com/docker/notary/proto"
@@ -12,10 +14,15 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+type checkableConnectionState interface {
+	State() grpc.ConnectivityState
+}
+
 // NotarySigner implements a RPC based Trust service that calls the Notary-signer Service
 type NotarySigner struct {
-	kmClient pb.KeyManagementClient
-	sClient  pb.SignerClient
+	kmClient   pb.KeyManagementClient
+	sClient    pb.SignerClient
+	clientConn checkableConnectionState
 }
 
 // NewNotarySigner is a convinience method that returns NotarySigner
@@ -35,8 +42,9 @@ func NewNotarySigner(hostname string, port string, tlscafile string) *NotarySign
 	kmClient := pb.NewKeyManagementClient(conn)
 	sClient := pb.NewSignerClient(conn)
 	return &NotarySigner{
-		kmClient: kmClient,
-		sClient:  sClient,
+		kmClient:   kmClient,
+		sClient:    sClient,
+		clientConn: conn,
 	}
 }
 
@@ -87,26 +95,55 @@ func (trust *NotarySigner) GetKey(keyid string) data.PublicKey {
 	return data.NewPublicKey(data.KeyAlgorithm(publicKey.KeyInfo.Algorithm.Algorithm), publicKey.PublicKey)
 }
 
-// KMHealth returns the health of the KeyManagement RPC service.
-func (trust *NotarySigner) KMHealth() error {
-	status, err := trust.kmClient.CheckHealth(context.Background(), &pb.Void{})
-	if err != nil {
-		return err
+// CheckHealth returns true if trust is healthy - that is if it can connect
+// to the trust server, and both the key management and signer services are
+// healthy
+func (trust *NotarySigner) CheckHealth(timeout int) error {
+	if e := trust.checkServiceHealth("Key manager", trust.kmClient,
+		timeout); e != nil {
+		return e
 	}
-	if len(status.Status) > 0 {
-		return errors.New("KeyManagement not healthy")
-	}
-	return nil
+	return trust.checkServiceHealth("Signer", trust.sClient, timeout)
 }
 
-// SHealth returns the health of the Signer RPC service.
-func (trust *NotarySigner) SHealth() error {
-	status, err := trust.sClient.CheckHealth(context.Background(), &pb.Void{})
-	if err != nil {
+// Generalized function that can check the health of both the signer client
+// and the key management client.
+func (trust *NotarySigner) checkServiceHealth(
+	serviceName string,
+	client interface {
+		CheckHealth(context.Context, *pb.Void, ...grpc.CallOption) (*pb.HealthStatus, error)
+	},
+	timeout int) error {
+
+	// Do not bother starting goroutine if the connection is broken.
+	if trust.clientConn.State() != grpc.Idle &&
+		trust.clientConn.State() != grpc.Ready {
+		return errors.New("Not currently connected to trust server.")
+	}
+
+	// We still want to time out getting health, because the connection could
+	// have disconnected sometime between when we checked the connection and
+	// when we try to make an RPC call.
+	channel := make(chan error)
+	go func() {
+		status, err := client.CheckHealth(context.Background(), &pb.Void{})
+		// if this function gets timed out, it might panic when writing to a
+		// closed channel
+		defer func() { recover() }()
+		if err != nil {
+			channel <- err
+		}
+		if len(status.Status) > 0 {
+			channel <- fmt.Errorf("%s not healthy", serviceName)
+		}
+		channel <- nil
+	}()
+	select {
+	case err := <-channel:
+		close(channel)
 		return err
+	case <-time.After(time.Second * time.Duration(timeout)):
+		close(channel)
+		return fmt.Errorf("Timed out connecting to %s after 60 seconds", serviceName)
 	}
-	if len(status.Status) > 0 {
-		return errors.New("Signer not healthy")
-	}
-	return nil
 }

--- a/signer/signer_trust_test.go
+++ b/signer/signer_trust_test.go
@@ -1,0 +1,122 @@
+package signer
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	pb "github.com/docker/notary/proto"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+type StubKeyManagementClient struct {
+	pb.KeyManagementClient
+	status map[string]string
+	err    error
+}
+
+func (c StubKeyManagementClient) CheckHealth(x context.Context, v *pb.Void, o ...grpc.CallOption) (*pb.HealthStatus, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &pb.HealthStatus{c.status}, nil
+}
+
+type StubSignerClient struct {
+	pb.SignerClient
+	status map[string]string
+	err    error
+}
+
+func (c StubSignerClient) CheckHealth(x context.Context, v *pb.Void, o ...grpc.CallOption) (*pb.HealthStatus, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &pb.HealthStatus{c.status}, nil
+}
+
+// KMHealth only succeeds if the KeyManagement service is healthy.
+func TestKMHealthFailure(t *testing.T) {
+	errs := []error{errors.New("Connection failure!"), nil}
+	status := map[string]string{"db": "bad"}
+
+	for _, err := range errs {
+		signer := NotarySigner{
+			StubKeyManagementClient{
+				pb.NewKeyManagementClient(nil),
+				status,
+				err,
+			},
+			StubSignerClient{
+				pb.NewSignerClient(nil),
+				make(map[string]string),
+				nil,
+			},
+		}
+		err := signer.KMHealth()
+		assert.Error(t, err)
+	}
+}
+
+// SHealth only succeeds if the Signer service is healthy.
+func TestSignerHealthFailure(t *testing.T) {
+	errs := []error{errors.New("Connection failure!"), nil}
+	status := map[string]string{"db": "bad"}
+
+	for _, err := range errs {
+		signer := NotarySigner{
+			StubKeyManagementClient{
+				pb.NewKeyManagementClient(nil),
+				make(map[string]string),
+				nil,
+			},
+			StubSignerClient{
+				pb.NewSignerClient(nil),
+				status,
+				err,
+			},
+		}
+		err := signer.SHealth()
+		assert.Error(t, err)
+	}
+}
+
+// SHealth succeeds if the signer service is healthy, regardless of the
+// key management service.
+func TestSignerHealthGood(t *testing.T) {
+	signer := NotarySigner{
+		StubKeyManagementClient{
+			pb.NewKeyManagementClient(nil),
+			nil,
+			errors.New("Connection failure!"),
+		},
+		StubSignerClient{
+			pb.NewSignerClient(nil),
+			make(map[string]string),
+			nil,
+		},
+	}
+	err := signer.SHealth()
+	assert.NoError(t, err)
+}
+
+// KMHealth succeeds if the key management service is healthy, regardless of
+// the signer service.
+func TestKMHealthGood(t *testing.T) {
+	signer := NotarySigner{
+		StubKeyManagementClient{
+			pb.NewKeyManagementClient(nil),
+			make(map[string]string),
+			nil,
+		},
+		StubSignerClient{
+			pb.NewSignerClient(nil),
+			nil,
+			errors.New("Connection failure!"),
+		},
+	}
+	err := signer.KMHealth()
+	assert.NoError(t, err)
+}

--- a/signer/signer_trust_test.go
+++ b/signer/signer_trust_test.go
@@ -17,7 +17,8 @@ type StubKeyManagementClient struct {
 	healthCheck func() (map[string]string, error)
 }
 
-func (c StubKeyManagementClient) CheckHealth(x context.Context, v *pb.Void, o ...grpc.CallOption) (*pb.HealthStatus, error) {
+func (c StubKeyManagementClient) CheckHealth(x context.Context,
+	v *pb.Void, o ...grpc.CallOption) (*pb.HealthStatus, error) {
 	status, err := c.healthCheck()
 	if err != nil {
 		return nil, err
@@ -30,7 +31,8 @@ type StubSignerClient struct {
 	healthCheck func() (map[string]string, error)
 }
 
-func (c StubSignerClient) CheckHealth(x context.Context, v *pb.Void, o ...grpc.CallOption) (*pb.HealthStatus, error) {
+func (c StubSignerClient) CheckHealth(x context.Context, v *pb.Void,
+	o ...grpc.CallOption) (*pb.HealthStatus, error) {
 	status, err := c.healthCheck()
 	if err != nil {
 		return nil, err

--- a/signer/signer_trust_test.go
+++ b/signer/signer_trust_test.go
@@ -23,7 +23,7 @@ func (c StubKeyManagementClient) CheckHealth(x context.Context,
 	if err != nil {
 		return nil, err
 	}
-	return &pb.HealthStatus{status}, nil
+	return &pb.HealthStatus{Status: status}, nil
 }
 
 type StubSignerClient struct {
@@ -37,7 +37,7 @@ func (c StubSignerClient) CheckHealth(x context.Context, v *pb.Void,
 	if err != nil {
 		return nil, err
 	}
-	return &pb.HealthStatus{status}, nil
+	return &pb.HealthStatus{Status: status}, nil
 }
 
 type StubGRPCConnection struct {


### PR DESCRIPTION
Fixes #190.

This PR makes notary-server unhealthy if:
~~- the connection to the trust service is dead~~
~~- it takes too long to answer an RPC call~~
~~- the trust signer service is unhealthy~~
~~- the trust key manager service is unhealthy~~
- the DB does not have the right tables

Update: It logs an error if the following are true:
- the connection to the trust service is dead
- it takes too long to answer an RPC call
- the trust signer service is unhealthy
- the trust key manager service is unhealthy

Since the server can operate with the signer down, but someone should get paged.

Note that the DB table query times out after a little while, the GRPC one seemed to hang forever (by which I mean about 10 minutes by wall clock).  It keeps trying to reconnect, but meanwhile the outstanding RPC call blocks.

The timeout should probably be in the distribution/health package, but since passing timeout arguments to all the functions breaks the existing API, maybe the health package should be split out and then projects can pin to a particular version or not?