### PR TITLE
Update README to reflect go 1.5.1 requirement

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -15,7 +15,7 @@ COPY . /go/src/github.com/docker/notary
 WORKDIR /go/src/${NOTARYPKG}
 
 RUN go install \
-    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit `git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion `cat NOTARY_VERSION`" \
+    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
     ${NOTARYPKG}/cmd/notary-server
 
 ENTRYPOINT [ "notary-server" ]

--- a/Dockerfile.signer
+++ b/Dockerfile.signer
@@ -32,7 +32,7 @@ WORKDIR /go/src/${NOTARYPKG}
 
 # Install notary-signer
 RUN go install \
-    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit `git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion `cat NOTARY_VERSION`" \
+    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
     ${NOTARYPKG}/cmd/notary-signer
 
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Lets try using notary.
 
 Prerequisites:
 
-- Requirements from the [Compiling Notary Server](#compiling-notary-server) section
+- Requirements from the [Compiling Notary Server](#compiling-notary-server) section (such as go 1.5.1)
 - [docker and docker-compose](http://docs.docker.com/compose/install/)
 - [Notary server configuration](#configuring-notary-server)
 
@@ -125,7 +125,7 @@ OpenSSL example:
 
 Prerequisites:
 
-- Go >= 1.3
+- Go = 1.5.1
 - [godep](https://github.com/tools/godep) installed
 - libtool development headers installed
 


### PR DESCRIPTION
Also and add a target to the makefile to check the go version so we can avoid errors like in #244.