### PR TITLE
Use make targets in circleci, more complete coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ gen-cover:
 	@rm -rf "$(COVERDIR)"
 	@mkdir -p "$(COVERDIR)"
 	$(foreach PKG,$(PKGS),$(call gocover,$(PKG)))
-	@echo "mode: $(COVERMODE)" > "$(COVERPROFILE)"
 
 cover: gen-cover
+	@echo "mode: $(COVERMODE)" > "$(COVERPROFILE)"
 	@grep -h -v "^mode:" "$(COVERDIR)"/*.cover >> "$(COVERPROFILE)"
 	@go tool cover -func="$(COVERPROFILE)"
 	@go tool cover -html="$(COVERPROFILE)"
@@ -100,7 +100,6 @@ define formatcov
 endef
 
 ci: OPTS = race test.short
-	GO_EXC = godep go
 ci: gen-cover
 
 aggregate-cover:

--- a/Makefile
+++ b/Makefile
@@ -87,28 +87,19 @@ gen-cover:
 	@rm -rf "$(COVERDIR)"
 	@mkdir -p "$(COVERDIR)"
 	$(foreach PKG,$(PKGS),$(call gocover,$(PKG)))
+	@echo "mode: $(COVERMODE)" > "$(COVERPROFILE)"
+	@grep -h -v "^mode:" "$(COVERDIR)"/*.cover >> "$(COVERPROFILE)"
 
 cover: GO_EXC = go
 cover: gen-cover
-	@echo "mode: $(COVERMODE)" > "$(COVERPROFILE)"
-	@grep -h -v "^mode:" "$(COVERDIR)"/*.cover >> "$(COVERPROFILE)"
 	@go tool cover -func="$(COVERPROFILE)"
 	@go tool cover -html="$(COVERPROFILE)"
 
 
-define formatcov
-	echo '<<<<<< EOF' | cat $(1) - >> coverage.txt;
-endef
-
 ci: OPTS = race test.short
     GO_EXC = godep go
+    COVERPROFILE = coverage.out
 ci: gen-cover
-
-aggregate-cover:
-	@rm -f coverage.out
-	@echo "" > coverage.txt
-	$(foreach COVFILE, $(shell find $(COVERDIR) -type f -name *.cover),$(call formatcov,$(COVFILE)))
-
 
 clean-protos:
 	@rm proto/*.pb.go

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ build:
 
 test: OPTS =
 test:
-	@echo "+ $@ OPTS=${OPTS}"
-	go test $(addprefix -,${OPTS}) -test.short ./...
+	@echo "+ $@ ${OPTS}"
+	go test ${OPTS} ./...
 
 test-full: vet lint
 	@echo "+ $@"
@@ -80,7 +80,7 @@ protos:
 
 
 define gocover
-$(GO_EXC) test $(addprefix -,${OPTS}) -covermode="$(COVERMODE)" -coverprofile="$(COVERDIR)/$(subst /,-,$(1)).cover" "$(1)" || exit 1;
+$(GO_EXC) test ${OPTS} -covermode="$(COVERMODE)" -coverprofile="$(COVERDIR)/$(subst /,-,$(1)).cover" "$(1)" || exit 1;
 endef
 
 gen-cover:
@@ -90,14 +90,13 @@ gen-cover:
 	@echo "mode: $(COVERMODE)" > "$(COVERPROFILE)"
 	@grep -h -v "^mode:" "$(COVERDIR)"/*.cover >> "$(COVERPROFILE)"
 
-cover: GO_EXC = godep go
-       OPTS = race
+cover: GO_EXC = go
 cover: gen-cover
 	@go tool cover -func="$(COVERPROFILE)"
 	@go tool cover -html="$(COVERPROFILE)"
 
 
-ci: OPTS = race
+ci: OPTS = -race
     GO_EXC = godep go
     COVERPROFILE = coverage.out
 ci: gen-cover

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ protos:
 
 
 define gocover
-$(GO_EXC) test $(addprefix -,${OPTS}) -covermode="$(COVERMODE)" -coverprofile="$(COVERDIR)/$(subst /,-,$(1)).cover" "$(1)";
+$(GO_EXC) test $(addprefix -,${OPTS}) -covermode="$(COVERMODE)" -coverprofile="$(COVERDIR)/$(subst /,-,$(1)).cover" "$(1)" || exit 1;
 endef
 
 gen-cover:
@@ -88,6 +88,7 @@ gen-cover:
 	@mkdir -p "$(COVERDIR)"
 	$(foreach PKG,$(PKGS),$(call gocover,$(PKG)))
 
+cover: GO_EXC = go
 cover: gen-cover
 	@echo "mode: $(COVERMODE)" > "$(COVERPROFILE)"
 	@grep -h -v "^mode:" "$(COVERDIR)"/*.cover >> "$(COVERPROFILE)"
@@ -100,6 +101,7 @@ define formatcov
 endef
 
 ci: OPTS = race test.short
+    GO_EXC = godep go
 ci: gen-cover
 
 aggregate-cover:

--- a/Makefile
+++ b/Makefile
@@ -90,13 +90,14 @@ gen-cover:
 	@echo "mode: $(COVERMODE)" > "$(COVERPROFILE)"
 	@grep -h -v "^mode:" "$(COVERDIR)"/*.cover >> "$(COVERPROFILE)"
 
-cover: GO_EXC = go
+cover: GO_EXC = godep go
+       OPTS = race
 cover: gen-cover
 	@go tool cover -func="$(COVERPROFILE)"
 	@go tool cover -html="$(COVERPROFILE)"
 
 
-ci: OPTS = race test.short
+ci: OPTS = race
     GO_EXC = godep go
     COVERPROFILE = coverage.out
 ci: gen-cover

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ dependencies:
   # For the stable go version, additionally install linting tools
     - >
       gvm use stable &&
-      go get github.com/axw/gocov/gocov github.com/mattn/goveralls github.com/golang/lint/golint
+      go get github.com/axw/gocov/gocov github.com/golang/lint/golint
 test:
   pre:
   # Output the go versions we are going to test
@@ -58,18 +58,14 @@ test:
 
   override:
   # Test stable, and report
-  # Preset the goverall report file
-    - echo "$CIRCLE_PAIN" > ~/goverage.report
-    - gvm use stable; go list ./... | xargs -L 1 -I{} rm -f $GOPATH/src/{}/coverage.out:
-        pwd: $BASE_STABLE
-
-    - gvm use stable; go list ./... | xargs -L 1 -I{} godep go test -race -test.short -coverprofile=$GOPATH/src/{}/coverage.out {}:
+    - gvm use stable && make ci:
         timeout: 600
         pwd: $BASE_STABLE
 
-  # post:
-  # Aggregate and report to coveralls
-  #   - gvm use stable; go list ./... | xargs -L 1 -I{} cat "$GOPATH/src/{}/coverage.out" | grep -v "$CIRCLE_PAIN" >> ~/goverage.report:
-  #       pwd: $BASE_STABLE
-  #   - gvm use stable; goveralls -service circleci -coverprofile=/home/ubuntu/goverage.report -repotoken $COVERALLS_TOKEN:
-  #       pwd: $BASE_STABLE
+  post:
+  # Aggregate and report to codecov.io
+    - make aggregate-cover:
+        pwd: $BASE_STABLE
+
+    - bash <(curl -s https://codecov.io/bash):
+        pwd: $BASE_STABLE

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,8 @@ dependencies:
   # For the stable go version, additionally install linting tools
     - >
       gvm use stable &&
-      go get github.com/axw/gocov/gocov github.com/golang/lint/golint
+      go get github.com/golang/lint/golint github.com/wadey/gocovmerge &&
+      go install github.com/wadey/gocovmerge
 test:
   pre:
   # Output the go versions we are going to test
@@ -64,5 +65,5 @@ test:
 
   post:
   # Report to codecov.io
-    - bash <(curl -s https://codecov.io/bash):
-        pwd: $BASE_STABLE
+    # - bash <(curl -s https://codecov.io/bash):
+    #     pwd: $BASE_STABLE

--- a/circle.yml
+++ b/circle.yml
@@ -63,9 +63,6 @@ test:
         pwd: $BASE_STABLE
 
   post:
-  # Aggregate and report to codecov.io
-    - make aggregate-cover:
-        pwd: $BASE_STABLE
-
+  # Report to codecov.io
     - bash <(curl -s https://codecov.io/bash):
         pwd: $BASE_STABLE

--- a/coverpkg.sh
+++ b/coverpkg.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Given a subpackage and the containing package, figures out which packages
+# need to be passed to `go test -coverpkg`:  this includes all of the
+# subpackage's dependencies within the containing package, as well as the
+# subpackage itself.
+
+DEPENDENCIES="$(go list -f $'{{range $f := .Deps}}{{$f}}\n{{end}}' ${1} | grep ${2})"
+
+echo "${1} ${DEPENDENCIES}" | xargs echo -n | tr ' ' ','


### PR DESCRIPTION
As per #213, #217, and #222, attempting to make the CircleCI config use make targets.  To that end I factored the `cover` a bit so that the testing/coverage part is the same across `make cover` and `make ci`.

We were also running short tests before on CI, which doesn't hit all code paths (for instance in the client.go tests we don't test with RSA keys)

cc @mtrmac (although apologies, in #213 you suggested using godep in all targets or none - I haven't done that here since not using godep lets us test various versions for development, but not using godep seems to fail in circleci - maybe we should just do a godep restore in circleci?)

This seems to work (see https://codecov.io/github/cyli/notary?branch=codecov), but the code coverage numbers as displayed in codecov.io are different than from `go tool cover --html`, which I'm still trying to work out.

Fixes #222 