### PR TITLE
Remove key ID from (notary key import-root)

### DIFF
--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -96,7 +96,7 @@ var cmdKeyImport = &cobra.Command{
 }
 
 var cmdKeyImportRoot = &cobra.Command{
-	Use:   "import-root [ keyID ] [ filename ]",
+	Use:   "import-root [ filename ]",
 	Short: "Imports root key.",
 	Long:  "imports a root key from a PEM file.",
 	Run:   keysImportRoot,
@@ -342,17 +342,12 @@ func keysImport(cmd *cobra.Command, args []string) {
 
 // keysImportRoot imports a root key from a PEM file
 func keysImportRoot(cmd *cobra.Command, args []string) {
-	if len(args) < 2 {
+	if len(args) != 1 {
 		cmd.Usage()
-		fatalf("must specify key ID and input filename for import")
+		fatalf("must specify input filename for import")
 	}
 
-	keyID := args[0]
-	importFilename := args[1]
-
-	if len(keyID) != idSize {
-		fatalf("please specify a valid root key ID")
-	}
+	importFilename := args[0]
 
 	parseConfig()
 
@@ -367,7 +362,7 @@ func keysImportRoot(cmd *cobra.Command, args []string) {
 	}
 	defer importFile.Close()
 
-	err = keyStoreManager.ImportRootKey(importFile, keyID)
+	err = keyStoreManager.ImportRootKey(importFile)
 
 	if err != nil {
 		fatalf("error importing root key: %v", err)

--- a/keystoremanager/import_export.go
+++ b/keystoremanager/import_export.go
@@ -101,10 +101,9 @@ func checkRootKeyIsEncrypted(pemBytes []byte) error {
 }
 
 // ImportRootKey imports a root in PEM format key from an io.Reader
-// The key's existing encryption is preserved. The keyID parameter is
-// necessary because otherwise we'd need the passphrase to decrypt the key
-// in order to compute the ID.
-func (km *KeyStoreManager) ImportRootKey(source io.Reader, keyID string) error {
+// It prompts for the key's passphrase to verify the data and to determine
+// the key ID.
+func (km *KeyStoreManager) ImportRootKey(source io.Reader) error {
 	pemBytes, err := ioutil.ReadAll(source)
 	if err != nil {
 		return err

--- a/keystoremanager/import_export_test.go
+++ b/keystoremanager/import_export_test.go
@@ -348,7 +348,7 @@ func TestImportExportRootKey(t *testing.T) {
 	keyReader, err := os.Open(tempKeyFilePath)
 	assert.NoError(t, err, "could not open key file")
 
-	err = repo2.KeyStoreManager.ImportRootKey(keyReader, rootKeyID)
+	err = repo2.KeyStoreManager.ImportRootKey(keyReader)
 	assert.NoError(t, err)
 	keyReader.Close()
 
@@ -368,11 +368,11 @@ func TestImportExportRootKey(t *testing.T) {
 	decryptedPEMBytes, err := trustmanager.KeyToPEM(privKey)
 	assert.NoError(t, err, "could not convert key to PEM")
 
-	err = repo2.KeyStoreManager.ImportRootKey(bytes.NewReader(decryptedPEMBytes), rootKeyID)
+	err = repo2.KeyStoreManager.ImportRootKey(bytes.NewReader(decryptedPEMBytes))
 	assert.EqualError(t, err, keystoremanager.ErrRootKeyNotEncrypted.Error())
 
 	// Try to import garbage and make sure it doesn't succeed
-	err = repo2.KeyStoreManager.ImportRootKey(strings.NewReader("this is not PEM"), rootKeyID)
+	err = repo2.KeyStoreManager.ImportRootKey(strings.NewReader("this is not PEM"))
 	assert.EqualError(t, err, keystoremanager.ErrNoValidPrivateKey.Error())
 
 	// Should be able to unlock the root key with the old password
@@ -429,7 +429,7 @@ func TestImportExportRootKeyReencrypt(t *testing.T) {
 	keyReader, err := os.Open(tempKeyFilePath)
 	assert.NoError(t, err, "could not open key file")
 
-	err = repo2.KeyStoreManager.ImportRootKey(keyReader, rootKeyID)
+	err = repo2.KeyStoreManager.ImportRootKey(keyReader)
 	assert.NoError(t, err)
 	keyReader.Close()
 


### PR DESCRIPTION
PR #242 has started requiring a passphrase for the imported key, and
recomputes the key ID, making the command-line argument redundant.  So,
remove it from the command line and from the KeyStoreManager API.

Also updates the comment for KeyStoreManager.ImportRootKey, and changes
(notary key import-root) to refuse unexpected arguments instead of
silently ignoring them.

Signed-off-by: Miloslav Trmač <mitr@redhat.com>