### PR TITLE
Private keys implement crypto.Signer

### DIFF
--- a/cryptoservice/certificate.go
+++ b/cryptoservice/certificate.go
@@ -1,10 +1,7 @@
 package cryptoservice
 
 import (
-	"crypto"
-	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 
@@ -15,28 +12,11 @@ import (
 // GenerateCertificate generates an X509 Certificate from a template, given a GUN
 func GenerateCertificate(rootKey data.PrivateKey, gun string) (*x509.Certificate, error) {
 
-	algorithm := rootKey.Algorithm()
-	var (
-		publicKey  crypto.PublicKey
-		privateKey crypto.PrivateKey
-		err        error
-	)
-	switch algorithm {
-	case data.RSAKey:
-		var rsaPrivateKey *rsa.PrivateKey
-		rsaPrivateKey, err = x509.ParsePKCS1PrivateKey(rootKey.Private())
-		privateKey = rsaPrivateKey
-		publicKey = rsaPrivateKey.Public()
-	case data.ECDSAKey:
-		var ecdsaPrivateKey *ecdsa.PrivateKey
-		ecdsaPrivateKey, err = x509.ParseECPrivateKey(rootKey.Private())
-		privateKey = ecdsaPrivateKey
-		publicKey = ecdsaPrivateKey.Public()
+	switch rootKey.(type) {
+	case *data.RSAPrivateKey, *data.ECDSAPrivateKey:
+		// go doesn't fall through
 	default:
-		return nil, fmt.Errorf("only RSA or ECDSA keys are currently supported. Found: %s", algorithm)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse root key: %s (%v)", gun, err)
+		return nil, fmt.Errorf("only bare RSA or ECDSA keys (not x509 variants) are currently supported. Found: %s", rootKey.Algorithm())
 	}
 
 	template, err := trustmanager.NewCertificate(gun)
@@ -44,7 +24,7 @@ func GenerateCertificate(rootKey data.PrivateKey, gun string) (*x509.Certificate
 		return nil, fmt.Errorf("failed to create the certificate template for: %s (%v)", gun, err)
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, rootKey.CryptoSigner().Public(), rootKey.CryptoSigner())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the certificate for: %s (%v)", gun, err)
 	}

--- a/cryptoservice/crypto_service_test.go
+++ b/cryptoservice/crypto_service_test.go
@@ -35,7 +35,7 @@ func testCryptoService(t *testing.T, keyAlgo string, verifier signed.Verifier) {
 	assert.Len(t, signatures, 1, "wrong number of signatures")
 
 	err = verifier.Verify(tufKey, signatures[0].Signature, content)
-	assert.NoError(t, err, "verification failed")
+	assert.NoError(t, err, "verification failed for %s key type", keyAlgo)
 
 	// Test GetKey
 	retrievedKey := cryptoService.GetKey(tufKey.ID())

--- a/signer/keydbstore.go
+++ b/signer/keydbstore.go
@@ -126,7 +126,10 @@ func (s *KeyDBStore) GetKey(name string) (data.PrivateKey, string, error) {
 
 	pubKey := data.NewPublicKey(dbPrivateKey.Algorithm, []byte(dbPrivateKey.Public))
 	// Create a new PrivateKey with unencrypted bytes
-	privKey := data.NewPrivateKey(pubKey, []byte(decryptedPrivKey))
+	privKey, err := data.NewPrivateKey(pubKey, []byte(decryptedPrivKey))
+	if err != nil {
+		return nil, "", err
+	}
 
 	// Add the key to cache
 	s.cachedKeys[privKey.ID()] = privKey

--- a/trustmanager/x509utils.go
+++ b/trustmanager/x509utils.go
@@ -325,7 +325,7 @@ func RSAToPrivateKey(rsaPrivKey *rsa.PrivateKey) (data.PrivateKey, error) {
 	rsaPrivBytes := x509.MarshalPKCS1PrivateKey(rsaPrivKey)
 
 	pubKey := data.NewRSAPublicKey(rsaPubBytes)
-	return data.NewRSAPrivateKey(*pubKey, rsaPrivBytes), nil
+	return data.NewRSAPrivateKey(pubKey, rsaPrivBytes)
 }
 
 // GenerateECDSAKey generates an ECDSA Private key and returns a TUF PrivateKey
@@ -383,7 +383,7 @@ func ECDSAToPrivateKey(ecdsaPrivKey *ecdsa.PrivateKey) (data.PrivateKey, error) 
 	}
 
 	pubKey := data.NewECDSAPublicKey(ecdsaPubBytes)
-	return data.NewECDSAPrivateKey(*pubKey, ecdsaPrivKeyBytes), nil
+	return data.NewECDSAPrivateKey(pubKey, ecdsaPrivKeyBytes)
 }
 
 // ED25519ToPrivateKey converts a serialized ED25519 key to a TUF
@@ -394,7 +394,7 @@ func ED25519ToPrivateKey(privKeyBytes []byte) (data.PrivateKey, error) {
 	}
 
 	pubKey := data.NewED25519PublicKey(privKeyBytes[:ed25519.PublicKeySize])
-	return data.NewED25519PrivateKey(*pubKey, privKeyBytes), nil
+	return data.NewED25519PrivateKey(*pubKey, privKeyBytes)
 }
 
 func blockType(k data.PrivateKey) (string, error) {

--- a/tuf/signed/ed25519.go
+++ b/tuf/signed/ed25519.go
@@ -60,7 +60,11 @@ func (e *Ed25519) Create(role, algorithm string) (data.PublicKey, error) {
 		return nil, err
 	}
 	public := data.NewED25519PublicKey(pub[:])
-	private := data.NewED25519PrivateKey(*public, priv[:])
+	private, err := data.NewED25519PrivateKey(*public, priv[:])
+	if err != nil {
+		return nil, err
+	}
+
 	e.addKey(private)
 	return public, nil
 }

--- a/tuf/signed/verifiers_test.go
+++ b/tuf/signed/verifiers_test.go
@@ -328,14 +328,13 @@ func TestECDSAVerifierOtherCurves(t *testing.T) {
 }
 
 func TestECDSAx509Verifier(t *testing.T) {
-	var testECDSAKey data.PrivateKey
 	var jsonKey bytes.Buffer
 
 	// Execute our template
 	templ, _ := template.New("KeyTemplate").Parse(baseECDSAx509Key)
 	templ.Execute(&jsonKey, KeyTemplate{KeyType: data.ECDSAx509Key})
 
-	testECDSAKey, err := data.UnmarshalPrivateKey(jsonKey.Bytes())
+	testECDSAKey, err := data.UnmarshalPublicKey(jsonKey.Bytes())
 	assert.NoError(t, err)
 
 	// Valid signature for message

--- a/tuf/signed/verifiers_test.go
+++ b/tuf/signed/verifiers_test.go
@@ -307,7 +307,8 @@ func TestECDSAVerifierOtherCurves(t *testing.T) {
 		assert.NoError(t, err, "failed to marshal private key")
 
 		testECDSAPubKey := data.NewECDSAPublicKey(ecdsaPubBytes)
-		testECDSAKey := data.NewECDSAPrivateKey(*testECDSAPubKey, ecdsaPrivKeyBytes)
+		testECDSAKey, err := data.NewECDSAPrivateKey(testECDSAPubKey, ecdsaPrivKeyBytes)
+		assert.NoError(t, err, "failed to read private key")
 
 		// Sign some data using ECDSA
 		message := []byte("test data for signing")


### PR DESCRIPTION
This builds on top of #243 to make all private key implementers also implement crypto.Signer. This moves towards making additional signing options much more modular as current the cryptoservice has to have at least some knowledge of the various signing mechanisms. This implementation allows us to push specifics of signing implementations into small cohesive types.

TODO:

* ~~New___PrivateKey functions need to return an error in case parsing of the private key fails.~~
* ~~#247 should be merged before this then we should update cryptoservice.Sign to call the private key signing functions.~~