### PR TITLE
Fix (notary key export-root)

### DIFF
--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -26,7 +26,7 @@ func init() {
 	cmdKeyExport.Flags().StringVarP(&keysExportGUN, "gun", "g", "", "Globally unique name to export keys for")
 	cmdKey.AddCommand(cmdKeyExport)
 	cmdKey.AddCommand(cmdKeyExportRoot)
-	cmdKeyExportRoot.Flags().BoolVarP(&keysExportRootChangePassphrase, "change-passphrase", "c", false, "set a new passphrase for the key being exported")
+	cmdKeyExportRoot.Flags().BoolVarP(&keysExportRootChangePassphrase, "change-passphrase", "p", false, "set a new passphrase for the key being exported")
 	cmdKey.AddCommand(cmdKeyImport)
 	cmdKey.AddCommand(cmdKeyImportRoot)
 	cmdKey.AddCommand(cmdRotateKey)


### PR DESCRIPTION
-c was recently taken over by --configFile; using it for --change-passphrase as well results in

panic: shorthand redefinition

So, move --change-passphrase to -p.

Signed-off-by: Miloslav Trmač <mitr@redhat.com>