### PR TITLE
Unify root nonroot keystore

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -109,7 +109,7 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 		return nil, err
 	}
 
-	cryptoService := cryptoservice.NewCryptoService(gun, keyStoreManager.NonRootKeyStore())
+	cryptoService := cryptoservice.NewCryptoService(gun, keyStoreManager.KeyStore)
 
 	nRepo := &NotaryRepository{
 		gun:             gun,

--- a/client/client_root_validation_test.go
+++ b/client/client_root_validation_test.go
@@ -66,7 +66,7 @@ func validateRootSuccessfully(t *testing.T, rootType data.KeyAlgorithm) {
 	var tempKey data.TUFKey
 	json.Unmarshal([]byte(timestampECDSAKeyJSON), &tempKey)
 
-	repo.KeyStoreManager.NonRootKeyStore().AddKey(filepath.Join(filepath.FromSlash(gun), tempKey.ID()), "root", &tempKey)
+	repo.KeyStoreManager.KeyStore.AddKey(filepath.Join(filepath.FromSlash(gun), tempKey.ID()), "root", &tempKey)
 
 	// Because ListTargets will clear this
 	savedTUFRepo := repo.tufRepo

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -94,9 +94,9 @@ func testInitRepo(t *testing.T, rootType data.KeyAlgorithm) {
 
 	// Look for keys in private. The filenames should match the key IDs
 	// in the private key store.
-	privKeyList := repo.KeyStoreManager.NonRootKeyStore().ListFiles()
+	privKeyList := repo.KeyStoreManager.KeyStore.ListFiles()
 	for _, privKeyName := range privKeyList {
-		privKeyFileName := filepath.Join(repo.KeyStoreManager.NonRootKeyStore().BaseDir(), privKeyName)
+		privKeyFileName := filepath.Join(repo.KeyStoreManager.KeyStore.BaseDir(), privKeyName)
 		_, err := os.Stat(privKeyFileName)
 		assert.NoError(t, err, "missing private key: %s", privKeyName)
 	}
@@ -301,7 +301,7 @@ func testAddListTarget(t *testing.T, rootType data.KeyAlgorithm) {
 	var tempKey data.TUFKey
 	json.Unmarshal([]byte(timestampECDSAKeyJSON), &tempKey)
 
-	repo.KeyStoreManager.NonRootKeyStore().AddKey(filepath.Join(filepath.FromSlash(gun), tempKey.ID()), "nonroot", &tempKey)
+	repo.KeyStoreManager.KeyStore.AddKey(filepath.Join(filepath.FromSlash(gun), tempKey.ID()), "nonroot", &tempKey)
 
 	// Because ListTargets will clear this
 	savedTUFRepo := repo.tufRepo

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -123,7 +123,12 @@ func tufInit(cmd *cobra.Command, args []string) {
 		fatalf(err.Error())
 	}
 
-	keysMap := nRepo.KeyStoreManager.RootKeyStore().ListKeys()
+	var keysMap map[string]string
+	for k, role := range nRepo.KeyStoreManager.KeyStore.ListKeys() {
+		if role == "root" {
+			keysMap[k] = role
+		}
+	}
 
 	var rootKeyID string
 	if len(keysMap) < 1 {

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -123,7 +123,7 @@ func tufInit(cmd *cobra.Command, args []string) {
 		fatalf(err.Error())
 	}
 
-	var keysMap map[string]string
+	keysMap := make(map[string]string)
 	for k, role := range nRepo.KeyStoreManager.KeyStore.ListKeys() {
 		if role == "root" {
 			keysMap[k] = role

--- a/keystoremanager/import_export_test.go
+++ b/keystoremanager/import_export_test.go
@@ -83,11 +83,14 @@ func TestImportExportZip(t *testing.T) {
 
 	// Add non-root keys to the map. These should use the new passphrase
 	// because the passwords were chosen by the newPassphraseRetriever.
-	privKeyMap := repo.KeyStoreManager.NonRootKeyStore().ListKeys()
+	privKeyMap := repo.KeyStoreManager.KeyStore.ListKeys()
 	for privKeyName := range privKeyMap {
-		_, alias, err := repo.KeyStoreManager.NonRootKeyStore().GetKey(privKeyName)
+		_, alias, err := repo.KeyStoreManager.KeyStore.GetKey(privKeyName)
 		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
 
+		if alias == "root" {
+			continue
+		}
 		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
 		passphraseByFile[relKeyPath] = exportPassphrase
 	}
@@ -156,9 +159,12 @@ func TestImportExportZip(t *testing.T) {
 	// Look for keys in private. The filenames should match the key IDs
 	// in the repo's private key store.
 	for privKeyName := range privKeyMap {
-		_, alias, err := repo.KeyStoreManager.NonRootKeyStore().GetKey(privKeyName)
+		_, alias, err := repo.KeyStoreManager.KeyStore.GetKey(privKeyName)
 		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
 
+		if alias == "root" {
+			continue
+		}
 		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
 		privKeyFileName := filepath.Join(tempBaseDir2, relKeyPath)
 		_, err = os.Stat(privKeyFileName)
@@ -219,11 +225,14 @@ func TestImportExportGUN(t *testing.T) {
 
 	// Add keys non-root keys to the map. These should use the new passphrase
 	// because they were formerly unencrypted.
-	privKeyMap := repo.KeyStoreManager.NonRootKeyStore().ListKeys()
+	privKeyMap := repo.KeyStoreManager.KeyStore.ListKeys()
 	for privKeyName := range privKeyMap {
-		_, alias, err := repo.KeyStoreManager.NonRootKeyStore().GetKey(privKeyName)
+		_, alias, err := repo.KeyStoreManager.KeyStore.GetKey(privKeyName)
 		if err != nil {
 			t.Fatalf("privKey %s has no alias", privKeyName)
+		}
+		if alias == "root" {
+			continue
 		}
 		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
 
@@ -290,9 +299,12 @@ func TestImportExportGUN(t *testing.T) {
 	// Look for keys in private. The filenames should match the key IDs
 	// in the repo's private key store.
 	for privKeyName := range privKeyMap {
-		_, alias, err := repo.KeyStoreManager.NonRootKeyStore().GetKey(privKeyName)
+		_, alias, err := repo.KeyStoreManager.KeyStore.GetKey(privKeyName)
 		if err != nil {
 			t.Fatalf("privKey %s has no alias", privKeyName)
+		}
+		if alias == "root" {
+			continue
 		}
 		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
 		privKeyFileName := filepath.Join(tempBaseDir2, relKeyPath)
@@ -381,7 +393,7 @@ func TestImportExportRootKey(t *testing.T) {
 	assert.EqualError(t, err, keystoremanager.ErrNoValidPrivateKey.Error())
 
 	// Should be able to unlock the root key with the old password
-	key, alias, err := repo2.KeyStoreManager.RootKeyStore().GetKey(rootKeyID)
+	key, alias, err := repo2.KeyStoreManager.KeyStore.GetKey(rootKeyID)
 	assert.NoError(t, err, "could not unlock root key")
 	assert.Equal(t, "root", alias)
 	assert.Equal(t, rootKeyID, key.ID())
@@ -452,7 +464,7 @@ func TestImportExportRootKeyReencrypt(t *testing.T) {
 	assert.NoError(t, err, "missing root key")
 
 	// Should be able to unlock the root key with the new password
-	key, alias, err := repo2.KeyStoreManager.RootKeyStore().GetKey(rootKeyID)
+	key, alias, err := repo2.KeyStoreManager.KeyStore.GetKey(rootKeyID)
 	assert.NoError(t, err, "could not unlock root key")
 	assert.Equal(t, "root", alias)
 	assert.Equal(t, rootKeyID, key.ID())

--- a/keystoremanager/keystoremanager.go
+++ b/keystoremanager/keystoremanager.go
@@ -26,11 +26,9 @@ type KeyStoreManager struct {
 }
 
 const (
-	trustDir          = "trusted_certificates"
-	privDir           = "private"
-	rootKeysSubdir    = "root_keys"
-	nonRootKeysSubdir = "tuf_keys"
-	rsaRootKeySize    = 4096 // Used for new root keys
+	trustDir       = "trusted_certificates"
+	privDir        = "private"
+	rsaRootKeySize = 4096 // Used for new root keys
 )
 
 // ErrValidationFail is returned when there is no valid trusted certificates

--- a/signer/keydbstore.go
+++ b/signer/keydbstore.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -194,6 +195,16 @@ func (s *KeyDBStore) RotateKeyPassphrase(name, newPassphraseAlias string) error 
 	s.db.Save(dbPrivateKey)
 
 	return nil
+}
+
+// ExportKey is currently unimplemented and will always return an error
+func (s *KeyDBStore) ExportKey(name string) ([]byte, error) {
+	return nil, errors.New("Exporting from a KeyDBStore is not supported.")
+}
+
+// ImportKey is currently unimplemented and will always return an error
+func (s *KeyDBStore) ImportKey(pemBytes []byte, alias string) error {
+	return errors.New("Importing into a KeyDBStore is not supported")
 }
 
 // HealthCheck verifies that DB exists and is query-able

--- a/trustmanager/keyfilestore_test.go
+++ b/trustmanager/keyfilestore_test.go
@@ -31,7 +31,7 @@ func TestAddKey(t *testing.T) {
 	defer os.RemoveAll(tempBaseDir)
 
 	// Since we're generating this manually we need to add the extension '.'
-	expectedFilePath := filepath.Join(tempBaseDir, testName+"_"+testAlias+"."+testExt)
+	expectedFilePath := filepath.Join(tempBaseDir, rootKeysSubdir, testName+"_"+testAlias+"."+testExt)
 
 	// Create our store
 	store, err := NewKeyFileStore(tempBaseDir, passphraseRetriever)
@@ -92,7 +92,7 @@ EMl3eFOJXjIch/wIesRSN+2dGOsl7neercjMh1i9RvpCwHDx/E0=
 	defer os.RemoveAll(tempBaseDir)
 
 	// Since we're generating this manually we need to add the extension '.'
-	filePath := filepath.Join(tempBaseDir, testName+"_"+testAlias+"."+testExt)
+	filePath := filepath.Join(tempBaseDir, rootKeysSubdir, testName+"_"+testAlias+"."+testExt)
 
 	os.MkdirAll(filepath.Dir(filePath), perms)
 	err = ioutil.WriteFile(filePath, testData, perms)
@@ -155,7 +155,7 @@ func TestGetDecryptedWithTamperedCipherText(t *testing.T) {
 	assert.NoError(t, err, "failed to add key to store")
 
 	// Since we're generating this manually we need to add the extension '.'
-	expectedFilePath := filepath.Join(tempBaseDir, privKey.ID()+"_"+testAlias+"."+testExt)
+	expectedFilePath := filepath.Join(tempBaseDir, rootKeysSubdir, privKey.ID()+"_"+testAlias+"."+testExt)
 
 	// Get file description, open file
 	fp, err := os.OpenFile(expectedFilePath, os.O_WRONLY, 0600)
@@ -262,7 +262,7 @@ func TestRemoveKey(t *testing.T) {
 	defer os.RemoveAll(tempBaseDir)
 
 	// Since we're generating this manually we need to add the extension '.'
-	expectedFilePath := filepath.Join(tempBaseDir, testName+"_"+testAlias+"."+testExt)
+	expectedFilePath := filepath.Join(tempBaseDir, nonRootKeysSubdir, testName+"_"+testAlias+"."+testExt)
 
 	// Create our store
 	store, err := NewKeyFileStore(tempBaseDir, passphraseRetriever)

--- a/trustmanager/keystore.go
+++ b/trustmanager/keystore.go
@@ -44,6 +44,8 @@ type KeyStore interface {
 	GetKey(name string) (data.PrivateKey, string, error)
 	ListKeys() map[string]string
 	RemoveKey(name string) error
+	ExportKey(name string) ([]byte, error)
+	ImportKey(pemBytes []byte, alias string) error
 }
 
 type cachedKey struct {


### PR DESCRIPTION
This leaves handling the `root_keys` and `tuf_keys` subdirectories to the `KeyFileStore` rather than having `KeyStoreManager` (which is going to be removed in the future) have a non-root `KeyFileStore` and a root `KeyFileStore`.

We cannot do away with the `root_keys` and `tuf_keys` subdirectory completely because we still have to be able to read repos in that format.  And if we see a `tuf_keys` subdirectory, we can't be sure if it's the old-style file structure, or if someone added a GUN that started with `tuf_keys`.

This also makes the following changes:
1. `KeyStore` now has `ImportKey` and `ExportKey` functions, so each `KeyStore` can decide for itself whether and how to import/export keys.
2. After discussion with @endophage, importing a root key now requires you to decrypt the key, to make sure that it's a valid key.  This makes the `ImportKey` function in `KeyStore` less ugly, because you don't have to provide the key ID.

Not sure how importing/exporting will work in the future if there are multiple `KeyStore`'s.