### PR TITLE
Remove KeyStoreManager's dependency on a KeyStore.

### DIFF
--- a/client/client_test_pkcs11.go
+++ b/client/client_test_pkcs11.go
@@ -1,0 +1,19 @@
+// +build pkcs11
+
+package client
+
+import "github.com/docker/notary/trustmanager/yubikey"
+
+// clear out all keys
+func init() {
+	yubikey.SetYubikeyKeyMode(0)
+	if !yubikey.YubikeyAccessible() {
+		return
+	}
+	store, err := yubikey.NewYubiKeyStore(nil, nil)
+	if err == nil {
+		for k := range store.ListKeys() {
+			store.RemoveKey(k)
+		}
+	}
+}

--- a/client/repo.go
+++ b/client/repo.go
@@ -24,12 +24,12 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 		return nil, fmt.Errorf("failed to create private key store in directory: %s", baseDir)
 	}
 
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(baseDir, fileKeyStore)
+	keyStoreManager, err := keystoremanager.NewKeyStoreManager(baseDir)
 	if err != nil {
 		return nil, err
 	}
 
-	cryptoService := cryptoservice.NewCryptoService(gun, keyStoreManager.KeyStore)
+	cryptoService := cryptoservice.NewCryptoService(gun, fileKeyStore)
 
 	nRepo := &NotaryRepository{
 		gun:             gun,

--- a/client/repo_pkcs11.go
+++ b/client/repo_pkcs11.go
@@ -27,13 +27,13 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 		return nil, fmt.Errorf("failed to create private key store in directory: %s", baseDir)
 	}
 
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(baseDir, fileKeyStore)
+	keyStoreManager, err := keystoremanager.NewKeyStoreManager(baseDir)
 	yubiKeyStore, _ := yubikey.NewYubiKeyStore(fileKeyStore, retriever)
 	var cryptoService signed.CryptoService
 	if yubiKeyStore == nil {
-		cryptoService = cryptoservice.NewCryptoService(gun, keyStoreManager.KeyStore)
+		cryptoService = cryptoservice.NewCryptoService(gun, fileKeyStore)
 	} else {
-		cryptoService = cryptoservice.NewCryptoService(gun, yubiKeyStore, keyStoreManager.KeyStore)
+		cryptoService = cryptoservice.NewCryptoService(gun, yubiKeyStore, fileKeyStore)
 	}
 
 	nRepo := &NotaryRepository{

--- a/cmd/notary/cert.go
+++ b/cmd/notary/cert.go
@@ -54,11 +54,7 @@ func certRemove(cmd *cobra.Command, args []string) {
 	parseConfig()
 
 	trustDir := mainViper.GetString("trust_dir")
-	fileKeyStore, err := trustmanager.NewKeyFileStore(trustDir, retriever)
-	if err != nil {
-		fatalf("Failed to create private key store in directory: %s", trustDir)
-	}
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(trustDir, fileKeyStore)
+	keyStoreManager, err := keystoremanager.NewKeyStoreManager(trustDir)
 	if err != nil {
 		fatalf("Failed to create a new truststore manager with directory: %s", trustDir)
 	}
@@ -122,11 +118,7 @@ func certList(cmd *cobra.Command, args []string) {
 	parseConfig()
 
 	trustDir := mainViper.GetString("trust_dir")
-	fileKeyStore, err := trustmanager.NewKeyFileStore(trustDir, retriever)
-	if err != nil {
-		fatalf("Failed to create private key store in directory: %s", trustDir)
-	}
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(trustDir, fileKeyStore)
+	keyStoreManager, err := keystoremanager.NewKeyStoreManager(trustDir)
 	if err != nil {
 		fatalf("Failed to create a new truststore manager with directory: %s", trustDir)
 	}


### PR DESCRIPTION
The root generation code is handled by CryptoService now.

Signed-off-by: Ying Li <ying.li@docker.com>

Fixes #274.