### PR TITLE
Don't use elliptic.P224()

### DIFF
--- a/tuf/signed/verifiers_test.go
+++ b/tuf/signed/verifiers_test.go
@@ -293,7 +293,7 @@ func TestECDSAVerifier(t *testing.T) {
 }
 
 func TestECDSAVerifierOtherCurves(t *testing.T) {
-	curves := []elliptic.Curve{elliptic.P224(), elliptic.P256(), elliptic.P384(), elliptic.P521()}
+	curves := []elliptic.Curve{elliptic.P256(), elliptic.P384(), elliptic.P521()}
 
 	for _, curve := range curves {
 		ecdsaPrivKey, err := ecdsa.GenerateKey(curve, rand.Reader)

--- a/utils/tls_config_test.go
+++ b/utils/tls_config_test.go
@@ -31,7 +31,7 @@ func generateMultiCert(t *testing.T) string {
 
 	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.NoError(t, err)
-	ecKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	assert.NoError(t, err)
 	template, err := trustmanager.NewCertificate("gun")
 	assert.NoError(t, err)


### PR DESCRIPTION
This curve is not available on Fedora and RHEL systems, so removing the
reference allows tests to pass there.  Vast majority of the
curve-specific work is done in the golang crypto/elliptic package, so
this does not weaken the tests noticeably.

Signed-off-by: Miloslav Trmač <mitr@redhat.com>