### PR TITLE
Do not use the viper singleton instance everywhere

### DIFF
--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -30,6 +30,7 @@ var (
 	configFileName    = "config"
 	configFileExt     = "json"
 	retriever         passphrase.Retriever
+	mainViper         = viper.New()
 )
 
 func init() {
@@ -69,12 +70,12 @@ func parseConfig() {
 	}
 
 	// Setup the configuration details into viper
-	viper.SetConfigName(configFileName)
-	viper.SetConfigType(configFileExt)
-	viper.AddConfigPath(configPath)
+	mainViper.SetConfigName(configFileName)
+	mainViper.SetConfigType(configFileExt)
+	mainViper.AddConfigPath(configPath)
 
 	// Find and read the config file
-	err := viper.ReadInConfig()
+	err := mainViper.ReadInConfig()
 	if err != nil {
 		logrus.Debugf("configuration file not found, using defaults")
 		// Ignore if the configuration file doesn't exist, we can use the defaults

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -24,7 +24,6 @@ import (
 	notaryclient "github.com/docker/notary/client"
 	"github.com/docker/notary/trustmanager"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var cmdTufList = &cobra.Command{
@@ -362,7 +361,7 @@ func (ps passwordStore) Basic(u *url.URL) (string, string) {
 func getTransport(gun string, readOnly bool) http.RoundTripper {
 	// Attempt to get a root CA from the config file. Nil is the host defaults.
 	rootPool := x509.NewCertPool()
-	rootCAFile := viper.GetString("remote_server.root_ca")
+	rootCAFile := mainViper.GetString("remote_server.root_ca")
 	if rootCAFile != "" {
 		// If we haven't been given an Absolute path, we assume it's relative
 		// from the configuration directory (~/.notary by default)
@@ -379,7 +378,7 @@ func getTransport(gun string, readOnly bool) http.RoundTripper {
 	// skipTLSVerify is false by default so verification will
 	// be performed.
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: viper.GetBool("remote_server.skipTLSVerify"),
+		InsecureSkipVerify: mainViper.GetBool("remote_server.skipTLSVerify"),
 		MinVersion:         tls.VersionTLS10,
 		RootCAs:            rootPool,
 	}
@@ -443,7 +442,7 @@ func tokenAuth(baseTransport *http.Transport, gun string, readOnly bool) http.Ro
 
 func getRemoteTrustServer() string {
 	if remoteTrustServer == "" {
-		configRemote := viper.GetString("remote_server.url")
+		configRemote := mainViper.GetString("remote_server.url")
 		if configRemote != "" {
 			remoteTrustServer = configRemote
 		} else {

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-// Version indicates which version of the binary is running.
+// NotaryVersion indicates which version of the binary is running.
 var NotaryVersion string
 
 // GitCommit indicates which git hash the binary was built off of


### PR DESCRIPTION
Well, this still has a singleton instance.  But not the `viper` package's private singleton instance.This way we can start injecting different configurations into helper functions in tests.