### PR TITLE
Certificate rotation

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -142,8 +142,9 @@ func ValidateRoot(certStore trustmanager.X509Store, root *data.Signed, gun strin
 	return nil
 }
 
-// validRootLeafCerts returns a list of non-exipired, non-sha1 certificates whose
-// Common-Names match the provided GUN
+// validRootLeafCerts returns a list of non-expired, non-sha1 certificates
+// found in root whoose Common-Names match the provided GUN. Note that this
+// "validity" alone does not imply any measure of trust.
 func validRootLeafCerts(root *data.SignedRoot, gun string) ([]*x509.Certificate, error) {
 	// Get a list of all of the leaf certificates present in root
 	allLeafCerts, _ := parseAllCerts(root)

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -55,7 +55,8 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts := []*x509.Certificate{cert1}
 	newCerts := []*x509.Certificate{cert2}
 
-	certificates := certsToRemove(oldCerts, newCerts)
+	certificates, err := certsToRemove(oldCerts, newCerts)
+	assert.NoError(t, err)
 	assert.Len(t, certificates, 1)
 	_, ok := certificates[cert1KeyID]
 	assert.True(t, ok)
@@ -64,7 +65,8 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts = []*x509.Certificate{cert1, cert2}
 	newCerts = []*x509.Certificate{cert3}
 
-	certificates = certsToRemove(oldCerts, newCerts)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	assert.NoError(t, err)
 	assert.Len(t, certificates, 2)
 	_, ok = certificates[cert1KeyID]
 	assert.True(t, ok)
@@ -77,7 +79,8 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts = []*x509.Certificate{cert3}
 	newCerts = []*x509.Certificate{cert2, cert1}
 
-	certificates = certsToRemove(oldCerts, newCerts)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	assert.NoError(t, err)
 	assert.Len(t, certificates, 1)
 	_, ok = certificates[cert3KeyID]
 	assert.True(t, ok)
@@ -90,20 +93,15 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts = []*x509.Certificate{cert1, cert2, cert3}
 	newCerts = []*x509.Certificate{}
 
-	certificates = certsToRemove(oldCerts, newCerts)
-	assert.Len(t, certificates, 0)
-	_, ok = certificates[cert1KeyID]
-	assert.False(t, ok)
-	_, ok = certificates[cert2KeyID]
-	assert.False(t, ok)
-	_, ok = certificates[cert3KeyID]
-	assert.False(t, ok)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	assert.Error(t, err)
 
 	// Call CertsToRemove with three new certificates and no old
 	oldCerts = []*x509.Certificate{}
 	newCerts = []*x509.Certificate{cert1, cert2, cert3}
 
-	certificates = certsToRemove(oldCerts, newCerts)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	assert.NoError(t, err)
 	assert.Len(t, certificates, 0)
 	_, ok = certificates[cert1KeyID]
 	assert.False(t, ok)

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -295,7 +295,7 @@ func testValidateSuccessfulRootRotation(t *testing.T, keyAlg, rootKeyType string
 	signedTestRoot, err := testRoot.ToSigned()
 	assert.NoError(t, err)
 
-	err = signed.Sign(cs, signedTestRoot, []data.PublicKey{replRootKey, origRootKey})
+	err = signed.Sign(cs, signedTestRoot, []data.PublicKey{replRootKey, origRootKey}, 2)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -351,7 +351,7 @@ func testValidateRootRotationMissingOrigSig(t *testing.T, keyAlg, rootKeyType st
 	assert.NoError(t, err)
 
 	// We only sign with the new key, and not with the original one.
-	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{replRootKey})
+	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{replRootKey}, 1)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -410,7 +410,7 @@ func testValidateRootRotationMissingNewSig(t *testing.T, keyAlg, rootKeyType str
 	assert.NoError(t, err)
 
 	// We only sign with the old key, and not with the new one
-	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{origRootKey})
+	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{origRootKey}, 1)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -295,7 +295,7 @@ func testValidateSuccessfulRootRotation(t *testing.T, keyAlg, rootKeyType string
 	signedTestRoot, err := testRoot.ToSigned()
 	assert.NoError(t, err)
 
-	err = signed.Sign(cs, signedTestRoot, replRootKey, origRootKey)
+	err = signed.Sign(cs, signedTestRoot, []data.PublicKey{replRootKey, origRootKey})
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -351,7 +351,7 @@ func testValidateRootRotationMissingOrigSig(t *testing.T, keyAlg, rootKeyType st
 	assert.NoError(t, err)
 
 	// We only sign with the new key, and not with the original one.
-	err = signed.Sign(cryptoService, signedTestRoot, replRootKey)
+	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{replRootKey})
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -410,7 +410,7 @@ func testValidateRootRotationMissingNewSig(t *testing.T, keyAlg, rootKeyType str
 	assert.NoError(t, err)
 
 	// We only sign with the old key, and not with the new one
-	err = signed.Sign(cryptoService, signedTestRoot, origRootKey)
+	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{origRootKey})
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -295,7 +295,7 @@ func testValidateSuccessfulRootRotation(t *testing.T, keyAlg, rootKeyType string
 	signedTestRoot, err := testRoot.ToSigned()
 	assert.NoError(t, err)
 
-	err = signed.Sign(cs, signedTestRoot, []data.PublicKey{replRootKey, origRootKey}, 2)
+	err = signed.Sign(cs, signedTestRoot, []data.PublicKey{replRootKey, origRootKey}, 2, nil)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -351,7 +351,7 @@ func testValidateRootRotationMissingOrigSig(t *testing.T, keyAlg, rootKeyType st
 	assert.NoError(t, err)
 
 	// We only sign with the new key, and not with the original one.
-	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{replRootKey}, 1)
+	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{replRootKey}, 1, nil)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -410,7 +410,7 @@ func testValidateRootRotationMissingNewSig(t *testing.T, keyAlg, rootKeyType str
 	assert.NoError(t, err)
 
 	// We only sign with the old key, and not with the new one
-	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{origRootKey}, 1)
+	err = signed.Sign(cryptoService, signedTestRoot, []data.PublicKey{origRootKey}, 1, nil)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM

--- a/client/changelist/change.go
+++ b/client/changelist/change.go
@@ -38,8 +38,10 @@ type TufChange struct {
 // TufRootData represents a modification of the keys associated
 // with a role that appears in the root.json
 type TufRootData struct {
-	Keys     data.KeyList `json:"keys"`
-	RoleName string       `json:"role"`
+	ReplaceKeys data.KeyList `json:"keys"`
+	AddKeys     data.KeyList `json:"add_keys, omitempty"`
+	RemoveKeys  []string     `json:"remove_keys,omitempty"`
+	RoleName    string       `json:"role"`
 }
 
 // NewTufChange initializes a tufChange object

--- a/client/client.go
+++ b/client/client.go
@@ -160,7 +160,10 @@ func NewTarget(targetName string, targetPath string) (*Target, error) {
 }
 
 // Initialize creates a new repository by using rootKey as the root Key for the
-// TUF repository.
+// TUF repository. The server must be reachable (and is asked to generate a
+// timestamp key and possibly other serverManagedRoles), but the created repository
+// result is only stored on local disk, not published to the server. To do that,
+// use r.Publish() eventually.
 func (r *NotaryRepository) Initialize(rootKeyID string, serverManagedRoles ...string) error {
 	privKey, _, err := r.CryptoService.GetPrivateKey(rootKeyID)
 	if err != nil {
@@ -650,9 +653,10 @@ func (r *NotaryRepository) publish(cl changelist.Changelist) error {
 	return remote.SetMultiMeta(updatedFiles)
 }
 
-// bootstrapRepo loads the repository from the local file system.  This attempts
-// to load metadata for all roles.  Since server snapshots are supported,
-// if the snapshot metadata fails to load, that's ok.
+// bootstrapRepo loads the repository from the local file system (i.e.
+// a not yet published repo or a possibly obsolete local copy) into
+// r.tufRepo.  This attempts to load metadata for all roles.  Since server
+// snapshots are supported, if the snapshot metadata fails to load, that's ok.
 // This can also be unified with some cache reading tools from tuf/client.
 // This assumes that bootstrapRepo is only used by Publish() or RotateKey()
 func (r *NotaryRepository) bootstrapRepo() error {
@@ -700,6 +704,8 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	return nil
 }
 
+// saveMetadata saves contents of r.tufRepo onto the local disk, creating
+// signatures as necessary, possibly prompting for passphrases.
 func (r *NotaryRepository) saveMetadata(ignoreSnapshot bool) error {
 	logrus.Debugf("Saving changes to Trusted Collection.")
 
@@ -782,6 +788,20 @@ func (r *NotaryRepository) Update(forWrite bool) (*tufclient.Client, error) {
 // we should always attempt to contact the server to determine if the repository
 // is initialized or not. If set to true, we will always attempt to download
 // and return an error if the remote repository errors.
+//
+// Partially populates r.tufRepo with this root metadata (only; use
+// tufclient.Client.Update to load the rest).
+//
+// As another side effect, r.CertManager's list of trusted certificates
+// is updated with data from the loaded root.json.
+//
+// Fails if the remote server is reachable and does not know the repo
+// (i.e. before the first r.Publish()), in which case the error is
+// store.ErrMetaNotFound, or if the root metadata (from whichever source is used)
+// is not trusted.
+//
+// Returns a tufclient.Client for the remote server, which may not be actually
+// operational (if the URL is invalid but a root.json is cached).
 func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Client, error) {
 	var (
 		rootJSON   []byte

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -942,8 +943,8 @@ func (r *NotaryRepository) rootFileKeyChange(cl changelist.Changelist, role, act
 	kl := make(data.KeyList, 0, 1)
 	kl = append(kl, key)
 	meta := changelist.TufRootData{
-		RoleName: role,
-		Keys:     kl,
+		RoleName:    role,
+		ReplaceKeys: kl,
 	}
 	metaJSON, err := json.Marshal(meta)
 	if err != nil {
@@ -982,4 +983,94 @@ func (r *NotaryRepository) DeleteTrustData() error {
 		}
 	}
 	return nil
+}
+
+// ListRootCerts returns current trusted root certificates.
+// (In particular, not old certificates which we have already
+// rotated from but are still using for signing to allow rollover,
+// even if they are still trusted locally.)
+func (r *NotaryRepository) ListRootCerts() ([]*x509.Certificate, error) {
+	_, err := r.Update(false)
+	if err != nil {
+		return nil, err
+	}
+
+	keyIDs := r.tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs
+	certs := make([]*x509.Certificate, 0, len(keyIDs))
+	for _, keyID := range keyIDs {
+		// r.tufRepo contains all data from root.json, which may include irrelevant
+		// certificates.  This is handled by certs.ValidateRoot, which adds
+		// only the real trusted certificates into the store.  So, this lookup by ID is not
+		// just a dumb way to not parse the certificate, the handling of ErrNoCertificatesFound
+		// ensures we only get the intersection of (certificates in current root.json) with
+		// (locally trusted certificates). The rotation code in certs.ValidateRoot ensures
+		// that we locally store a copy of all relevant certificates.
+		cert, err := r.CertStore.GetCertificateByCertID(keyID)
+		if err == nil {
+			certs = append(certs, cert)
+		} else if _, ok := err.(*trustmanager.ErrNoCertificatesFound); !ok {
+			return nil, err
+		}
+	}
+	return certs, nil
+}
+
+// RotateRootCert generates a new certificate to replace oldCert and adds
+// a changelist entry to update the root role with this certificate replacement
+// shen r.Publish() is called.
+func (r *NotaryRepository) RotateRootCert(oldCert *x509.Certificate) error {
+	oldCertX509PublicKey := trustmanager.CertToKey(oldCert)
+	if oldCertX509PublicKey == nil {
+		return fmt.Errorf("invalid format for root key: %s", oldCert.PublicKeyAlgorithm)
+	}
+	rootKeyID, err := trustmanager.X509PublicKeyID(oldCertX509PublicKey)
+	if err != nil {
+		return err
+	}
+
+	privKey, _, err := r.CryptoService.GetPrivateKey(rootKeyID)
+	if err != nil {
+		return err
+	}
+
+	// Hard-coded policy: the generated certificate expires in 10 years.
+	startTime := time.Now()
+	newCert, err := cryptoservice.GenerateCertificate(privKey, r.gun, startTime, startTime.AddDate(10, 0, 0))
+	if err != nil {
+		return err
+	}
+	newCertX509PublicKey := trustmanager.CertToKey(newCert)
+	if newCertX509PublicKey == nil {
+		return fmt.Errorf("cannot use regenerated certificate?! format %s", newCert.PublicKeyAlgorithm)
+	}
+
+	cl, err := changelist.NewFileChangelist(filepath.Join(r.tufRepoPath, "changelist"))
+	if err != nil {
+		return err
+	}
+	defer cl.Close()
+
+	// Not changelist.ActionCreate/ReplaceKeys, which would drop other certificates.
+	meta := changelist.TufRootData{
+		RoleName:   data.CanonicalRootRole,
+		AddKeys:    []data.PublicKey{newCertX509PublicKey},
+		RemoveKeys: []string{oldCertX509PublicKey.ID()},
+	}
+	metaJSON, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	c := changelist.NewTufChange(
+		changelist.ActionUpdate,
+		changelist.ScopeRoot,
+		changelist.TypeRootRole,
+		data.CanonicalRootRole,
+		metaJSON,
+	)
+	return cl.Add(c)
+
+	// Note that we don't need to worry about updating r.CertStore (and synchronizing
+	// this with the r.Publish() call; after we push the new root.json to the server,
+	// calls to r.Update() will cause this client to rotate certificates in r.CertStore
+	// just as other clients do.
 }

--- a/client/client.go
+++ b/client/client.go
@@ -634,7 +634,7 @@ func (r *NotaryRepository) publish(cl changelist.Changelist) error {
 	if err == nil {
 		// Only update the snapshot if we've successfully signed it.
 		updatedFiles[data.CanonicalSnapshotRole] = snapshotJSON
-	} else if _, ok := err.(signed.ErrNoKeys); ok {
+	} else if signErr, ok := err.(signed.ErrInsufficientSignatures); ok && signErr.FoundKeys == 0 {
 		// If signing fails due to us not having the snapshot key, then
 		// assume the server is going to sign, and do not include any snapshot
 		// data.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	regJson "encoding/json"
 	"fmt"
@@ -3338,4 +3339,135 @@ func TestListRoles(t *testing.T) {
 	rolesWithSigs, err = repo.ListRoles()
 	require.NoError(t, err)
 	require.Len(t, rolesWithSigs, len(data.BaseRoles)+2)
+}
+
+func logRepoTrustRoot(t *testing.T, prefix string, repo *NotaryRepository) {
+	logrus.Debugf("==== %s", prefix)
+	root := repo.tufRepo.Root
+	logrus.Debugf("Root signatures:")
+	for _, s := range root.Signatures {
+		logrus.Debugf("\t%s", s.KeyID)
+	}
+	logrus.Debugf("Valid root keys:")
+	for _, k := range root.Signed.Roles[data.CanonicalRootRole].KeyIDs {
+		logrus.Debugf("\t%s", k)
+	}
+	logrus.Debugf("All trusted certs:")
+	certs, err := repo.CertStore.GetCertificatesByCN(repo.gun)
+	require.NoError(t, err)
+	for _, cert := range certs {
+		id, err := trustmanager.FingerprintCert(cert)
+		require.NoError(t, err)
+		logrus.Debugf("\t%s", id)
+	}
+}
+
+// ID of the (only) certificate trusted by the root role metadata
+func rootRoleCertID(t *testing.T, repo *NotaryRepository) string {
+	rootKeys := repo.tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs
+	require.Len(t, rootKeys, 1)
+	return rootKeys[0]
+}
+
+func verifyOnlyTrustedCertificate(t *testing.T, repo *NotaryRepository, certID string) {
+	certs, err := repo.CertStore.GetCertificatesByCN(repo.gun)
+	require.NoError(t, err)
+	require.Len(t, certs, 1)
+	id, err := trustmanager.FingerprintCert(certs[0])
+	require.NoError(t, err)
+	require.Equal(t, certID, id)
+}
+
+func TestRotateRootCert(t *testing.T) {
+	ts := fullTestServer(t)
+	defer ts.Close()
+
+	// Set up author's view of the repo and publish first version.
+	authorRepo, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary", ts.URL, false)
+	defer os.RemoveAll(authorRepo.baseDir)
+	err := authorRepo.Publish()
+	require.NoError(t, err)
+	oldRootCertID := rootRoleCertID(t, authorRepo)
+
+	// Initialize an user, using the original certificate.
+	userRepo, _ := newRepoToTestRepo(t, authorRepo, true)
+	defer os.RemoveAll(userRepo.baseDir)
+	_, err = userRepo.Update(false)
+	require.NoError(t, err)
+
+	// Rotate root certificate.
+	certs, err := authorRepo.ListRootCerts()
+	require.NoError(t, err)
+	var cert *x509.Certificate
+	require.Len(t, certs, 1)
+	// Just get the only certificate in there.
+	for _, c := range certs {
+		cert = c
+	}
+	logRepoTrustRoot(t, "original", authorRepo)
+	err = authorRepo.RotateRootCert(cert)
+	require.NoError(t, err)
+	logRepoTrustRoot(t, "post-rotate", authorRepo)
+
+	// Set up a target to verify the repo is actually usable.
+	publishedTarget := addTarget(t, authorRepo, "current", "../fixtures/intermediate-ca.crt")
+
+	// Publish the rotation
+	logRepoTrustRoot(t, "pre-publish", authorRepo)
+	err = authorRepo.Publish()
+	require.NoError(t, err)
+	logRepoTrustRoot(t, "post-publish", authorRepo)
+	newRootCertID := rootRoleCertID(t, authorRepo)
+	require.NotEqual(t, oldRootCertID, newRootCertID)
+
+	// Verify the user can use the rotated repo, and see the added target.
+	receivedTarget, err := userRepo.GetTargetByName("current")
+	require.NoError(t, err)
+	require.Equal(t, newRootCertID, rootRoleCertID(t, userRepo))
+	require.True(t, reflect.DeepEqual(*publishedTarget, receivedTarget.Target), "target does not match")
+	logRepoTrustRoot(t, "client", userRepo)
+
+	// Verify that clients initialized post-rotation can use the repo, and use
+	// the new certificate immediately.
+	freshUserRepo, _ := newRepoToTestRepo(t, authorRepo, true)
+	defer os.RemoveAll(freshUserRepo.baseDir)
+	receivedTarget, err = freshUserRepo.GetTargetByName("current")
+	require.NoError(t, err)
+	require.Equal(t, newRootCertID, rootRoleCertID(t, freshUserRepo))
+	verifyOnlyTrustedCertificate(t, freshUserRepo, newRootCertID)
+	require.True(t, reflect.DeepEqual(*publishedTarget, receivedTarget.Target), "target does not match")
+	logRepoTrustRoot(t, "fresh client", freshUserRepo)
+
+	// NotaryRepository.Update's handling of certificate rotation is weird:
+	//
+	// On every run, NotaryRepository.bootstrapClient rotates the trusted certificates
+	// based on CACHED root data.
+	// Then the client calls Repo.Update, which fetches a new timestmap,
+	// notices an updated root.json, validates it and stores it into the cache.
+	//
+	// So, the locally trusted certificates are rotated only on the SECOND call of
+	// NotaryRepository.Update after the rotation is pushed to the server.
+	//
+	// This would be nice to fix eventually (breaking down the NotaryRepository.Update
+	// / Repo.Update separation which causes this), but for now, just ensure that the
+	// second update does result in updated certificates.
+
+	// Verify that the author eventually rotates to the new certificate.
+	_, err = authorRepo.Update(false)
+	require.NoError(t, err)
+	logRepoTrustRoot(t, "author refresh 1", authorRepo)
+	require.Equal(t, newRootCertID, rootRoleCertID(t, authorRepo))
+	// verifyOnlyTrustedCertificate(t, authorRepo, newRootCertID)
+	_, err = authorRepo.Update(false)
+	require.NoError(t, err)
+	logRepoTrustRoot(t, "author refresh 2", authorRepo)
+	require.Equal(t, newRootCertID, rootRoleCertID(t, authorRepo))
+	verifyOnlyTrustedCertificate(t, authorRepo, newRootCertID)
+
+	// Verify that the user initialized with the original certificate eventually
+	// rotates to the new certificate.
+	_, err = userRepo.Update(false)
+	require.NoError(t, err)
+	logRepoTrustRoot(t, "user refresh 1", userRepo)
+	require.Equal(t, newRootCertID, rootRoleCertID(t, userRepo))
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -180,7 +180,21 @@ func applyRootRoleChange(repo *tuf.Repo, c changelist.Change) error {
 		if err != nil {
 			return err
 		}
-		err = repo.ReplaceBaseKeys(d.RoleName, d.Keys...)
+		err = repo.ReplaceBaseKeys(d.RoleName, d.ReplaceKeys...)
+		if err != nil {
+			return err
+		}
+	case changelist.ActionUpdate:
+		d := &changelist.TufRootData{}
+		err := json.Unmarshal(c.Content(), d)
+		if err != nil {
+			return err
+		}
+		err = repo.AddBaseKeys(d.RoleName, d.AddKeys...)
+		if err != nil {
+			return err
+		}
+		err = repo.RemoveBaseKeys(d.RoleName, d.RemoveKeys...)
 		if err != nil {
 			return err
 		}

--- a/cmd/notary/cert.go
+++ b/cmd/notary/cert.go
@@ -25,6 +25,12 @@ var cmdCertListTemplate = usageTemplate{
 	Long:  "Lists root certificates known to notary.",
 }
 
+var cmdCertRotateTemplate = &usageTemplate{
+	Use:   "rotate [ GUN ]",
+	Short: "Rotate certificates for a role.",
+	Long:  "Generates new certificates for the given role (without replacing the root key).",
+}
+
 var cmdCertRemoveTemplate = usageTemplate{
 	Use:   "remove [ certID ]",
 	Short: "Removes the certificate with the given cert ID.",
@@ -44,6 +50,7 @@ type certCommander struct {
 func (c *certCommander) GetCommand() *cobra.Command {
 	cmd := cmdCertTemplate.ToCommand(nil)
 	cmd.AddCommand(cmdCertListTemplate.ToCommand(c.certList))
+	cmd.AddCommand(cmdCertRotateTemplate.ToCommand(c.certRotate))
 
 	cmdCertRemove := cmdCertRemoveTemplate.ToCommand(c.certRemove)
 	cmdCertRemove.Flags().StringVarP(
@@ -156,6 +163,51 @@ func (c *certCommander) certRemove(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+	return nil
+}
+
+// certRotate replaces a certificate with a new version
+func (c *certCommander) certRotate(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		cmd.Usage()
+		return fmt.Errorf("Must specify a GUN")
+	}
+
+	gun := args[0]
+	config, err := c.configGetter()
+	if err != nil {
+		return err
+	}
+
+	rt, err := getTransport(config, gun, false)
+	if err != nil {
+		return err
+	}
+	nRepo, err := notaryclient.NewNotaryRepository(config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, c.retriever)
+	if err != nil {
+		return err
+	}
+
+	certs, err := nRepo.ListRootCerts()
+	if err != nil {
+		return err
+	}
+
+	for _, cert := range certs {
+		err := nRepo.RotateRootCert(cert)
+		if err != nil {
+			id, err := trustmanager.FingerprintCert(cert)
+			if err != nil {
+				return fmt.Errorf("Could not fingerprint certificate: %v", err)
+			}
+			return fmt.Errorf("Error rotating certificate %s: %s", id, err)
+		}
+	}
+
+	cmd.Printf(
+		"Rotation of the following certificates into repository \"%s\" staged for next publish.\n",
+		gun)
+	prettyPrintCerts(certs, cmd.Out())
 	return nil
 }
 

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -1379,6 +1379,75 @@ func TestClientKeyPassphraseChange(t *testing.T) {
 	assert.Equal(t, rootID, rootIDs[0])
 }
 
+func TestCertRotate(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	// -- setup --
+	setUp(t)
+
+	authorTempDir := tempDirWithConfig(t, "{}")
+	defer os.RemoveAll(authorTempDir)
+	userTempDir := tempDirWithConfig(t, "{}")
+	defer os.RemoveAll(userTempDir)
+
+	server := setupServer()
+	defer server.Close()
+
+	// init repo
+	_, err := runCommand(t, authorTempDir, "-s", server.URL, "init", "gun")
+	assert.NoError(t, err)
+	certs := assertNumCerts(t, authorTempDir, 1)
+	oldCertID := strings.Fields(certs[0])[1]
+
+	// publish repo
+	_, err = runCommand(t, authorTempDir, "-s", server.URL, "publish", "gun")
+	assert.NoError(t, err)
+
+	// init user
+	_, err = runCommand(t, userTempDir, "-s", server.URL, "list", "gun")
+	assert.NoError(t, err)
+	certs = assertNumCerts(t, userTempDir, 1)
+	assert.Equal(t, oldCertID, strings.Fields(certs[0])[1])
+
+	// schedule root cert rotation
+	output, err := runCommand(t, authorTempDir, "-s", server.URL, "cert", "rotate", "gun")
+	assert.NoError(t, err)
+	assert.Contains(t, output, oldCertID)
+
+	// check status - see target
+	output, err = runCommand(t, authorTempDir, "status", "gun")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "root")
+
+	// publish repo
+	_, err = runCommand(t, authorTempDir, "-s", server.URL, "publish", "gun")
+	assert.NoError(t, err)
+
+	// check status - no targets
+	output, err = runCommand(t, authorTempDir, "status", "gun")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "No unpublished changes for gun")
+
+	// check the other user can use the updated repo
+	_, err = runCommand(t, userTempDir, "-s", server.URL, "list", "gun")
+	assert.NoError(t, err)
+
+	// See the comment in TestRotateRootCert for why we need to cause two refreshes
+	// to see the updated certificate.
+	_, err = runCommand(t, authorTempDir, "-s", server.URL, "list", "gun")
+	assert.NoError(t, err)
+	certs = assertNumCerts(t, authorTempDir, 1)
+	_, err = runCommand(t, authorTempDir, "-s", server.URL, "list", "gun")
+	assert.NoError(t, err)
+	certs = assertNumCerts(t, authorTempDir, 1)
+	newCertID := strings.Fields(certs[0])[1]
+	assert.NotEqual(t, oldCertID, newCertID)
+
+	_, err = runCommand(t, userTempDir, "-s", server.URL, "list", "gun")
+	assert.NoError(t, err)
+	certs = assertNumCerts(t, userTempDir, 1)
+	assert.Equal(t, newCertID, strings.Fields(certs[0])[1])
+}
+
 func tempDirWithConfig(t *testing.T, config string) string {
 	tempDir, err := ioutil.TempDir("", "repo")
 	assert.NoError(t, err)

--- a/cryptoservice/crypto_service_test.go
+++ b/cryptoservice/crypto_service_test.go
@@ -97,7 +97,7 @@ func (c CryptoServiceTester) TestGetNonexistentKey(t *testing.T) {
 	_, _, err := cryptoService.GetPrivateKey("boguskeyid")
 	assert.Error(t, err)
 	// The underlying error has been correctly propagated.
-	_, ok := err.(*trustmanager.ErrKeyNotFound)
+	_, ok := err.(trustmanager.ErrKeyNotFound)
 	assert.True(t, ok)
 }
 

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -190,7 +190,7 @@ func TestValidateRootRotation(t *testing.T) {
 
 	r, err = repo.SignRoot(data.DefaultExpires(data.CanonicalRootRole))
 	assert.NoError(t, err)
-	err = signed.Sign(crypto, r, []data.PublicKey{rootKey, oldRootKey}, 2)
+	err = signed.Sign(crypto, r, []data.PublicKey{rootKey, oldRootKey}, 2, nil)
 	assert.NoError(t, err)
 
 	rt, err := data.RootFromSigned(r)

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -183,7 +183,7 @@ func TestValidateRootRotation(t *testing.T) {
 
 	r, err = repo.SignRoot(data.DefaultExpires(data.CanonicalRootRole))
 	assert.NoError(t, err)
-	err = signed.Sign(crypto, r, rootKey, oldRootKey)
+	err = signed.Sign(crypto, r, []data.PublicKey{rootKey, oldRootKey})
 	assert.NoError(t, err)
 
 	rt, err := data.RootFromSigned(r)

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -114,7 +114,7 @@ func createSnapshot(gun string, sn *data.SignedSnapshot, store storage.MetaStore
 	if err != nil {
 		return nil, 0, err
 	}
-	err = signed.Sign(cryptoService, out, key)
+	err = signed.Sign(cryptoService, out, []data.PublicKey{key})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -114,7 +114,7 @@ func createSnapshot(gun string, sn *data.SignedSnapshot, store storage.MetaStore
 	if err != nil {
 		return nil, 0, err
 	}
-	err = signed.Sign(cryptoService, out, []data.PublicKey{key}, 1)
+	err = signed.Sign(cryptoService, out, []data.PublicKey{key}, 1, nil)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -114,7 +114,7 @@ func createSnapshot(gun string, sn *data.SignedSnapshot, store storage.MetaStore
 	if err != nil {
 		return nil, 0, err
 	}
-	err = signed.Sign(cryptoService, out, []data.PublicKey{key})
+	err = signed.Sign(cryptoService, out, []data.PublicKey{key}, 1)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -139,7 +139,7 @@ func CreateTimestamp(gun string, prev *data.SignedTimestamp, snapshot []byte, st
 		Signatures: ts.Signatures,
 		Signed:     &sgndTs,
 	}
-	err = signed.Sign(cryptoService, out, key)
+	err = signed.Sign(cryptoService, out, []data.PublicKey{key})
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -139,7 +139,7 @@ func CreateTimestamp(gun string, prev *data.SignedTimestamp, snapshot []byte, st
 		Signatures: ts.Signatures,
 		Signed:     &sgndTs,
 	}
-	err = signed.Sign(cryptoService, out, []data.PublicKey{key})
+	err = signed.Sign(cryptoService, out, []data.PublicKey{key}, 1)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -139,7 +139,7 @@ func CreateTimestamp(gun string, prev *data.SignedTimestamp, snapshot []byte, st
 		Signatures: ts.Signatures,
 		Signed:     &sgndTs,
 	}
-	err = signed.Sign(cryptoService, out, []data.PublicKey{key}, 1)
+	err = signed.Sign(cryptoService, out, []data.PublicKey{key}, 1, nil)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/signer/keydbstore/keydbstore.go
+++ b/signer/keydbstore/keydbstore.go
@@ -117,7 +117,7 @@ func (s *KeyDBStore) GetKey(name string) (data.PrivateKey, string, error) {
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return nil, "", trustmanager.ErrKeyNotFound{}
+		return nil, "", trustmanager.ErrKeyNotFound{KeyID: name}
 	}
 
 	// Get the passphrase to use for this key
@@ -165,7 +165,7 @@ func (s *KeyDBStore) RemoveKey(keyID string) error {
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: keyID}).First(&dbPrivateKey).RecordNotFound() {
-		return trustmanager.ErrKeyNotFound{}
+		return trustmanager.ErrKeyNotFound{KeyID: keyID}
 	}
 
 	// Delete the key from the database
@@ -179,7 +179,7 @@ func (s *KeyDBStore) RotateKeyPassphrase(name, newPassphraseAlias string) error 
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return trustmanager.ErrKeyNotFound{}
+		return trustmanager.ErrKeyNotFound{KeyID: name}
 	}
 
 	// Get the current passphrase to use for this key

--- a/trustmanager/keyfilestore.go
+++ b/trustmanager/keyfilestore.go
@@ -361,7 +361,7 @@ func getKeyRole(s LimitedFileStore, keyID string) (string, bool, error) {
 		}
 	}
 
-	return "", false, &ErrKeyNotFound{KeyID: keyID}
+	return "", false, ErrKeyNotFound{KeyID: keyID}
 }
 
 // GetKey returns the PrivateKey given a KeyID

--- a/trustmanager/keystore.go
+++ b/trustmanager/keystore.go
@@ -43,6 +43,8 @@ type KeyStore interface {
 	// AddKey adds a key to the KeyStore, and if the key already exists,
 	// succeeds.  Otherwise, returns an error if it cannot add.
 	AddKey(keyInfo KeyInfo, privKey data.PrivateKey) error
+	// Should fail with ErrKeyNotFound if the keystore is operating normally
+	// and knows that it does not store the requested key.
 	GetKey(keyID string) (data.PrivateKey, string, error)
 	GetKeyInfo(keyID string) (KeyInfo, error)
 	ListKeys() map[string]KeyInfo

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -60,7 +60,7 @@ func TestRotation(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey, replacementKey})
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey, replacementKey}, 2)
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -122,7 +122,7 @@ func TestRotationNewSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey})
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey}, 1)
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -185,7 +185,7 @@ func TestRotationOldSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, []data.PublicKey{replacementKey})
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{replacementKey}, 1)
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -60,7 +60,7 @@ func TestRotation(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, rootKey, replacementKey)
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey, replacementKey})
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -122,7 +122,7 @@ func TestRotationNewSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, rootKey)
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey})
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -185,7 +185,7 @@ func TestRotationOldSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, replacementKey)
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{replacementKey})
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -60,7 +60,7 @@ func TestRotation(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey, replacementKey}, 2)
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey, replacementKey}, 2, nil)
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -122,7 +122,7 @@ func TestRotationNewSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey}, 1)
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{rootKey}, 1, nil)
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -185,7 +185,7 @@ func TestRotationOldSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, []data.PublicKey{replacementKey}, 1)
+	err = signed.Sign(signer, signedRoot, []data.PublicKey{replacementKey}, 1, nil)
 	require.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool

