### PR TITLE
Server check that the root.json's timestamp key ID is valid.

### DIFF
--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -382,7 +382,11 @@ func checkRoot(oldRoot, newRoot *data.SignedRoot, timestampKey data.PublicKey) e
 		if !ok {
 			return fmt.Errorf("missing required %s role from root", r)
 		}
-		if role.Threshold < 1 {
+		// According to the TUF spec, any role may have more than one signing
+		// key and require a threshold signature.  However, notary-server
+		// creates the timestamp, and there is only ever one, so a threshold
+		// greater than one would just always fail validation
+		if (r == timestampRole && role.Threshold != 1) || role.Threshold < 1 {
 			return fmt.Errorf("%s role has invalid threshold", r)
 		}
 		if len(role.KeyIDs) < role.Threshold {

--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -297,8 +297,8 @@ func validateRoot(gun string, oldRoot, newRoot []byte, store storage.MetaStore) 
 	return parsedNewRoot, nil
 }
 
-// checkRoot errors if an invalid valid rotation has taken place, if the
-// threshold number of signatures is invalid valid, if there are an invalid
+// checkRoot errors if an invalid rotation has taken place, if the
+// threshold number of signatures is invalid, if there are an invalid
 // number of roles and keys, or if the timestamp keys are invalid
 func checkRoot(oldRoot, newRoot *data.SignedRoot, timestampKey data.PublicKey) error {
 	rootRole := data.RoleName(data.CanonicalRootRole)

--- a/tuf/store/httpstore.go
+++ b/tuf/store/httpstore.go
@@ -33,6 +33,19 @@ func (err ErrMaliciousServer) Error() string {
 	return "Trust server returned a bad response."
 }
 
+// ErrInvalidOperation indicates that the server returned a 400 response and
+// propogate any body we received.
+type ErrInvalidOperation struct {
+	msg string
+}
+
+func (err ErrInvalidOperation) Error() string {
+	if err.msg != "" {
+		return fmt.Sprintf("Trust server rejected operation: %s", err.msg)
+	}
+	return "Trust server rejected operation."
+}
+
 // HTTPStore manages pulling and pushing metadata from and to a remote
 // service over HTTP. It assumes the URL structure of the remote service
 // maps identically to the structure of the TUF repo:
@@ -70,6 +83,17 @@ func NewHTTPStore(baseURL, metaPrefix, metaExtension, targetsPrefix, keyExtensio
 	}, nil
 }
 
+func translateStatusToError(resp *http.Response) error {
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrMetaNotFound{}
+	} else if resp.StatusCode == http.StatusBadRequest {
+		return ErrInvalidOperation{}
+	} else if resp.StatusCode != http.StatusOK {
+		return ErrServerUnavailable{code: resp.StatusCode}
+	}
+	return nil
+}
+
 // GetMeta downloads the named meta file with the given size. A short body
 // is acceptable because in the case of timestamp.json, the size is a cap,
 // not an exact length.
@@ -87,11 +111,9 @@ func (s HTTPStore) GetMeta(name string, size int64) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrMetaNotFound{}
-	} else if resp.StatusCode != http.StatusOK {
+	if err := translateStatusToError(resp); err != nil {
 		logrus.Debugf("received HTTP status %d when requesting %s.", resp.StatusCode, name)
-		return nil, ErrServerUnavailable{code: resp.StatusCode}
+		return nil, err
 	}
 	if resp.ContentLength > size {
 		return nil, ErrMaliciousServer{}
@@ -120,12 +142,7 @@ func (s HTTPStore) SetMeta(name string, blob []byte) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return ErrMetaNotFound{}
-	} else if resp.StatusCode != http.StatusOK {
-		return ErrServerUnavailable{code: resp.StatusCode}
-	}
-	return nil
+	return translateStatusToError(resp)
 }
 
 // SetMultiMeta does a single batch upload of multiple pieces of TUF metadata.
@@ -159,12 +176,7 @@ func (s HTTPStore) SetMultiMeta(metas map[string][]byte) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return ErrMetaNotFound{}
-	} else if resp.StatusCode != http.StatusOK {
-		return ErrServerUnavailable{code: resp.StatusCode}
-	}
-	return nil
+	return translateStatusToError(resp)
 }
 
 func (s HTTPStore) buildMetaURL(name string) (*url.URL, error) {
@@ -212,10 +224,8 @@ func (s HTTPStore) GetTarget(path string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrMetaNotFound{}
-	} else if resp.StatusCode != http.StatusOK {
-		return nil, ErrServerUnavailable{code: resp.StatusCode}
+	if err := translateStatusToError(resp); err != nil {
+		return nil, err
 	}
 	return resp.Body, nil
 }
@@ -235,10 +245,8 @@ func (s HTTPStore) GetKey(role string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrMetaNotFound{}
-	} else if resp.StatusCode != http.StatusOK {
-		return nil, ErrServerUnavailable{code: resp.StatusCode}
+	if err := translateStatusToError(resp); err != nil {
+		return nil, err
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/tuf/store/httpstore.go
+++ b/tuf/store/httpstore.go
@@ -84,14 +84,16 @@ func NewHTTPStore(baseURL, metaPrefix, metaExtension, targetsPrefix, keyExtensio
 }
 
 func translateStatusToError(resp *http.Response) error {
-	if resp.StatusCode == http.StatusNotFound {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusNotFound:
 		return ErrMetaNotFound{}
-	} else if resp.StatusCode == http.StatusBadRequest {
+	case http.StatusBadRequest:
 		return ErrInvalidOperation{}
-	} else if resp.StatusCode != http.StatusOK {
+	default:
 		return ErrServerUnavailable{code: resp.StatusCode}
 	}
-	return nil
 }
 
 // GetMeta downloads the named meta file with the given size. A short body

--- a/tuf/store/httpstore_test.go
+++ b/tuf/store/httpstore_test.go
@@ -178,11 +178,11 @@ func testErrorCode(t *testing.T, errorCode int, errType error) {
 		fmt.Sprintf("%d should translate to %v", errorCode, errType))
 }
 
-func TestErrMetadataNotFound(t *testing.T) {
+func Test404Error(t *testing.T) {
 	testErrorCode(t, http.StatusNotFound, ErrMetaNotFound{})
 }
 
-func Test500Errors(t *testing.T) {
+func Test50XErrors(t *testing.T) {
 	fiveHundreds := []int{
 		http.StatusInternalServerError,
 		http.StatusNotImplemented,
@@ -194,4 +194,8 @@ func Test500Errors(t *testing.T) {
 	for _, code := range fiveHundreds {
 		testErrorCode(t, code, ErrServerUnavailable{})
 	}
+}
+
+func Test400Error(t *testing.T) {
+	testErrorCode(t, http.StatusBadRequest, ErrInvalidOperation{})
 }


### PR DESCRIPTION
If the client sends a root.json with an invalid timestamp key ID,
possibly because they are pushing an existing repo to a new server,
then the server should reject the update.

Signed-off-by: Ying Li <ying.li@docker.com>

Fixes #297 