### PR TITLE
Fixes client to report problems contacting the remote server.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -515,11 +515,15 @@ func (r *NotaryRepository) bootstrapClient() (*tufclient.Client, error) {
 			// the store and it doesn't know about the repo.
 			return nil, err
 		}
-		rootJSON, err = r.fileStore.GetMeta("root", maxSize)
-		if err != nil {
-			// if cache didn't return a root, we cannot proceed
-			return nil, store.ErrMetaNotFound{}
+		result, cacheErr := r.fileStore.GetMeta("root", maxSize)
+		if cacheErr != nil {
+			// if cache didn't return a root, we cannot proceed - just return
+			// the original error.
+			return nil, err
 		}
+		rootJSON = result
+		logrus.Debugf(
+			"Using local cache instead of remote due to failure: %s", err.Error())
 	}
 	// can't just unmarshal into SignedRoot because validate root
 	// needs the root.Signed field to still be []byte for signature


### PR DESCRIPTION
Currently, when listing, publishing, or getting a particular target, if the remote server errors, the client attempts to load it from a local cache.  However, if there is no local cache, it just returns Metadata Not Found for listing and getting.  Have it report the remote the original remote error instead of Metadata Not Found locally.

Fixes #277.