### PR TITLE
Retooling for Hugo 15 patch

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM docs/base:latest
+FROM docs/base:hugo-github-linking
 MAINTAINER Mary Anthony <mary@docker.com> (@moxiegirl)
 
 # To get the git info for this repo
@@ -13,15 +13,3 @@ RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/mach
 RUN svn checkout https://github.com/docker/distribution/trunk/docs /docs/content/registry
 RUN svn checkout https://github.com/docker/tutorials/trunk/docs /docs/content/tutorials
 RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content
-
-
-# Sed to process GitHub Markdown
-# 1-2 Remove comment code from metadata block
-# 3 Change ](/word to ](/project/ in links
-# 4 Change ](word.md) to ](/project/word)
-# 5 Remove .md extension from link text
-# 6 Change ](../ to ](/project/word) 
-# 7 Change ](../../ to ](/project/ --> not implemented
-# 
-# 
-RUN /src/pre-process.sh /docs


### PR DESCRIPTION
@SvenDowideit created a patch to Hugo 15 which supports GitHub relative source links
This removes the scripts we were using to preprocess
Updates the Dockefile to use the new patch

Signed-off-by: Mary Anthony <mary@docker.com>