### PR TITLE
Factor out TLS configuration code for server and TLS

### DIFF
--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"crypto/rand"
-	"crypto/tls"
 	"database/sql"
 	"errors"
 	_ "expvar"
@@ -22,6 +20,7 @@ import (
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/signer"
 	"github.com/docker/notary/signer/api"
+	"github.com/docker/notary/utils"
 	"github.com/docker/notary/version"
 	"github.com/endophage/gotuf/data"
 	_ "github.com/go-sql-driver/mysql"
@@ -103,20 +102,10 @@ func main() {
 		log.Fatalf("Certificate and key are mandatory")
 	}
 
-	tlsConfig := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA},
+	tlsConfig, err := utils.ConfigureServerTLS(certFile, keyFile, false, "")
+	if err != nil {
+		logrus.Fatalf("Unable to set up TLS: %s", err.Error())
 	}
-	tlsConfig.Rand = rand.Reader
 
 	cryptoServices := make(signer.CryptoServiceIndex)
 

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -102,7 +102,10 @@ func main() {
 		log.Fatalf("Certificate and key are mandatory")
 	}
 
-	tlsConfig, err := utils.ConfigureServerTLS(certFile, keyFile, false, "")
+	tlsConfig, err := utils.ConfigureServerTLS(&utils.ServerTLSOpts{
+		ServerCertFile: certFile,
+		ServerKeyFile:  keyFile,
+	})
 	if err != nil {
 		logrus.Fatalf("Unable to set up TLS: %s", err.Error())
 	}

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -371,8 +371,10 @@ func getTransport(gun string, readOnly bool) http.RoundTripper {
 	if mainViper.IsSet("remote_server.skipTLSVerify") {
 		insecureSkipVerify = mainViper.GetBool("remote_server.skipTLSVerify")
 	}
-	tlsConfig, err := utils.ConfigureClientTLS(
-		rootCAFile, "", insecureSkipVerify, "", "")
+	tlsConfig, err := utils.ConfigureClientTLS(&utils.ClientTLSOpts{
+		RootCAFile:         rootCAFile,
+		InsecureSkipVerify: insecureSkipVerify,
+	})
 	if err != nil {
 		logrus.Fatal("Unable to configure TLS: ", err.Error())
 	}

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -367,9 +367,12 @@ func getTransport(gun string, readOnly bool) http.RoundTripper {
 		}
 	}
 