--- a/tuf/signed/errors.go
+++ b/tuf/signed/errors.go
@@ -8,17 +8,17 @@ import (
 // ErrInsufficientSignatures - can not create enough signatures on a piece of
 // metadata
 type ErrInsufficientSignatures struct {
-	FoundKeys  int
-	NeededKeys int
-	KeyIDs     []string
+	FoundKeys     int
+	NeededKeys    int
+	MissingKeyIDs []string
 }
 
 func (e ErrInsufficientSignatures) Error() string {
-	candidates := strings.Join(e.KeyIDs, ", ")
+	candidates := strings.Join(e.MissingKeyIDs, ", ")
 	if e.FoundKeys == 0 {
 		return fmt.Sprintf("signing keys not available, need %d keys out of: %s", e.NeededKeys, candidates)
 	}
-	return fmt.Sprintf("not enough signing keys: got %d of %d needed keys out of: %s",
+	return fmt.Sprintf("not enough signing keys: got %d of %d needed keys, other candidates: %s",
 		e.FoundKeys, e.NeededKeys, candidates)
 }
 

--- a/tuf/signed/errors.go
+++ b/tuf/signed/errors.go
@@ -5,14 +5,21 @@ import (
 	"strings"
 )
 
-// ErrInsufficientSignatures - do not have enough signatures on a piece of
+// ErrInsufficientSignatures - can not create enough signatures on a piece of
 // metadata
 type ErrInsufficientSignatures struct {
-	Name string
+	FoundKeys  int
+	NeededKeys int
+	KeyIDs     []string
 }
 
 func (e ErrInsufficientSignatures) Error() string {
-	return fmt.Sprintf("tuf: insufficient signatures: %s", e.Name)
+	candidates := strings.Join(e.KeyIDs, ", ")
+	if e.FoundKeys == 0 {
+		return fmt.Sprintf("signing keys not available, need %d keys out of: %s", e.NeededKeys, candidates)
+	}
+	return fmt.Sprintf("not enough signing keys: got %d of %d needed keys out of: %s",
+		e.FoundKeys, e.NeededKeys, candidates)
 }
 
 // ErrExpired indicates a piece of metadata has expired

--- a/tuf/signed/sign.go
+++ b/tuf/signed/sign.go
@@ -20,11 +20,11 @@ import (
 	"github.com/docker/notary/tuf/utils"
 )
 
-// Sign takes a data.Signed and a key, calculated and adds the signature
+// Sign takes a data.Signed and keys, calculates and adds the signature
 // to the data.Signed
 // N.B. All public keys for a role should be passed so that this function
 //      can correctly clean up signatures that are no longer valid.
-func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
+func Sign(service CryptoService, s *data.Signed, keys []data.PublicKey) error {
 	logrus.Debugf("sign called with %d keys", len(keys))
 	signatures := make([]data.Signature, 0, len(s.Signatures)+1)
 	signingKeyIDs := make(map[string]struct{})

--- a/tuf/signed/sign_test.go
+++ b/tuf/signed/sign_test.go
@@ -101,7 +101,7 @@ func TestBasicSign(t *testing.T) {
 		Signed: &json.RawMessage{},
 	}
 
-	err = Sign(cs, &testData, []data.PublicKey{key}, 1)
+	err = Sign(cs, &testData, []data.PublicKey{key}, 1, nil)
 	require.NoError(t, err)
 
 	if len(testData.Signatures) != 1 {
@@ -123,8 +123,8 @@ func TestReSign(t *testing.T) {
 		Signed: &json.RawMessage{},
 	}
 
-	Sign(cs, &testData, []data.PublicKey{key}, 1)
-	Sign(cs, &testData, []data.PublicKey{key}, 1)
+	Sign(cs, &testData, []data.PublicKey{key}, 1, nil)
+	Sign(cs, &testData, []data.PublicKey{key}, 1, nil)
 
 	if len(testData.Signatures) != 1 {
 		t.Fatalf("Incorrect number of signatures: %d", len(testData.Signatures))
@@ -146,7 +146,7 @@ func TestMultiSign(t *testing.T) {
 	key1, err := cs.Create(data.CanonicalRootRole, "", data.ED25519Key)
 	require.NoError(t, err)
 
-	Sign(cs, &testData, []data.PublicKey{key1}, 1)
+	Sign(cs, &testData, []data.PublicKey{key1}, 1, nil)
 
 	// reinitializing cs means it won't know about key1. We want
 	// to attempt to sign passing both key1 and key2, while expecting
@@ -156,26 +156,17 @@ func TestMultiSign(t *testing.T) {
 	key2, err := cs.Create(data.CanonicalRootRole, "", data.ED25519Key)
 	require.NoError(t, err)
 
-	Sign(
+	err = Sign(
 		cs,
 		&testData,
-		[]data.PublicKey{key1, key2},
+		[]data.PublicKey{key2},
 		1,
+		[]data.PublicKey{key1},
 	)
+	require.NoError(t, err)
 
-	if len(testData.Signatures) != 2 {
-		t.Fatalf("Incorrect number of signatures: %d", len(testData.Signatures))
-	}
-
-	keyIDs := map[string]struct{}{key1.ID(): {}, key2.ID(): {}}
-	count := 0
-	for _, sig := range testData.Signatures {
-		count++
-		if _, ok := keyIDs[sig.KeyID]; !ok {
-			t.Fatalf("Got a signature we didn't expect: %s", sig.KeyID)
-		}
-	}
-	require.Equal(t, 2, count)
+	require.Len(t, testData.Signatures, 1)
+	require.Equal(t, key2.ID(), testData.Signatures[0].KeyID)
 }
 
 func TestSignReturnsNoSigs(t *testing.T) {
@@ -186,7 +177,7 @@ func TestSignReturnsNoSigs(t *testing.T) {
 
 	testKey, _ := pem.Decode([]byte(testKeyPEM1))
 	key := data.NewPublicKey(data.RSAKey, testKey.Bytes)
-	err := Sign(failingCryptoService, &testData, []data.PublicKey{key}, 1)
+	err := Sign(failingCryptoService, &testData, []data.PublicKey{key}, 1, nil)
 
 	require.Error(t, err)
 	require.IsType(t, ErrInsufficientSignatures{}, err)
@@ -213,7 +204,8 @@ func TestSignWithX509(t *testing.T) {
 	testData := data.Signed{
 		Signed: &json.RawMessage{},
 	}
-	err = Sign(mockCryptoService, &testData, []data.PublicKey{tufRSAx509Key}, 1)
+
+	err = Sign(mockCryptoService, &testData, []data.PublicKey{tufRSAx509Key}, 1, nil)
 	require.NoError(t, err)
 
 	require.Len(t, testData.Signatures, 1)
@@ -229,7 +221,7 @@ func TestSignRemovesValidSigByInvalidKey(t *testing.T) {
 	key1, err := cs.Create(data.CanonicalRootRole, "", data.ED25519Key)
 	require.NoError(t, err)
 
-	Sign(cs, &testData, []data.PublicKey{key1}, 1)
+	Sign(cs, &testData, []data.PublicKey{key1}, 1, nil)
 	require.Len(t, testData.Signatures, 1)
 	require.Equal(t, key1.ID(), testData.Signatures[0].KeyID)
 
@@ -238,7 +230,7 @@ func TestSignRemovesValidSigByInvalidKey(t *testing.T) {
 
 	// should remove key1 sig even though it's valid. It no longer appears
 	// in the list of signing keys for the role
-	Sign(cs, &testData, []data.PublicKey{key2}, 1)
+	Sign(cs, &testData, []data.PublicKey{key2}, 1, nil)
 
 	require.Len(t, testData.Signatures, 1)
 	require.Equal(t, key2.ID(), testData.Signatures[0].KeyID)
@@ -253,7 +245,7 @@ func TestSignRemovesInvalidSig(t *testing.T) {
 	key1, err := cs.Create(data.CanonicalRootRole, "", data.ED25519Key)
 	require.NoError(t, err)
 
-	Sign(cs, &testData, []data.PublicKey{key1}, 1)
+	Sign(cs, &testData, []data.PublicKey{key1}, 1, nil)
 	require.Len(t, testData.Signatures, 1)
 	require.Equal(t, key1.ID(), testData.Signatures[0].KeyID)
 
@@ -266,7 +258,7 @@ func TestSignRemovesInvalidSig(t *testing.T) {
 	raw := json.RawMessage([]byte{0xff})
 	testData.Signed = &raw
 	// should remove key1 sig because it's out of date
-	Sign(cs, &testData, []data.PublicKey{key1, key2}, 1)
+	Sign(cs, &testData, []data.PublicKey{key1, key2}, 1, nil)
 
 	require.Len(t, testData.Signatures, 1)
 	require.Equal(t, key2.ID(), testData.Signatures[0].KeyID)
@@ -287,23 +279,59 @@ func TestSignMinSignatures(t *testing.T) {
 
 	// 2 available keys, threshold 1: 2 signatures created nevertheless
 	testData := data.Signed{Signed: &json.RawMessage{}}
-	err = Sign(csA, &testData, allKeys, 1)
+	err = Sign(csA, &testData, allKeys, 1, nil)
 	require.NoError(t, err)
 	require.Len(t, testData.Signatures, 2)
 
 	// 2 available keys, threshold 2
 	testData = data.Signed{Signed: &json.RawMessage{}}
-	err = Sign(csA, &testData, allKeys, 2)
+	err = Sign(csA, &testData, allKeys, 2, nil)
 	require.NoError(t, err)
 	require.Len(t, testData.Signatures, 2)
 
 	// 2 available keys, threshold 3
 	testData = data.Signed{Signed: &json.RawMessage{}}
-	err = Sign(csA, &testData, allKeys, 3)
+	err = Sign(csA, &testData, allKeys, 3, nil)
 	require.Error(t, err)
 	if err2, ok := err.(ErrInsufficientSignatures); ok {
 		require.Equal(t, err2.FoundKeys, 2)
 		require.Equal(t, err2.NeededKeys, 3)
+	} else {
+		// We know this will fail if !ok
+		require.IsType(t, ErrInsufficientSignatures{}, err)
+	}
+}
+
+func TestSignOptionalKeys(t *testing.T) {
+	csA := NewEd25519()
+	keyA1, err := csA.Create("keyA", "", data.ED25519Key)
+	require.NoError(t, err)
+	keyA2, err := csA.Create("keyA", "", data.ED25519Key)
+	require.NoError(t, err)
+	// csB is only used to create public keys which are unavailable from csA.
+	csB := NewEd25519()
+	keyB, err := csB.Create("keyB", "", data.ED25519Key)
+	require.NoError(t, err)
+
+	// Both primary and optional keys are used.
+	testData := data.Signed{Signed: &json.RawMessage{}}
+	err = Sign(csA, &testData, []data.PublicKey{keyA1, keyB}, 1, []data.PublicKey{keyA2})
+	require.NoError(t, err)
+	require.Len(t, testData.Signatures, 2)
+
+	// Missing optional keys are not an error.
+	testData = data.Signed{Signed: &json.RawMessage{}}
+	err = Sign(csA, &testData, []data.PublicKey{keyA1}, 1, []data.PublicKey{keyB})
+	require.NoError(t, err)
+	require.Len(t, testData.Signatures, 1)
+
+	// minSignatures is only counting primary keys.
+	testData = data.Signed{Signed: &json.RawMessage{}}
+	err = Sign(csA, &testData, []data.PublicKey{keyA1, keyB}, 2, []data.PublicKey{keyA2})
+	require.Error(t, err)
+	if err2, ok := err.(ErrInsufficientSignatures); ok {
+		require.Equal(t, err2.FoundKeys, 1)
+		require.Equal(t, err2.NeededKeys, 2)
 	} else {
 		// We know this will fail if !ok
 		require.IsType(t, ErrInsufficientSignatures{}, err)

--- a/tuf/signed/sign_test.go
+++ b/tuf/signed/sign_test.go
@@ -154,7 +154,7 @@ func TestReSign(t *testing.T) {
 
 }
 
-// Should not remove signatures for valid keys that were not resigned with
+// Resigning drops all obsolete signatures
 func TestMultiSign(t *testing.T) {
 	cs := NewEd25519()
 	testData := data.Signed{
@@ -166,10 +166,7 @@ func TestMultiSign(t *testing.T) {
 
 	Sign(cs, &testData, []data.PublicKey{key1}, 1, nil)
 
-	// reinitializing cs means it won't know about key1. We want
-	// to attempt to sign passing both key1 and key2, while expecting
-	// that the signature for key1 is left intact and the signature
-	// for key2 is added
+	// reinitializing cs means it won't know about key1.
 	cs = NewEd25519()
 	key2, err := cs.Create(data.CanonicalRootRole, "", data.ED25519Key)
 	require.NoError(t, err)

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -23,7 +23,7 @@ func TestRoleNoKeys(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k})
+	Sign(cs, s, []data.PublicKey{k}, 1)
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -40,7 +40,7 @@ func TestNotEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k})
+	Sign(cs, s, []data.PublicKey{k}, 1)
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -58,8 +58,9 @@ func TestMoreThanEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k1, k2})
+	Sign(cs, s, []data.PublicKey{k1, k2}, 2)
 	require.Equal(t, 2, len(s.Signatures))
+
 	err = Verify(s, roleWithKeys, 1)
 	require.NoError(t, err)
 }
@@ -75,7 +76,7 @@ func TestDuplicateSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k})
+	Sign(cs, s, []data.PublicKey{k}, 1)
 	s.Signatures = append(s.Signatures, s.Signatures[0])
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
@@ -94,7 +95,7 @@ func TestUnknownKeyBelowThreshold(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k, unknown})
+	Sign(cs, s, []data.PublicKey{k, unknown}, 2)
 	s.Signatures = append(s.Signatures)
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
@@ -169,7 +170,7 @@ func Test(t *testing.T) {
 			b, err := json.MarshalCanonical(meta)
 			require.NoError(t, err)
 			s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-			Sign(cryptoService, s, []data.PublicKey{k})
+			Sign(cryptoService, s, []data.PublicKey{k}, 1)
 			run.s = s
 		}
 		if run.mut != nil {

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -23,7 +23,7 @@ func TestRoleNoKeys(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, k)
+	Sign(cs, s, []data.PublicKey{k})
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -40,7 +40,7 @@ func TestNotEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, k)
+	Sign(cs, s, []data.PublicKey{k})
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -58,7 +58,7 @@ func TestMoreThanEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, k1, k2)
+	Sign(cs, s, []data.PublicKey{k1, k2})
 	require.Equal(t, 2, len(s.Signatures))
 	err = Verify(s, roleWithKeys, 1)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestDuplicateSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, k)
+	Sign(cs, s, []data.PublicKey{k})
 	s.Signatures = append(s.Signatures, s.Signatures[0])
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
@@ -94,7 +94,7 @@ func TestUnknownKeyBelowThreshold(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, k, unknown)
+	Sign(cs, s, []data.PublicKey{k, unknown})
 	s.Signatures = append(s.Signatures)
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
@@ -169,7 +169,7 @@ func Test(t *testing.T) {
 			b, err := json.MarshalCanonical(meta)
 			require.NoError(t, err)
 			s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-			Sign(cryptoService, s, k)
+			Sign(cryptoService, s, []data.PublicKey{k})
 			run.s = s
 		}
 		if run.mut != nil {

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -23,7 +23,7 @@ func TestRoleNoKeys(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k}, 1)
+	Sign(cs, s, []data.PublicKey{k}, 1, nil)
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -40,7 +40,7 @@ func TestNotEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k}, 1)
+	Sign(cs, s, []data.PublicKey{k}, 1, nil)
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -58,7 +58,7 @@ func TestMoreThanEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k1, k2}, 2)
+	Sign(cs, s, []data.PublicKey{k1, k2}, 2, nil)
 	require.Equal(t, 2, len(s.Signatures))
 
 	err = Verify(s, roleWithKeys, 1)
@@ -76,7 +76,7 @@ func TestDuplicateSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k}, 1)
+	Sign(cs, s, []data.PublicKey{k}, 1, nil)
 	s.Signatures = append(s.Signatures, s.Signatures[0])
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
@@ -95,7 +95,7 @@ func TestUnknownKeyBelowThreshold(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	require.NoError(t, err)
 	s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-	Sign(cs, s, []data.PublicKey{k, unknown}, 2)
+	Sign(cs, s, []data.PublicKey{k, unknown}, 2, nil)
 	s.Signatures = append(s.Signatures)
 	err = Verify(s, roleWithKeys, 1)
 	require.IsType(t, ErrRoleThreshold{}, err)
@@ -170,7 +170,7 @@ func Test(t *testing.T) {
 			b, err := json.MarshalCanonical(meta)
 			require.NoError(t, err)
 			s := &data.Signed{Signed: (*json.RawMessage)(&b)}
-			Sign(cryptoService, s, []data.PublicKey{k}, 1)
+			Sign(cryptoService, s, []data.PublicKey{k}, 1, nil)
 			run.s = s
 		}
 		if run.mut != nil {

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -72,8 +72,8 @@ func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
 		return nil, ErrNoKeyForRole{role}
 	}
 
-	if err := signed.Sign(cs, s, pubKeys); err != nil {
-		if _, ok := err.(signed.ErrNoKeys); ok {
+	if err := signed.Sign(cs, s, pubKeys, 1); err != nil {
+		if _, ok := err.(signed.ErrInsufficientSignatures); ok {
 			return nil, ErrNoKeyForRole{Role: role}
 		}
 		return nil, err

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -72,7 +72,7 @@ func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
 		return nil, ErrNoKeyForRole{role}
 	}
 
-	if err := signed.Sign(cs, s, pubKeys, 1); err != nil {
+	if err := signed.Sign(cs, s, pubKeys, 1, nil); err != nil {
 		if _, ok := err.(signed.ErrInsufficientSignatures); ok {
 			return nil, ErrNoKeyForRole{Role: role}
 		}

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -64,10 +64,6 @@ func getPubKeys(cs signed.CryptoService, s *data.Signed, role string) ([]data.Pu
 // signs the new metadata, replacing whatever signature was there
 func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
 	pubKeys ...data.PublicKey) ([]byte, error) {
-
-	// delete the existing signatures
-	s.Signatures = []data.Signature{}
-
 	if len(pubKeys) < 1 {
 		return nil, ErrNoKeyForRole{role}
 	}

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -72,7 +72,7 @@ func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
 		return nil, ErrNoKeyForRole{role}
 	}
 
-	if err := signed.Sign(cs, s, pubKeys...); err != nil {
+	if err := signed.Sign(cs, s, pubKeys); err != nil {
 		if _, ok := err.(signed.ErrNoKeys); ok {
 			return nil, ErrNoKeyForRole{Role: role}
 		}

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -919,7 +919,7 @@ func (tr *Repo) SignTimestamp(expires time.Time) (*data.Signed, error) {
 }
 
 func (tr Repo) sign(signedData *data.Signed, role data.BaseRole) (*data.Signed, error) {
-	if err := signed.Sign(tr.cryptoService, signedData, role.ListKeys()...); err != nil {
+	if err := signed.Sign(tr.cryptoService, signedData, role.ListKeys()); err != nil {
 		return nil, err
 	}
 	return signedData, nil

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -919,7 +919,7 @@ func (tr *Repo) SignTimestamp(expires time.Time) (*data.Signed, error) {
 }
 
 func (tr Repo) sign(signedData *data.Signed, role data.BaseRole) (*data.Signed, error) {
-	if err := signed.Sign(tr.cryptoService, signedData, role.ListKeys(), role.Threshold); err != nil {
+	if err := signed.Sign(tr.cryptoService, signedData, role.ListKeys(), role.Threshold, nil); err != nil {
 		return nil, err
 	}
 	return signedData, nil

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -919,7 +919,7 @@ func (tr *Repo) SignTimestamp(expires time.Time) (*data.Signed, error) {
 }
 
 func (tr Repo) sign(signedData *data.Signed, role data.BaseRole) (*data.Signed, error) {
-	if err := signed.Sign(tr.cryptoService, signedData, role.ListKeys()); err != nil {
+	if err := signed.Sign(tr.cryptoService, signedData, role.ListKeys(), role.Threshold); err != nil {
 		return nil, err
 	}
 	return signedData, nil

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -8,7 +8,11 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/passphrase"
+	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +23,10 @@ var testGUN = "gun"
 func initRepo(t *testing.T, cryptoService signed.CryptoService) *Repo {
 	rootKey, err := cryptoService.Create("root", testGUN, data.ED25519Key)
 	assert.NoError(t, err)
+	return initRepoWithRoot(t, cryptoService, rootKey)
+}
+
+func initRepoWithRoot(t *testing.T, cryptoService signed.CryptoService, rootKey data.PublicKey) *Repo {
 	targetsKey, err := cryptoService.Create("targets", testGUN, data.ED25519Key)
 	assert.NoError(t, err)
 	snapshotKey, err := cryptoService.Create("snapshot", testGUN, data.ED25519Key)
@@ -1041,4 +1049,132 @@ func TestGetDelegationRoleKeyMissing(t *testing.T) {
 	_, err := repo.GetDelegationRole("targets/missing_key")
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
+}
+
+func verifySignatureList(t *testing.T, signed *data.Signed, expectedKeys ...data.PublicKey) {
+	assert.Equal(t, len(expectedKeys), len(signed.Signatures))
+	usedKeys := make(map[string]struct{}, len(signed.Signatures))
+	for _, sig := range signed.Signatures {
+		usedKeys[sig.KeyID] = struct{}{}
+	}
+	for _, key := range expectedKeys {
+		_, ok := usedKeys[key.ID()]
+		assert.True(t, ok)
+	}
+}
+
+func verifyRootSignatureAgainstKey(t *testing.T, signedRoot *data.Signed, key data.PublicKey) error {
+	roleWithKeys := data.BaseRole{Name: data.CanonicalRootRole, Keys: data.Keys{key.ID(): key}, Threshold: 1}
+	return signed.VerifySignatures(signedRoot, roleWithKeys)
+}
+
+func TestSignRootOldKeyExists(t *testing.T) {
+	gun := "docker/test-sign-root"
+	referenceTime := time.Now()
+
+	cs := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(
+		passphrase.ConstantRetriever("password")))
+
+	rootPublicKey, err := cs.Create(data.CanonicalRootRole, gun, data.ECDSAKey)
+	assert.NoError(t, err)
+	rootPrivateKey, _, err := cs.GetPrivateKey(rootPublicKey.ID())
+	assert.NoError(t, err)
+	oldRootCert, err := cryptoservice.GenerateCertificate(rootPrivateKey, gun, referenceTime.AddDate(-9, 0, 0),
+		referenceTime.AddDate(1, 0, 0))
+	assert.NoError(t, err)
+	oldRootCertKey := trustmanager.CertToKey(oldRootCert)
+
+	repo := initRepoWithRoot(t, cs, oldRootCertKey)
+
+	// Create a first signature, using the old key.
+	signedRoot, err := repo.SignRoot(data.DefaultExpires(data.CanonicalRootRole))
+	assert.NoError(t, err)
+	verifySignatureList(t, signedRoot, oldRootCertKey)
+	err = verifyRootSignatureAgainstKey(t, signedRoot, oldRootCertKey)
+	assert.NoError(t, err)
+
+	// Create a new certificate
+	newRootCert, err := cryptoservice.GenerateCertificate(rootPrivateKey, gun, referenceTime, referenceTime.AddDate(10, 0, 0))
+	assert.NoError(t, err)
+	newRootCertKey := trustmanager.CertToKey(newRootCert)
+	assert.NotEqual(t, oldRootCertKey.ID(), newRootCertKey.ID())
+
+	// Only trust the new certificate
+	err = repo.ReplaceBaseKeys(data.CanonicalRootRole, newRootCertKey)
+	assert.NoError(t, err)
+	updatedRootRole, err := repo.GetBaseRole(data.CanonicalRootRole)
+	assert.NoError(t, err)
+	updatedRootKeyIDs := updatedRootRole.ListKeyIDs()
+	assert.Equal(t, 1, len(updatedRootKeyIDs))
+	assert.Equal(t, newRootCertKey.ID(), updatedRootKeyIDs[0])
+
+	// Create a second signature
+	signedRoot, err = repo.SignRoot(data.DefaultExpires(data.CanonicalRootRole))
+	assert.NoError(t, err)
+	verifySignatureList(t, signedRoot, oldRootCertKey, newRootCertKey)
+
+	// Verify that the signature can be verified when trusting the old certificate
+	err = verifyRootSignatureAgainstKey(t, signedRoot, oldRootCertKey)
+	assert.NoError(t, err)
+	// Verify that the signature can be verified when trusting the new certificate
+	err = verifyRootSignatureAgainstKey(t, signedRoot, newRootCertKey)
+	assert.NoError(t, err)
+}
+
+func TestSignRootOldKeyMissing(t *testing.T) {
+	gun := "docker/test-sign-root"
+	referenceTime := time.Now()
+
+	cs := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(
+		passphrase.ConstantRetriever("password")))
+
+	rootPublicKey, err := cs.Create(data.CanonicalRootRole, gun, data.ECDSAKey)
+	assert.NoError(t, err)
+	rootPrivateKey, _, err := cs.GetPrivateKey(rootPublicKey.ID())
+	assert.NoError(t, err)
+	oldRootCert, err := cryptoservice.GenerateCertificate(rootPrivateKey, gun, referenceTime.AddDate(-9, 0, 0),
+		referenceTime.AddDate(1, 0, 0))
+	assert.NoError(t, err)
+	oldRootCertKey := trustmanager.CertToKey(oldRootCert)
+
+	repo := initRepoWithRoot(t, cs, oldRootCertKey)
+
+	// Create a first signature, using the old key.
+	signedRoot, err := repo.SignRoot(data.DefaultExpires(data.CanonicalRootRole))
+	assert.NoError(t, err)
+	verifySignatureList(t, signedRoot, oldRootCertKey)
+	err = verifyRootSignatureAgainstKey(t, signedRoot, oldRootCertKey)
+	assert.NoError(t, err)
+
+	// Create a new certificate
+	newRootCert, err := cryptoservice.GenerateCertificate(rootPrivateKey, gun, referenceTime, referenceTime.AddDate(10, 0, 0))
+	assert.NoError(t, err)
+	newRootCertKey := trustmanager.CertToKey(newRootCert)
+	assert.NotEqual(t, oldRootCertKey.ID(), newRootCertKey.ID())
+
+	// Only trust the new certificate
+	err = repo.ReplaceBaseKeys(data.CanonicalRootRole, newRootCertKey)
+	assert.NoError(t, err)
+	updatedRootRole, err := repo.GetBaseRole(data.CanonicalRootRole)
+	assert.NoError(t, err)
+	updatedRootKeyIDs := updatedRootRole.ListKeyIDs()
+	assert.Equal(t, 1, len(updatedRootKeyIDs))
+	assert.Equal(t, newRootCertKey.ID(), updatedRootKeyIDs[0])
+
+	// Now forget all about the old certificate: drop it from the Root carried keys, and set up a new key DB
+	delete(repo.Root.Signed.Keys, oldRootCertKey.ID())
+	repo2 := NewRepo(cs)
+	err = repo2.SetRoot(repo.Root)
+	assert.NoError(t, err)
+
+	// Create a second signature
+	signedRoot, err = repo2.SignRoot(data.DefaultExpires(data.CanonicalRootRole))
+	assert.NoError(t, err)
+	verifySignatureList(t, signedRoot, newRootCertKey) // Without oldRootCertKey
+
+	// Verify that the signature can be verified when trusting the new certificate
+	err = verifyRootSignatureAgainstKey(t, signedRoot, newRootCertKey)
+	assert.NoError(t, err)
+	err = verifyRootSignatureAgainstKey(t, signedRoot, oldRootCertKey)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
When initializing a repository, notary currently creates a certificate with 10-year expiration. We can't have customers set up their system with such a time bomb without knowing for sure that we will be able to give them a smooth key rollover path.

So, this PR will eventually contain a proof-of-concept implementation, sufficient at least to make sure we are not painting ourselves into a corner.

The individual improvement/refactoring commits might be worth looking at; the final WIP commit is pretty useless at this moment and something which is likely to yet change drastically, feel free to completely ignore it.