### PR TITLE
WIP: Removing _alias in a backwards compatible way

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -101,7 +101,7 @@ func testInitRepo(t *testing.T, rootType string) {
 	// Look for keys in root_keys
 	// There should be a file named after the key ID of the root key we
 	// passed in.
-	rootKeyFilename := rootKeyID + "_root.key"
+	rootKeyFilename := rootKeyID + ".key"
 	_, err = os.Stat(filepath.Join(tempBaseDir, "private", "root_keys", rootKeyFilename))
 	assert.NoError(t, err, "missing root key")
 

--- a/cryptoservice/certificate_test.go
+++ b/cryptoservice/certificate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnlockedSigner(t *testing.T) {
+func TestGenerateCertificate(t *testing.T) {
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err, "could not generate key")
 

--- a/cryptoservice/crypto_service_test.go
+++ b/cryptoservice/crypto_service_test.go
@@ -1,8 +1,9 @@
 package cryptoservice
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
@@ -26,7 +27,7 @@ func testCryptoService(t *testing.T, keyAlgo string, verifier signed.Verifier) {
 	cryptoService := NewCryptoService("", keyStore)
 
 	// Test Create
-	tufKey, err := cryptoService.Create("", keyAlgo)
+	tufKey, err := cryptoService.Create("root", keyAlgo)
 	assert.NoError(t, err, "error creating key")
 
 	// Test Sign

--- a/keystoremanager/import_export.go
+++ b/keystoremanager/import_export.go
@@ -128,7 +128,6 @@ func moveKeys(oldKeyStore, newKeyStore *trustmanager.KeyFileStore) error {
 		}
 
 		err = newKeyStore.AddKey(f, alias, privateKey)
-
 		if err != nil {
 			return err
 		}

--- a/keystoremanager/import_export_test.go
+++ b/keystoremanager/import_export_test.go
@@ -88,7 +88,7 @@ func TestImportExportZip(t *testing.T) {
 		if alias == "root" {
 			continue
 		}
-		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
+		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+".key")
 		passphraseByFile[relKeyPath] = exportPassphrase
 	}
 
@@ -113,7 +113,7 @@ func TestImportExportZip(t *testing.T) {
 		pemBytes, err := ioutil.ReadAll(rc)
 		assert.NoError(t, err, "could not read file from zip")
 
-		_, err = trustmanager.ParsePEMPrivateKey(pemBytes, expectedPassphrase)
+		_, _, err = trustmanager.ParsePEMPrivateKey(pemBytes, expectedPassphrase)
 		assert.NoError(t, err, "PEM not encrypted with the expected passphrase")
 
 		rc.Close()
@@ -159,7 +159,7 @@ func TestImportExportZip(t *testing.T) {
 		if alias == "root" {
 			continue
 		}
-		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
+		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+".key")
 		privKeyFileName := filepath.Join(tempBaseDir2, relKeyPath)
 		_, err = os.Stat(privKeyFileName)
 		assert.NoError(t, err, "missing private key: %s", privKeyName)
@@ -225,7 +225,7 @@ func TestImportExportGUN(t *testing.T) {
 		if alias == "root" {
 			continue
 		}
-		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
+		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+".key")
 
 		passphraseByFile[relKeyPath] = exportPassphrase
 	}
@@ -247,7 +247,7 @@ func TestImportExportGUN(t *testing.T) {
 		pemBytes, err := ioutil.ReadAll(rc)
 		assert.NoError(t, err, "could not read file from zip")
 
-		_, err = trustmanager.ParsePEMPrivateKey(pemBytes, expectedPassphrase)
+		_, _, err = trustmanager.ParsePEMPrivateKey(pemBytes, expectedPassphrase)
 		assert.NoError(t, err, "PEM not encrypted with the expected passphrase")
 
 		rc.Close()
@@ -294,7 +294,7 @@ func TestImportExportGUN(t *testing.T) {
 		if alias == "root" {
 			continue
 		}
-		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+"_"+alias+".key")
+		relKeyPath := filepath.Join("private", "tuf_keys", privKeyName+".key")
 		privKeyFileName := filepath.Join(tempBaseDir2, relKeyPath)
 		_, err = os.Stat(privKeyFileName)
 	}
@@ -362,9 +362,9 @@ func TestImportExportRootKey(t *testing.T) {
 	// doesn't succeed
 	pemBytes, err := ioutil.ReadFile(tempKeyFilePath)
 	assert.NoError(t, err, "could not read key file")
-	privKey, err := trustmanager.ParsePEMPrivateKey(pemBytes, oldPassphrase)
+	privKey, alias, err := trustmanager.ParsePEMPrivateKey(pemBytes, oldPassphrase)
 	assert.NoError(t, err, "could not decrypt key file")
-	decryptedPEMBytes, err := trustmanager.KeyToPEM(privKey)
+	decryptedPEMBytes, err := trustmanager.KeyToPEM(privKey, alias)
 	assert.NoError(t, err, "could not convert key to PEM")
 
 	err = repo2.KeyStoreManager.ImportRootKey(bytes.NewReader(decryptedPEMBytes))

--- a/signer/api/api_test.go
+++ b/signer/api/api_test.go
@@ -98,7 +98,7 @@ func TestDeleteKeyHandler(t *testing.T) {
 	cryptoService := cryptoservice.NewCryptoService("", keyStore)
 	setup(signer.CryptoServiceIndex{data.ED25519Key: cryptoService, data.RSAKey: cryptoService, data.ECDSAKey: cryptoService})
 
-	tufKey, _ := cryptoService.Create("", data.ED25519Key)
+	tufKey, _ := cryptoService.Create("timestamp", data.ED25519Key)
 	assert.NotNil(t, tufKey)
 
 	requestJson, _ := json.Marshal(&pb.KeyID{ID: tufKey.ID()})

--- a/signer/api/rpc_api.go
+++ b/signer/api/rpc_api.go
@@ -39,7 +39,7 @@ func (s *KeyManagementServer) CreateKey(ctx context.Context, algorithm *pb.Algor
 		return nil, fmt.Errorf("algorithm %s not supported for create key", algorithm.Algorithm)
 	}
 
-	tufKey, err := service.Create("", keyAlgo)
+	tufKey, err := service.Create("timestamp", keyAlgo)
 	if err != nil {
 		logger.Error("CreateKey: failed to create key: ", err)
 		return nil, grpc.Errorf(codes.Internal, "Key creation failed")

--- a/trustmanager/filestore.go
+++ b/trustmanager/filestore.go
@@ -91,6 +91,7 @@ func (f *SimpleFileStore) Remove(name string) error {
 	if err != nil {
 		return err
 	}
+
 	return os.Remove(filePath)
 }
 
@@ -118,6 +119,7 @@ func (f *SimpleFileStore) Get(name string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I've been fighting this for a while. Maintaining backwards compatibility involves always trying the new style of file, and attempting to fallback to the old one in case that one fails.

This part will get cleaner as soon as we stop supporting "_alias", and I'm happy with the way the code for keeping aliases in PEMs looks.

The major problem that I can't solve is the fact that to find a key in the filesystem given only the KeyID, we have to transverse all the files until we find the right one. Additionally, to get the Alias from a KeyID (since the alias was in the filename, and is now in the file itself) means also transversing all of the file system looking for the file so we can parse it and return the alias. This is super ugly, but the only ways I see around it is:

- Maintain a flat list of keys, instead of doing `path/gun/keyid.key`
- Maintain a file mapping IDs -> locations

Both of those solutions are super ugly too.

@cyli 

Also, I can't seem to make ImportExport work.

Signed-off-by: Diogo Monica <diogo@docker.com>