+	insecureSkipVerify := false
+	if mainViper.IsSet("remote_server.skipTLSVerify") {
+		insecureSkipVerify = mainViper.GetBool("remote_server.skipTLSVerify")
+	}
 	tlsConfig, err := utils.ConfigureClientTLS(
-		rootCAFile, "", mainViper.GetBool("remote_server.skipTLSVerify"),
-		"", "")
+		rootCAFile, "", insecureSkipVerify, "", "")
 	if err != nil {
 		logrus.Fatal("Unable to configure TLS: ", err.Error())
 	}

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -3,8 +3,6 @@ package main
 import (
 	"bufio"
 	"crypto/sha256"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -22,7 +20,7 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/pkg/term"
 	notaryclient "github.com/docker/notary/client"
-	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -360,7 +358,6 @@ func (ps passwordStore) Basic(u *url.URL) (string, string) {
 
 func getTransport(gun string, readOnly bool) http.RoundTripper {
 	// Attempt to get a root CA from the config file. Nil is the host defaults.
-	rootPool := x509.NewCertPool()
 	rootCAFile := mainViper.GetString("remote_server.root_ca")
 	if rootCAFile != "" {
 		// If we haven't been given an Absolute path, we assume it's relative
@@ -368,19 +365,13 @@ func getTransport(gun string, readOnly bool) http.RoundTripper {
 		if !filepath.IsAbs(rootCAFile) {
 			rootCAFile = filepath.Join(configPath, rootCAFile)
 		}
-		rootCert, err := trustmanager.LoadCertFromFile(rootCAFile)
-		if err != nil {
-			fatalf("could not load root ca file. %s", err.Error())
-		}
-		rootPool.AddCert(rootCert)
 	}
 
-	// skipTLSVerify is false by default so verification will
-	// be performed.
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: mainViper.GetBool("remote_server.skipTLSVerify"),
-		MinVersion:         tls.VersionTLS10,
-		RootCAs:            rootPool,
+	tlsConfig, err := utils.ConfigureClientTLS(
+		rootCAFile, "", mainViper.GetBool("remote_server.skipTLSVerify"),
+		"", "")
+	if err != nil {
+		logrus.Fatal("Unable to configure TLS: ", err.Error())
 	}
 
 	base := &http.Transport{

--- a/server/server.go
+++ b/server/server.go
@@ -41,8 +41,10 @@ func Run(ctx context.Context, addr, tlsCertFile, tlsKeyFile string, trust signed
 	}
 
 	if tlsCertFile != "" && tlsKeyFile != "" {
-		tlsConfig, err := utils.ConfigureServerTLS(
-			tlsCertFile, tlsKeyFile, false, "")
+		tlsConfig, err := utils.ConfigureServerTLS(&utils.ServerTLSOpts{
+			ServerCertFile: tlsCertFile,
+			ServerKeyFile:  tlsKeyFile,
+		})
 		if err != nil {
 			return err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"crypto/rand"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -42,27 +41,11 @@ func Run(ctx context.Context, addr, tlsCertFile, tlsKeyFile string, trust signed
 	}
 
 	if tlsCertFile != "" && tlsKeyFile != "" {
-		keypair, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+		tlsConfig, err := utils.ConfigureServerTLS(
+			tlsCertFile, tlsKeyFile, false, "")
 		if err != nil {
 			return err
 		}
-		tlsConfig := &tls.Config{
-			MinVersion:               tls.VersionTLS12,
-			PreferServerCipherSuites: true,
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-				tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-			},
-			Certificates: []tls.Certificate{keypair},
-			Rand:         rand.Reader,
-		}
-
 		logrus.Info("Enabling TLS")
 		lsnr = tls.NewListener(lsnr, tlsConfig)
 	} else if tlsCertFile != "" || tlsKeyFile != "" {

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -31,8 +31,10 @@ type NotarySigner struct {
 func NewNotarySigner(hostname string, port string, tlscafile string) *NotarySigner {
 	var opts []grpc.DialOption
 	netAddr := net.JoinHostPort(hostname, port)
-	tlsConfig, err := utils.ConfigureClientTLS(
-		tlscafile, hostname, false, "", "")
+	tlsConfig, err := utils.ConfigureClientTLS(&utils.ClientTLSOpts{
+		RootCAFile: tlscafile,
+		ServerName: hostname,
+	})
 	if err != nil {
 		logrus.Fatal("Unable to set up TLS: ", err)
 	}

--- a/signer/signer_trust.go
+++ b/signer/signer_trust.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	pb "github.com/docker/notary/proto"
+	"github.com/docker/notary/utils"
 	"github.com/endophage/gotuf/data"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -30,10 +31,12 @@ type NotarySigner struct {
 func NewNotarySigner(hostname string, port string, tlscafile string) *NotarySigner {
 	var opts []grpc.DialOption
 	netAddr := net.JoinHostPort(hostname, port)
-	creds, err := credentials.NewClientTLSFromFile(tlscafile, hostname)
+	tlsConfig, err := utils.ConfigureClientTLS(
+		tlscafile, hostname, false, "", "")
 	if err != nil {
-		logrus.Fatal("fail to read: ", err)
+		logrus.Fatal("Unable to set up TLS: ", err)
 	}
+	creds := credentials.NewTLS(tlsConfig)
 	opts = append(opts, grpc.WithTransportCredentials(creds))
 	conn, err := grpc.Dial(netAddr, opts...)
 

--- a/signer/signer_trust_test.go
+++ b/signer/signer_trust_test.go
@@ -40,7 +40,7 @@ func stubHealthFunction(t *testing.T, status map[string]string, err error) rpcHe
 		_, withDeadline := ctx.Deadline()
 		assert.True(t, withDeadline)
 
-		return &pb.HealthStatus{status}, err
+		return &pb.HealthStatus{Status: status}, err
 	}
 }
 

--- a/trustmanager/x509filestore.go
+++ b/trustmanager/x509filestore.go
@@ -260,6 +260,12 @@ func (s *X509FileStore) GetVerifyOptions(dnsName string) (x509.VerifyOptions, er
 	return opts, nil
 }
 
+// Empty returns true if there are no certificates in the X509FileStore, false
+// otherwise.
+func (s *X509FileStore) Empty() bool {
+	return len(s.fingerprintMap) == 0
+}
+
 func fileName(cert *x509.Certificate) (string, CertID, error) {
 	certID, err := fingerprintCert(cert)
 	if err != nil {

--- a/trustmanager/x509filestore_test.go
+++ b/trustmanager/x509filestore_test.go
@@ -124,6 +124,21 @@ func TestAddCertFromFileX509FileStore(t *testing.T) {
 	}
 }
 
+// TestNewX509FileStoreEmpty verifies the behavior of the Empty function
+func TestNewX509FileStoreEmpty(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "cert-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store, err := NewX509FileStore(tempDir)
+	assert.NoError(t, err, "failed to create a new X509FileStore: %v", store)
+	assert.True(t, store.Empty())
+
+	err = store.AddCertFromFile("../fixtures/root-ca.crt")
+	assert.NoError(t, err, "failed to add certificate from file")
+	assert.False(t, store.Empty())
+}
+
 func TestAddCertFromPEMX509FileStore(t *testing.T) {
 	b, err := ioutil.ReadFile("../fixtures/root-ca.crt")
 	if err != nil {

--- a/trustmanager/x509filestore_test.go
+++ b/trustmanager/x509filestore_test.go
@@ -27,39 +27,36 @@ func TestNewX509FileStore(t *testing.T) {
 // not overwrite any of the.
 func TestNewX509FileStoreLoadsExistingCerts(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "cert-test")
-	assert.NoError(t, err, "couldn't open temp directory")
+	assert.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
 	certBytes, err := ioutil.ReadFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err, "couldn't read fixtures/root-ca.crt")
+	assert.NoError(t, err)
 	out, err := os.Create(filepath.Join(tempDir, "root-ca.crt"))
-	assert.NoError(t, err, "couldn't create a file in the temp dir")
+	assert.NoError(t, err)
 
 	// to distinguish it from the canonical format
 	distinguishingBytes := []byte{'\n', '\n', '\n', '\n', '\n', '\n'}
 	nBytes, err := out.Write(distinguishingBytes)
-	assert.NoError(t, err, "could not write newlines to the temporary file")
-	assert.Equal(t, len(distinguishingBytes), nBytes,
-		"didn't write all bytes to temporary file")
+	assert.NoError(t, err)
+	assert.Len(t, distinguishingBytes, nBytes)
 
 	nBytes, err = out.Write(certBytes)
-	assert.NoError(t, err, "could not write cert to the temporary file")
-	assert.Equal(t, len(certBytes), nBytes,
-		"didn't write all bytes to temporary file")
+	assert.NoError(t, err)
+	assert.Len(t, certBytes, nBytes)
 
 	err = out.Close()
-	assert.NoError(t, err, "could not close temporary file")
+	assert.NoError(t, err)
 
 	store, err := NewX509FileStore(tempDir)
-	assert.NoError(t, err, "failed to create a new X509FileStore")
+	assert.NoError(t, err)
 
 	expectedCert, err := LoadCertFromFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err, "could not load root-ca.crt")
-	assert.Equal(t, store.GetCertificates(), []*x509.Certificate{expectedCert},
-		"did not load certificate already in the directory")
+	assert.NoError(t, err)
+	assert.Equal(t, []*x509.Certificate{expectedCert}, store.GetCertificates())
 
 	outBytes, err := ioutil.ReadFile(filepath.Join(tempDir, "root-ca.crt"))
-	assert.NoError(t, err, "couldn't read temporary file")
+	assert.NoError(t, err)
 	assert.Equal(t, distinguishingBytes, outBytes[:6], "original file overwritten")
 	assert.Equal(t, certBytes, outBytes[6:], "original file overwritten")
 }
@@ -131,11 +128,11 @@ func TestNewX509FileStoreEmpty(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	store, err := NewX509FileStore(tempDir)
-	assert.NoError(t, err, "failed to create a new X509FileStore: %v", store)
+	assert.NoError(t, err)
 	assert.True(t, store.Empty())
 
 	err = store.AddCertFromFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err, "failed to add certificate from file")
+	assert.NoError(t, err)
 	assert.False(t, store.Empty())
 }
 

--- a/utils/tls_config.go
+++ b/utils/tls_config.go
@@ -14,7 +14,7 @@ import (
 // and optionally client authentication.  Note that a tls configuration is
 // constructed that either requires and verifies client authentication or
 // doesn't deal with client certs at all. Nothing in the middle.
-func ConfigureServerTLS(serverCert string, serverKey string, clientAuth bool, caCertDir string) (*tls.Config, error) {
+func ConfigureServerTLS(serverCert, serverKey string, clientAuth bool, caCertDir string) (*tls.Config, error) {
 	keypair, err := tls.LoadX509KeyPair(serverCert, serverKey)
 	if err != nil {
 		return nil, err
@@ -66,10 +66,11 @@ func ConfigureServerTLS(serverCert string, serverKey string, clientAuth bool, ca
 
 // ConfigureClientTLS generates a tls configuration for clients using the
 // provided.
-func ConfigureClientTLS(rootCA string, skipVerify bool, clientCert string, clientKey string) (*tls.Config, error) {
+func ConfigureClientTLS(rootCA, serverName string, skipVerify bool, clientCert, clientKey string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: skipVerify,
 		MinVersion:         tls.VersionTLS12,
+		ServerName:         serverName,
 	}
 
 	if rootCA != "" {

--- a/utils/tls_config.go
+++ b/utils/tls_config.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+
+	"github.com/docker/notary/trustmanager"
+)
+
+// ConfigureServerTLS specifies a set of ciphersuites, the server cert and key,
+// and optionally client authentication.  Note that a tls configuration is
+// constructed that either requires and verifies client authentication or
+// doesn't deal with client certs at all. Nothing in the middle.
+func ConfigureServerTLS(serverCert string, serverKey string, clientAuth bool, caCert string) (*tls.Config, error) {
+	keypair, err := tls.LoadX509KeyPair(serverCert, serverKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+		Certificates: []tls.Certificate{keypair},
+		Rand:         rand.Reader,
+	}
+
+	if clientAuth {
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		if caCert != "" {
+			cert, err := trustmanager.LoadCertFromFile(caCert)
+			if err != nil {
+				return nil, err
+			}
+			caPool := x509.NewCertPool()
+			caPool.AddCert(cert)
+			tlsConfig.ClientCAs = caPool
+		}
+	}
+
+	return tlsConfig, nil
+}

--- a/utils/tls_config.go
+++ b/utils/tls_config.go
@@ -54,6 +54,10 @@ type ServerTLSOpts struct {
 // and optionally client authentication.  Note that a tls configuration is
 // constructed that either requires and verifies client authentication or
 // doesn't deal with client certs at all. Nothing in the middle.
+//
+// Also note that if the client CA file contains invalid data, behavior is not
+// guaranteed.  Currently (as of Go 1.5.1) only the valid certificates up to
+// the bad data will be parsed and added the client CA pool.
 func ConfigureServerTLS(opts *ServerTLSOpts) (*tls.Config, error) {
 	keypair, err := tls.LoadX509KeyPair(
 		opts.ServerCertFile, opts.ServerKeyFile)
@@ -96,6 +100,10 @@ type ClientTLSOpts struct {
 
 // ConfigureClientTLS generates a tls configuration for clients using the
 // provided parameters.
+///
+// Note that if the root CA file contains invalid data, behavior is not
+// guaranteed.  Currently (as of Go 1.5.1) only the valid certificates up to
+// the bad data will be parsed and added the root CA pool.
 func ConfigureClientTLS(opts *ClientTLSOpts) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: opts.InsecureSkipVerify,

--- a/utils/tls_config.go
+++ b/utils/tls_config.go
@@ -73,9 +73,9 @@ func ConfigureServerTLS(serverCert, serverKey string, clientAuth bool, caCertDir
 
 // ConfigureClientTLS generates a tls configuration for clients using the
 // provided parameters.
-func ConfigureClientTLS(rootCA, serverName string, skipVerify bool, clientCert, clientKey string) (*tls.Config, error) {
+func ConfigureClientTLS(rootCA, serverName string, insecureSkipVerify bool, clientCert, clientKey string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: skipVerify,
+		InsecureSkipVerify: insecureSkipVerify,
 		MinVersion:         tls.VersionTLS12,
 		CipherSuites:       clientCipherSuites,
 		ServerName:         serverName,

--- a/utils/tls_config_test.go
+++ b/utils/tls_config_test.go
@@ -2,6 +2,10 @@ package utils
 
 import (
 	"crypto/tls"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,16 +14,35 @@ import (
 const (
 	ServerCert = "../fixtures/notary-server.crt"
 	ServerKey  = "../fixtures/notary-server.key"
-	CACert     = "../fixtures/root-ca.crt"
-	FakeFile   = "../fixtures/not-a-file"
+	RootCA     = "../fixtures/root-ca.crt"
 )
+
+// copies the provided certificate into a temporary directory
+func makeTempCertDir(t *testing.T) string {
+	tempDir, err := ioutil.TempDir("/tmp", "cert-test")
+	assert.NoError(t, err, "couldn't open temp directory")
+
+	in, err := os.Open(RootCA)
+	assert.NoError(t, err, "cannot open %s", RootCA)
+	defer in.Close()
+	copiedCert := filepath.Join(tempDir, filepath.Base(RootCA))
+	out, err := os.Create(copiedCert)
+	assert.NoError(t, err, "cannot open %s", copiedCert)
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	assert.NoError(t, err, "cannot copy %s to %s", RootCA, copiedCert)
+
+	return tempDir
+}
 
 // TestTLSConfigFailsIfUnableToLoadCerts fails if unable to load either of the
 // server files or the client cert info
 func TestConfigServerTLSFailsIfUnableToLoadCerts(t *testing.T) {
+	tempDir := makeTempCertDir(t)
+
 	for i := 0; i < 3; i++ {
-		files := []string{ServerCert, ServerKey, CACert}
-		files[i] = FakeFile
+		files := []string{ServerCert, ServerKey, tempDir}
+		files[i] = "not-real-file"
 
 		result, err := ConfigureServerTLS(files[0], files[1], true, files[2])
 		assert.Nil(t, result)
@@ -46,10 +69,11 @@ func TestConfigServerTLSServerCertsOnly(t *testing.T) {
 // the provided server certificate, and since clientAuth was false, no client
 // auth or CAs configured even though a client CA cert was provided.
 func TestConfigServerTLSNoCACertsIfNoClientAuth(t *testing.T) {
+	tempDir := makeTempCertDir(t)
 	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
 	assert.NoError(t, err)
 
-	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, false, CACert)
+	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, false, tempDir)
 	assert.NoError(t, err)
 	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
 	assert.True(t, tlsConfig.PreferServerCipherSuites)
@@ -74,10 +98,11 @@ func TestTLSConfigClientAuthEnabledNoCACerts(t *testing.T) {
 // TestTLSConfigClientAuthEnabledWithCACert returns a valid tls config with the
 // provided server certificate, client auth enabled, and a client CA.
 func TestTLSConfigClientAuthEnabledWithCACert(t *testing.T) {
+	tempDir := makeTempCertDir(t)
 	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
 	assert.NoError(t, err)
 
-	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, true, CACert)
+	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, true, tempDir)
 	assert.NoError(t, err)
 	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
 	assert.True(t, tlsConfig.PreferServerCipherSuites)

--- a/utils/tls_config_test.go
+++ b/utils/tls_config_test.go
@@ -64,6 +64,17 @@ func TestConfigServerTLSServerCertsOnly(t *testing.T) {
 	assert.Nil(t, tlsConfig.ClientCAs)
 }
 
+// If a valid client cert directory is provided, but it contains no client
+// certs, an error is returned.
+func TestConfigServerTLSWithEmptyCACertDir(t *testing.T) {
+	tempDir, err := ioutil.TempDir("/tmp", "cert-test")
+	assert.NoError(t, err, "couldn't open temp directory")
+
+	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, false, tempDir)
+	assert.Nil(t, tlsConfig)
+	assert.Error(t, err)
+}
+
 // If server cert and key are provided, and client cert directory is provided,
 // a valid tls.Config is returned with the clientCAs set to the certs in that
 // directory.

--- a/utils/tls_config_test.go
+++ b/utils/tls_config_test.go
@@ -1,0 +1,86 @@
+package utils
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ServerCert = "../fixtures/notary-server.crt"
+	ServerKey  = "../fixtures/notary-server.key"
+	CACert     = "../fixtures/root-ca.crt"
+	FakeFile   = "../fixtures/not-a-file"
+)
+
+// TestTLSConfigFailsIfUnableToLoadCerts fails if unable to load either of the
+// server files or the client cert info
+func TestConfigServerTLSFailsIfUnableToLoadCerts(t *testing.T) {
+	for i := 0; i < 3; i++ {
+		files := []string{ServerCert, ServerKey, CACert}
+		files[i] = FakeFile
+
+		result, err := ConfigureServerTLS(files[0], files[1], true, files[2])
+		assert.Nil(t, result)
+		assert.Error(t, err)
+	}
+}
+
+// TestConfigServerTLSServerCertsOnly returns a valid tls config with the
+// provided server certificate, and since clientAuth was false, no client auth
+// or CAs configured.
+func TestConfigServerTLSServerCertsOnly(t *testing.T) {
+	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
+	assert.NoError(t, err)
+
+	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, false, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.PreferServerCipherSuites)
+	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
+	assert.Nil(t, tlsConfig.ClientCAs)
+}
+
+// TestConfigServerTLSNoCACertsIfNoClientAuth returns a valid tls config with
+// the provided server certificate, and since clientAuth was false, no client
+// auth or CAs configured even though a client CA cert was provided.
+func TestConfigServerTLSNoCACertsIfNoClientAuth(t *testing.T) {
+	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
+	assert.NoError(t, err)
+
+	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, false, CACert)
+	assert.NoError(t, err)
+	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.PreferServerCipherSuites)
+	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
+	assert.Nil(t, tlsConfig.ClientCAs)
+}
+
+// TestTLSConfigClientAuthEnabledNoCACerts returns a valid tls config with the
+// provided server certificate client auth enabled, but no CAs configured.
+func TestTLSConfigClientAuthEnabledNoCACerts(t *testing.T) {
+	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
+	assert.NoError(t, err)
+
+	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, true, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.PreferServerCipherSuites)
+	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+	assert.Nil(t, tlsConfig.ClientCAs)
+}
+
+// TestTLSConfigClientAuthEnabledWithCACert returns a valid tls config with the
+// provided server certificate, client auth enabled, and a client CA.
+func TestTLSConfigClientAuthEnabledWithCACert(t *testing.T) {
+	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
+	assert.NoError(t, err)
+
+	tlsConfig, err := ConfigureServerTLS(ServerCert, ServerKey, true, CACert)
+	assert.NoError(t, err)
+	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.PreferServerCipherSuites)
+	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
+	assert.Equal(t, 1, len(tlsConfig.ClientCAs.Subjects()))
+}

--- a/utils/tls_config_test.go
+++ b/utils/tls_config_test.go
@@ -1,13 +1,18 @@
 package utils
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
-	"io"
+	"crypto/x509"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
+	"github.com/docker/notary/trustmanager"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,38 +22,57 @@ const (
 	RootCA     = "../fixtures/root-ca.crt"
 )
 
-// copies the provided certificate into a temporary directory
-func makeTempCertDir(t *testing.T) string {
-	tempDir, err := ioutil.TempDir("/tmp", "cert-test")
-	assert.NoError(t, err, "couldn't open temp directory")
+// generates a multiple-certificate file with both RSA and ECDSA certs and
+// some garbage, returns filename.
+func generateMultiCert(t *testing.T) string {
+	tempFile, err := ioutil.TempFile("/tmp", "cert-test")
+	defer tempFile.Close()
+	assert.NoError(t, err)
 
-	in, err := os.Open(RootCA)
-	assert.NoError(t, err, "cannot open %s", RootCA)
-	defer in.Close()
-	copiedCert := filepath.Join(tempDir, filepath.Base(RootCA))
-	out, err := os.Create(copiedCert)
-	assert.NoError(t, err, "cannot open %s", copiedCert)
-	defer out.Close()
-	_, err = io.Copy(out, in)
-	assert.NoError(t, err, "cannot copy %s to %s", RootCA, copiedCert)
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	ecKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	assert.NoError(t, err)
+	template, err := trustmanager.NewCertificate("gun")
+	assert.NoError(t, err)
 
-	return tempDir
+	for _, key := range []crypto.Signer{rsaKey, ecKey} {
+		derBytes, err := x509.CreateCertificate(
+			rand.Reader, template, template, key.Public(), key)
+		assert.NoError(t, err)
+
+		cert, err := x509.ParseCertificate(derBytes)
+		assert.NoError(t, err)
+
+		pemBytes := trustmanager.CertToPEM(cert)
+		nBytes, err := tempFile.Write(pemBytes)
+		assert.NoError(t, err)
+		assert.Equal(t, nBytes, len(pemBytes))
+
+		assert.NoError(t, err)
+	}
+
+	_, err = tempFile.WriteString(`\n
+    -----BEGIN CERTIFICATE-----
+    This is some garbage that isnt a cert
+    -----END CERTIFICATE-----
+    `)
+
+	return tempFile.Name()
 }
 
 // If the cert files and directory are provided but are invalid, an error is
 // returned.
 func TestConfigServerTLSFailsIfUnableToLoadCerts(t *testing.T) {
-	tempDir := makeTempCertDir(t)
-
 	for i := 0; i < 3; i++ {
-		files := []string{ServerCert, ServerKey, tempDir}
+		files := []string{ServerCert, ServerKey, RootCA}
 		files[i] = "not-real-file"
 
 		result, err := ConfigureServerTLS(&ServerTLSOpts{
 			ServerCertFile:    files[0],
 			ServerKeyFile:     files[1],
 			RequireClientAuth: true,
-			ClientCADirectory: files[2],
+			ClientCAFile:      files[2],
 		})
 		assert.Nil(t, result)
 		assert.Error(t, err)
@@ -72,39 +96,64 @@ func TestConfigServerTLSServerCertsOnly(t *testing.T) {
 	assert.Nil(t, tlsConfig.ClientCAs)
 }
 
-// If a valid client cert directory is provided, but it contains no client
+// If a valid client cert file is provided, but it contains no client
 // certs, an error is returned.
-func TestConfigServerTLSWithEmptyCACertDir(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "cert-test")
-	assert.NoError(t, err, "couldn't open temp directory")
+func TestConfigServerTLSWithEmptyCACertFile(t *testing.T) {
+	tempFile, err := ioutil.TempFile("/tmp", "cert-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempFile.Name())
+	tempFile.Close()
 
 	tlsConfig, err := ConfigureServerTLS(&ServerTLSOpts{
-		ServerCertFile:    ServerCert,
-		ServerKeyFile:     ServerKey,
-		ClientCADirectory: tempDir,
+		ServerCertFile: ServerCert,
+		ServerKeyFile:  ServerKey,
+		ClientCAFile:   tempFile.Name(),
 	})
 	assert.Nil(t, tlsConfig)
 	assert.Error(t, err)
 }
 
-// If server cert and key are provided, and client cert directory is provided,
-// a valid tls.Config is returned with the clientCAs set to the certs in that
-// directory.
-func TestConfigServerTLSWithCACerts(t *testing.T) {
-	tempDir := makeTempCertDir(t)
+// If server cert and key are provided, and client cert file is provided with
+// one cert, a valid tls.Config is returned with the clientCAs set to that
+// cert.
+func TestConfigServerTLSWithOneCACert(t *testing.T) {
 	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
 	assert.NoError(t, err)
 
 	tlsConfig, err := ConfigureServerTLS(&ServerTLSOpts{
-		ServerCertFile:    ServerCert,
-		ServerKeyFile:     ServerKey,
-		ClientCADirectory: tempDir,
+		ServerCertFile: ServerCert,
+		ServerKeyFile:  ServerKey,
+		ClientCAFile:   RootCA,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
 	assert.True(t, tlsConfig.PreferServerCipherSuites)
 	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
 	assert.Len(t, tlsConfig.ClientCAs.Subjects(), 1)
+}
+
+// If server cert and key are provided, and client cert file is provided with
+// multiple certs (and garbage), a valid tls.Config is returned with the
+// clientCAs set to the valid cert and the garbage is ignored (but only
+// because the garbage is at the end - actually CertPool.AppendCertsFromPEM
+// aborts as soon as it finds an invalid cert)
+func TestConfigServerTLSWithMultipleCACertsAndGarbage(t *testing.T) {
+	tempFilename := generateMultiCert(t)
+	defer os.RemoveAll(tempFilename)
+
+	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
+	assert.NoError(t, err)
+
+	tlsConfig, err := ConfigureServerTLS(&ServerTLSOpts{
+		ServerCertFile: ServerCert,
+		ServerKeyFile:  ServerKey,
+		ClientCAFile:   tempFilename,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.PreferServerCipherSuites)
+	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
+	assert.Len(t, tlsConfig.ClientCAs.Subjects(), 2)
 }
 
 // If server cert and key are provided, and client auth is disabled, then
@@ -151,8 +200,8 @@ func TestConfigClientServerName(t *testing.T) {
 	}
 }
 
-// The RootCA is set if it is provided and valid
-func TestConfigClientTLSValidRootCA(t *testing.T) {
+// The RootCA is set if the file provided has a single CA cert.
+func TestConfigClientTLSRootCAFileWithOneCert(t *testing.T) {
 	tlsConfig, err := ConfigureClientTLS(&ClientTLSOpts{RootCAFile: RootCA})
 	assert.NoError(t, err)
 	assert.Nil(t, tlsConfig.Certificates)
@@ -161,8 +210,24 @@ func TestConfigClientTLSValidRootCA(t *testing.T) {
 	assert.Len(t, tlsConfig.RootCAs.Subjects(), 1)
 }
 
-// An error is returned if a root CA is provided but not valid
-func TestConfigClientTLSInvalidRootCA(t *testing.T) {
+// If the root CA file provided has multiple CA certs and garbage, only the
+// valid certs are read (but only because the garbage is at the end - actually
+// CertPool.AppendCertsFromPEM aborts as soon as it finds an invalid cert)
+func TestConfigClientTLSRootCAFileMultipleCertsAndGarbage(t *testing.T) {
+	tempFilename := generateMultiCert(t)
+	defer os.RemoveAll(tempFilename)
+
+	tlsConfig, err := ConfigureClientTLS(
+		&ClientTLSOpts{RootCAFile: tempFilename})
+	assert.NoError(t, err)
+	assert.Nil(t, tlsConfig.Certificates)
+	assert.Equal(t, false, tlsConfig.InsecureSkipVerify)
+	assert.Equal(t, "", tlsConfig.ServerName)
+	assert.Len(t, tlsConfig.RootCAs.Subjects(), 2)
+}
+
+// An error is returned if a root CA is provided but the file doesn't exist.
+func TestConfigClientTLSNonexistentRootCAFile(t *testing.T) {
 	tlsConfig, err := ConfigureClientTLS(
 		&ClientTLSOpts{RootCAFile: "not-a-file"})
 	assert.Error(t, err)


### PR DESCRIPTION
So that mutual authentication can be supported between notary-server and notary-signer as well as notary and notary-server.