### PR TITLE
Make the server/signer configurations more similar

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -20,4 +20,4 @@ RUN go install \
     ${NOTARYPKG}/cmd/notary-server
 
 ENTRYPOINT [ "notary-server" ]
-CMD [ "-config", "cmd/notary-server/config.json" ]
+CMD [ "-config", "fixtures/server-config.json" ]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -20,4 +20,4 @@ RUN go install \
     ${NOTARYPKG}/cmd/notary-server
 
 ENTRYPOINT [ "notary-server" ]
-CMD [ "-config", "fixtures/server-config.json" ]
+CMD [ "-config=fixtures/server-config-local.json" ]

--- a/Dockerfile.signer
+++ b/Dockerfile.signer
@@ -38,4 +38,4 @@ RUN go install \
 
 
 ENTRYPOINT [ "notary-signer" ]
-CMD [ "-config=cmd/notary-signer/config.json" ]
+CMD [ "-config=fixtures/signer-config.json" ]

--- a/Dockerfile.signer
+++ b/Dockerfile.signer
@@ -38,4 +38,4 @@ RUN go install \
 
 
 ENTRYPOINT [ "notary-signer" ]
-CMD [ "-config=fixtures/signer-config.json" ]
+CMD [ "-config=fixtures/signer-config-local.json" ]

--- a/cmd/notary-server/config.json
+++ b/cmd/notary-server/config.json
@@ -1,6 +1,6 @@
 {
 	"server": {
-		"addr": ":4443",
+		"http_addr": ":4443",
 		"tls_key_file": "./fixtures/notary-server.key",
 		"tls_cert_file": "./fixtures/notary-server.crt"
 	},

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -73,10 +73,10 @@ func getAddrAndTLSConfig(configuration *viper.Viper) (string, *tls.Config, error
 
 // sets up TLS for the GRPC connection to notary-signer
 func grpcTLS(configuration *viper.Viper) (*tls.Config, error) {
-	rootCA := configuration.GetString("trust_service.tls_ca_file")
+	rootCA := utils.GetPathRelativeToConfig(configuration, "trust_service.tls_ca_file")
 	serverName := configuration.GetString("trust_service.hostname")
-	clientCert := configuration.GetString("trust_service.tls_client_cert")
-	clientKey := configuration.GetString("trust_service.tls_client_key")
+	clientCert := utils.GetPathRelativeToConfig(configuration, "trust_service.tls_client_cert")
+	clientKey := utils.GetPathRelativeToConfig(configuration, "trust_service.tls_client_key")
 
 	if (clientCert == "" && clientKey != "") || (clientCert != "" && clientKey == "") {
 		return nil, fmt.Errorf("Partial TLS configuration found. Either include both a client cert and client key file in the configuration, or include neither.")

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/docker/notary/server/storage"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,63 +21,71 @@ const (
 )
 
 // initializes a viper object with test configuration
-func configure(jsonConfig []byte) *viper.Viper {
+func configure(jsonConfig string) *viper.Viper {
 	config := viper.New()
 	config.SetConfigType("json")
-	config.ReadConfig(bytes.NewBuffer(jsonConfig))
+	config.ReadConfig(bytes.NewBuffer([]byte(jsonConfig)))
 	return config
 }
 
-// If neither the cert nor the key are provided, a nil tls config is returned.
-func TestServerTLSMissingCertAndKey(t *testing.T) {
-	tlsConfig, err := serverTLS(configure([]byte(`{"server": {}}`)))
-	assert.NoError(t, err)
-	assert.Nil(t, tlsConfig)
-}
-
-// Cert and Key either both have to be empty or both have to be provided.
-func TestServerTLSMissingCertAndOrKey(t *testing.T) {
-	configs := []string{
-		fmt.Sprintf(`{"tls_cert_file": "%s"}`, Cert),
-		fmt.Sprintf(`{"tls_key_file": "%s"}`, Key),
+func TestGetAddrAndTLSConfigInvalidTLS(t *testing.T) {
+	invalids := []string{
+		`{"server": {
+				"http_addr": ":1234",
+				"tls_key_file": "nope"
+		}}`,
 	}
-	for _, serverConfig := range configs {
-		config := configure(
-			[]byte(fmt.Sprintf(`{"server": %s}`, serverConfig)))
-		tlsConfig, err := serverTLS(config)
+	for _, configJSON := range invalids {
+		_, _, err := getAddrAndTLSConfig(configure(configJSON))
 		assert.Error(t, err)
-		assert.Nil(t, tlsConfig)
-		assert.True(t,
-			strings.Contains(err.Error(), "Partial TLS configuration found."))
 	}
 }
 
-// The rest of the functionality of serverTLS depends upon
-// utils.ConfigureServerTLS, so this test just asserts that if successful,
-// the correct tls.Config is returned based on all the configuration parameters
-func TestServerTLSSuccess(t *testing.T) {
-	keypair, err := tls.LoadX509KeyPair(Cert, Key)
-	assert.NoError(t, err, "Unable to load cert and key for testing")
-
-	config := fmt.Sprintf(
-		`{"server": {"tls_cert_file": "%s", "tls_key_file": "%s"}}`,
-		Cert, Key)
-	tlsConfig, err := serverTLS(configure([]byte(config)))
-	assert.NoError(t, err)
-	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
+func TestGetAddrAndTLSConfigNoHTTPAddr(t *testing.T) {
+	_, _, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s"
+		}
+	}`, Cert, Key)))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http listen address required for server")
 }
 
-// The rest of the functionality of serverTLS depends upon
-// utils.ConfigureServerTLS, so this test just asserts that if it fails,
-// the error is propogated.
-func TestServerTLSFailure(t *testing.T) {
-	config := fmt.Sprintf(
-		`{"server": {"tls_cert_file": "non-exist", "tls_key_file": "%s"}}`,
-		Key)
-	tlsConfig, err := serverTLS(configure([]byte(config)))
-	assert.Error(t, err)
-	assert.Nil(t, tlsConfig)
-	assert.True(t, strings.Contains(err.Error(), "Unable to set up TLS"))
+func TestGetAddrAndTLSConfigSuccessWithTLS(t *testing.T) {
+	httpAddr, tlsConf, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"http_addr": ":2345",
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s"
+		}
+	}`, Cert, Key)))
+	assert.NoError(t, err)
+	assert.Equal(t, ":2345", httpAddr)
+	assert.NotNil(t, tlsConf)
+}
+
+func TestGetAddrAndTLSConfigSuccessWithoutTLS(t *testing.T) {
+	httpAddr, tlsConf, err := getAddrAndTLSConfig(configure(
+		`{"server": {"http_addr": ":2345"}}`))
+	assert.NoError(t, err)
+	assert.Equal(t, ":2345", httpAddr)
+	assert.Nil(t, tlsConf)
+}
+
+// We don't support client CAs yet on notary server
+func TestGetAddrAndTLSConfigSkipClientTLS(t *testing.T) {
+	httpAddr, tlsConf, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"http_addr": ":2345",
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s",
+			"client_ca_file": "%s"
+		}
+	}`, Cert, Key, Root)))
+	assert.NoError(t, err)
+	assert.Equal(t, ":2345", httpAddr)
+	assert.Nil(t, tlsConf.ClientCAs)
 }
 
 // Client cert and Key either both have to be empty or both have to be
@@ -88,7 +99,7 @@ func TestGrpcTLSMissingCertOrKey(t *testing.T) {
 		jsonConfig := fmt.Sprintf(
 			`{"trust_service": {"hostname": "notary-signer", %s}}`,
 			trustConfig)
-		config := configure([]byte(jsonConfig))
+		config := configure(jsonConfig)
 		tlsConfig, err := grpcTLS(config)
 		assert.Error(t, err)
 		assert.Nil(t, tlsConfig)
@@ -101,7 +112,7 @@ func TestGrpcTLSMissingCertOrKey(t *testing.T) {
 // the provided serverName is still returned.
 func TestGrpcTLSNoConfig(t *testing.T) {
 	tlsConfig, err := grpcTLS(
-		configure([]byte(`{"trust_service": {"hostname": "notary-signer"}}`)))
+		configure(`{"trust_service": {"hostname": "notary-signer"}}`))
 	assert.NoError(t, err)
 	assert.Equal(t, "notary-signer", tlsConfig.ServerName)
 	assert.Nil(t, tlsConfig.RootCAs)
@@ -121,7 +132,7 @@ func TestGrpcTLSSuccess(t *testing.T) {
             "tls_client_cert": "%s",
             "tls_client_key": "%s"}}`,
 		Cert, Key)
-	tlsConfig, err := grpcTLS(configure([]byte(config)))
+	tlsConfig, err := grpcTLS(configure(config))
 	assert.NoError(t, err)
 	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
 }
@@ -136,9 +147,40 @@ func TestGrpcTLSFailure(t *testing.T) {
             "tls_client_cert": "no-exist",
             "tls_client_key": "%s"}}`,
 		Key)
-	tlsConfig, err := grpcTLS(configure([]byte(config)))
+	tlsConfig, err := grpcTLS(configure(config))
 	assert.Error(t, err)
 	assert.Nil(t, tlsConfig)
 	assert.True(t, strings.Contains(err.Error(),
 		"Unable to configure TLS to the trust service"))
+}
+
+// Just to ensure that errors are propogated
+func TestGetStoreInvalid(t *testing.T) {
+	config := `{"storage": {"backend": "asdf", "db_url": "/tmp/1234"}}`
+
+	_, err := getStore(configure(config), []string{"mysql"})
+	assert.Error(t, err)
+}
+
+func TestGetStoreDBStore(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("/tmp", "sqlite3")
+	assert.NoError(t, err)
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+
+	config := fmt.Sprintf(`{"storage": {"backend": "sqlite3", "db_url": "%s"}}`,
+		tmpFile.Name())
+
+	store, err := getStore(configure(config), []string{"sqlite3"})
+	assert.NoError(t, err)
+	_, ok := store.(*storage.SQLStorage)
+	assert.True(t, ok)
+}
+
+func TestGetMemoryStore(t *testing.T) {
+	config := fmt.Sprintf(`{"storage": {}}`)
+	store, err := getStore(configure(config), []string{"mysql"})
+	assert.NoError(t, err)
+	_, ok := store.(*storage.MemStorage)
+	assert.True(t, ok)
 }

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -121,18 +121,22 @@ func TestGrpcTLSNoConfig(t *testing.T) {
 
 // The rest of the functionality of grpcTLS depends upon
 // utils.ConfigureClientTLS, so this test just asserts that if successful,
-// the correct tls.Config is returned based on all the configuration parameters
+// the correct tls.Config is returned based on all the configuration parameters,
+// and that it gets the path relative to the config file
 func TestGrpcTLSSuccess(t *testing.T) {
 	keypair, err := tls.LoadX509KeyPair(Cert, Key)
 	assert.NoError(t, err, "Unable to load cert and key for testing")
 
-	config := fmt.Sprintf(
-		`{"trust_service": {
+	configJSON := `{
+		"trust_service": {
             "hostname": "notary-server",
-            "tls_client_cert": "%s",
-            "tls_client_key": "%s"}}`,
-		Cert, Key)
-	tlsConfig, err := grpcTLS(configure(config))
+            "tls_client_cert": "notary-server.crt",
+            "tls_client_key": "notary-server.key"
+        }
+    }`
+	config := configure(configJSON)
+	config.SetConfigFile("../../fixtures/config.json")
+	tlsConfig, err := grpcTLS(config)
 	assert.NoError(t, err)
 	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
 }

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/notary/server/storage"
+	"github.com/docker/notary/utils"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -172,18 +173,19 @@ func TestGetStoreDBStore(t *testing.T) {
 	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
 
-	config := fmt.Sprintf(`{"storage": {"backend": "sqlite3", "db_url": "%s"}}`,
-		tmpFile.Name())
+	config := fmt.Sprintf(`{"storage": {"backend": "%s", "db_url": "%s"}}`,
+		utils.SqliteBackend, tmpFile.Name())
 
-	store, err := getStore(configure(config), []string{"sqlite3"})
+	store, err := getStore(configure(config), []string{utils.SqliteBackend})
 	assert.NoError(t, err)
 	_, ok := store.(*storage.SQLStorage)
 	assert.True(t, ok)
 }
 
 func TestGetMemoryStore(t *testing.T) {
-	config := fmt.Sprintf(`{"storage": {}}`)
-	store, err := getStore(configure(config), []string{"mysql"})
+	config := fmt.Sprintf(`{"storage": {"backend": "%s"}}`, utils.MemoryBackend)
+	store, err := getStore(configure(config),
+		[]string{utils.MySQLBackend, utils.MemoryBackend})
 	assert.NoError(t, err)
 	_, ok := store.(*storage.MemStorage)
 	assert.True(t, ok)

--- a/cmd/notary-signer/config.json
+++ b/cmd/notary-signer/config.json
@@ -2,15 +2,12 @@
 	"server": {
 		"http_addr": ":4444",
 		"grpc_addr": ":7899",
-		"cert_file": "./fixtures/notary-signer.crt",
-		"key_file": "./fixtures/notary-signer.key",
+		"tls_cert_file": "./fixtures/notary-signer.crt",
+		"tls_key_file": "./fixtures/notary-signer.key",
 		"client_ca_file": "./fixtures/notary-server.crt"
 	},
-	"crypto": {
-		"pkcslib": "/usr/local/lib/softhsm/libsofthsm2.so"
-	},
 	"logging": {
-		"level": 5
+		"level": "debug"
 	},
 	"storage": {
 		"backend": "mysql",

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -100,14 +100,15 @@ func setUpCryptoservices(configuration *viper.Viper, allowedBackends []string) (
 		}
 		logrus.Debugf("Using %s DB: %s", storeConfig.Backend, storeConfig.Source)
 
-		keyStore, err := keydbstore.NewKeyDBStore(
+		dbStore, err := keydbstore.NewKeyDBStore(
 			passphraseRetriever, defaultAlias, storeConfig.Backend, dbSQL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a new keydbstore: %v", err)
 		}
 
 		health.RegisterPeriodicFunc(
-			"DB operational", keyStore.HealthCheck, time.Second*60)
+			"DB operational", dbStore.HealthCheck, time.Second*60)
+		keyStore = dbStore
 	}
 
 	cryptoService := cryptoservice.NewCryptoService("", keyStore)

--- a/cmd/notary-signer/main_test.go
+++ b/cmd/notary-signer/main_test.go
@@ -6,9 +6,12 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"strings"
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/docker/notary/signer"
+	"github.com/docker/notary/tuf/data"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,54 +23,127 @@ const (
 )
 
 // initializes a viper object with test configuration
-func configure(jsonConfig []byte) *viper.Viper {
+func configure(jsonConfig string) *viper.Viper {
 	config := viper.New()
 	config.SetConfigType("json")
-	config.ReadConfig(bytes.NewBuffer(jsonConfig))
+	config.ReadConfig(bytes.NewBuffer([]byte(jsonConfig)))
 	return config
 }
 
-func TestSignerTLSMissingCertAndOrKey(t *testing.T) {
-	configs := []string{
-		"{}",
-		fmt.Sprintf(`{"cert_file": "%s"}`, Cert),
-		fmt.Sprintf(`{"key_file": "%s"}`, Key),
+func TestGetAddrAndTLSConfigInvalidTLS(t *testing.T) {
+	invalids := []string{
+		`{"server": {"http_addr": ":1234", "grpc_addr": ":2345"}}`,
+		`{"server": {
+				"http_addr": ":1234",
+				"grpc_addr": ":2345",
+				"tls_cert_file": "nope",
+				"tls_key_file": "nope"
+		}}`,
 	}
-	for _, serverConfig := range configs {
-		config := configure(
-			[]byte(fmt.Sprintf(`{"server": %s}`, serverConfig)))
-		tlsConfig, err := signerTLS(config, false)
+	for _, configJSON := range invalids {
+		_, _, _, err := getAddrAndTLSConfig(configure(configJSON))
 		assert.Error(t, err)
-		assert.Nil(t, tlsConfig)
-		assert.Equal(t, "Certificate and key are mandatory", err.Error())
+		assert.Contains(t, err.Error(), "unable to set up TLS")
 	}
 }
 
-// The rest of the functionality of signerTLS depends upon
-// utils.ConfigureServerTLS, so this test just asserts that if successful,
-// the correct tls.Config is returned based on all the configuration parameters
-func TestSignerTLSSuccess(t *testing.T) {
-	keypair, err := tls.LoadX509KeyPair(Cert, Key)
-	assert.NoError(t, err, "Unable to load cert and key for testing")
-
-	config := fmt.Sprintf(
-		`{"server": {"cert_file": "%s", "key_file": "%s", "client_ca_file": "%s"}}`,
-		Cert, Key, Cert)
-	tlsConfig, err := signerTLS(configure([]byte(config)), false)
-	assert.NoError(t, err)
-	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
-	assert.NotNil(t, tlsConfig.ClientCAs)
+func TestGetAddrAndTLSConfigNoGRPCAddr(t *testing.T) {
+	_, _, _, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"http_addr": ":1234",
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s"
+		}
+	}`, Cert, Key)))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "grpc listen address required for server")
 }
 
-// The rest of the functionality of signerTLS depends upon
-// utils.ConfigureServerTLS, so this test just asserts that if it fails,
-// the error is propogated.
-func TestSignerTLSFailure(t *testing.T) {
-	config := fmt.Sprintf(
-		`{"server": {"cert_file": "%s", "key_file": "%s", "client_ca_file": "%s"}}`,
-		Cert, Key, "non-existant")
-	tlsConfig, err := signerTLS(configure([]byte(config)), false)
+func TestGetAddrAndTLSConfigNoHTTPAddr(t *testing.T) {
+	_, _, _, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"grpc_addr": ":1234",
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s"
+		}
+	}`, Cert, Key)))
 	assert.Error(t, err)
-	assert.Nil(t, tlsConfig)
-	assert.True(t, strings.Contains(err.Error(), "Unable to set up TLS"))
+	assert.Contains(t, err.Error(), "http listen address required for server")
+}
+
+func TestGetAddrAndTLSConfigSuccess(t *testing.T) {
+	httpAddr, grpcAddr, tlsConf, err := getAddrAndTLSConfig(configure(fmt.Sprintf(`{
+		"server": {
+			"http_addr": ":2345",
+			"grpc_addr": ":1234",
+			"tls_cert_file": "%s",
+			"tls_key_file": "%s"
+		}
+	}`, Cert, Key)))
+	assert.NoError(t, err)
+	assert.Equal(t, ":2345", httpAddr)
+	assert.Equal(t, ":1234", grpcAddr)
+	assert.NotNil(t, tlsConf)
+}
+
+func TestSetupCryptoServicesNoDefaultAlias(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("/tmp", "sqlite3")
+	assert.NoError(t, err)
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+
+	_, err = setUpCryptoservices(
+		configure(fmt.Sprintf(
+			`{"storage": {"backend": "sqlite3", "db_url": "%s"}}`,
+			tmpFile.Name())),
+		[]string{"sqlite3"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must provide a default alias for the key DB")
+}
+
+func TestSetupCryptoServicesSuccess(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("/tmp", "sqlite3")
+	assert.NoError(t, err)
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+
+	cryptoServices, err := setUpCryptoservices(
+		configure(fmt.Sprintf(
+			`{"storage": {"backend": "sqlite3", "db_url": "%s"},
+			"default_alias": "timestamp"}`,
+			tmpFile.Name())),
+		[]string{"sqlite3"})
+	assert.NoError(t, err)
+	assert.Len(t, cryptoServices, 2)
+
+	edService, ok := cryptoServices[data.ED25519Key]
+	assert.True(t, ok)
+
+	ecService, ok := cryptoServices[data.ECDSAKey]
+	assert.True(t, ok)
+
+	assert.Equal(t, edService, ecService)
+}
+
+func TestSetupHTTPServer(t *testing.T) {
+	httpServer := setupHTTPServer(":4443", nil, make(signer.CryptoServiceIndex))
+	assert.Equal(t, ":4443", httpServer.Addr)
+	assert.Nil(t, httpServer.TLSConfig)
+}
+
+func TestSetupGRPCServerInvalidAddress(t *testing.T) {
+	_, _, err := setupGRPCServer("nope", nil, make(signer.CryptoServiceIndex))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "grpc server failed to listen on nope")
+}
+
+func TestSetupGRPCServerSuccess(t *testing.T) {
+	tlsConf := tls.Config{InsecureSkipVerify: true}
+	grpcServer, lis, err := setupGRPCServer(":7899", &tlsConf,
+		make(signer.CryptoServiceIndex))
+	defer lis.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, "[::]:7899", lis.Addr().String())
+	assert.Equal(t, "tcp", lis.Addr().Network())
+	assert.NotNil(t, grpcServer)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ notaryserver:
    - "8080"
    - "4443:4443"
   environment:
-    SERVICE_NAME: notary
+   - SERVICE_NAME=notary
+  command: -config=fixtures/server-config.json
 notarysigner:
   volumes:
    - /dev/bus/usb/003/010:/dev/bus/usb/002/010
@@ -17,6 +18,7 @@ notarysigner:
   dockerfile: Dockerfile.signer
   links:
    - notarymysql
+  command: -config=fixtures/signer-config.json
 notarymysql:
   build: ./notarymysql/
   ports:

--- a/fixtures/server-config-local.json
+++ b/fixtures/server-config-local.json
@@ -1,0 +1,22 @@
+{
+	"server": {
+		"http_addr": ":4443",
+		"tls_key_file": "./notary-server.key",
+		"tls_cert_file": "./notary-server.crt"
+	},
+	"trust_service": {
+	  "type": "remote",
+	  "hostname": "notarysigner",
+	  "port": "7899",
+	  "tls_ca_file": "./root-ca.crt",
+	  "key_algorithm": "ecdsa",
+	  "tls_client_cert": "./notary-server.crt",
+	  "tls_client_key": "./notary-server.key"
+	},
+	"logging": {
+		"level": "debug"
+	},
+	"storage": {
+		"backend": "memory"
+	}
+}

--- a/fixtures/server-config.json
+++ b/fixtures/server-config.json
@@ -1,17 +1,17 @@
 {
 	"server": {
 		"http_addr": ":4443",
-		"tls_key_file": "./fixtures/notary-server.key",
-		"tls_cert_file": "./fixtures/notary-server.crt"
+		"tls_key_file": "./notary-server.key",
+		"tls_cert_file": "./notary-server.crt"
 	},
 	"trust_service": {
 	  "type": "remote",
 	  "hostname": "notarysigner",
 	  "port": "7899",
-	  "tls_ca_file": "./fixtures/root-ca.crt",
+	  "tls_ca_file": "./root-ca.crt",
 	  "key_algorithm": "ecdsa",
-	  "tls_client_cert": "./fixtures/notary-server.crt",
-	  "tls_client_key": "./fixtures/notary-server.key"
+	  "tls_client_cert": "./notary-server.crt",
+	  "tls_client_key": "./notary-server.key"
 	},
 	"logging": {
 		"level": "debug"

--- a/fixtures/signer-config-local.json
+++ b/fixtures/signer-config-local.json
@@ -1,0 +1,15 @@
+{
+	"server": {
+		"http_addr": ":4444",
+		"grpc_addr": ":7899",
+		"tls_cert_file": "./notary-signer.crt",
+		"tls_key_file": "./notary-signer.key",
+		"client_ca_file": "./notary-server.crt"
+	},
+	"logging": {
+		"level": "debug"
+	},
+	"storage": {
+		"backend": "memory"
+	}
+}

--- a/fixtures/signer-config.json
+++ b/fixtures/signer-config.json
@@ -2,9 +2,9 @@
 	"server": {
 		"http_addr": ":4444",
 		"grpc_addr": ":7899",
-		"tls_cert_file": "./fixtures/notary-signer.crt",
-		"tls_key_file": "./fixtures/notary-signer.key",
-		"client_ca_file": "./fixtures/notary-server.crt"
+		"tls_cert_file": "./notary-signer.crt",
+		"tls_key_file": "./notary-signer.key",
+		"client_ca_file": "./notary-server.crt"
 	},
 	"logging": {
 		"level": "debug"

--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -1,0 +1,135 @@
+// Common configuration elements that may be resused
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	bugsnag_hook "github.com/Sirupsen/logrus/hooks/bugsnag"
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/spf13/viper"
+)
+
+// Server is a configuration about what addresses a server should listen on
+type Server struct {
+	*ServerTLSOpts
+	HTTPAddr string
+	GRPCAddr string
+}
+
+// Storage is a configuration about what storage backend a server should use
+type Storage struct {
+	Backend string `mapstructure:"backend"`
+	URL     string `mapstructure:"db_url"`
+}
+
+// ParseServer tries to parse out a valid Server from a Viper:
+// - Either or both of HTTP and GRPC address must be provided
+// - If TLS is required, both the cert and key must be provided
+// - If TLS is not requried, either both the cert and key must be provided or
+//	 neither must be provided
+func ParseServer(configuration *viper.Viper, tlsRequired bool) (*Server, error) {
+	// mapstructure does not support unmarshalling into a pointer
+	var tlsOpts ServerTLSOpts
+	err := configuration.UnmarshalKey("server", &tlsOpts)
+	if err != nil {
+		return nil, err
+	}
+	cert, key := tlsOpts.ServerCertFile, tlsOpts.ServerKeyFile
+	if tlsRequired {
+		if cert == "" || key == "" {
+			return nil, fmt.Errorf("both the TLS certificate and key are mandatory")
+		}
+	} else {
+		if (cert == "" && key != "") || (cert != "" && key == "") {
+			return nil, fmt.Errorf(
+				"either include both a cert and key file, or neither to disable TLS")
+		}
+	}
+
+	server := Server{
+		HTTPAddr:      configuration.GetString("server.http_addr"),
+		GRPCAddr:      configuration.GetString("server.grpc_addr"),
+		ServerTLSOpts: &tlsOpts,
+	}
+	if cert == "" && key == "" && tlsOpts.ClientCAFile == "" {
+		server.ServerTLSOpts = nil
+	}
+
+	if server.HTTPAddr == "" && server.GRPCAddr == "" {
+		return nil, fmt.Errorf("server must have an HTTP and/or GRPC address")
+	}
+
+	return &server, nil
+}
+
+// ParseLogLevel tries to parse out a log level from a Viper.  If there is no
+// configuration, defaults to the provided error level
+func ParseLogLevel(configuration *viper.Viper, defaultLevel logrus.Level) (
+	logrus.Level, error) {
+
+	logStr := configuration.GetString("logging.level")
+	if logStr == "" {
+		return defaultLevel, nil
+	}
+	return logrus.ParseLevel(logStr)
+}
+
+// ParseStorage tries to parse out Storage from a Viper.  If backend and
+// URL are not provided, returns a nil pointer.
+func ParseStorage(configuration *viper.Viper) (*Storage, error) {
+	var store Storage
+	err := configuration.UnmarshalKey("storage", &store)
+	if err != nil {
+		return nil, err
+	}
+	if store.Backend == "" && store.URL == "" {
+		return nil, nil
+	}
+	store.Backend = strings.ToLower(store.Backend)
+	if store.Backend != "mysql" {
+		return nil, fmt.Errorf(
+			"must specify one of these supported backends: mysql")
+	}
+	if store.URL == "" {
+		return nil, fmt.Errorf("must provide a non-empty database URL")
+	}
+	return &store, nil
+}
+
+// ParseBugsnag tries to parse out a Bugsnag Configuration from a Viper.
+// If no values are provided, returns a nil pointer.
+func ParseBugsnag(configuration *viper.Viper) (*bugsnag.Configuration, error) {
+	// can't unmarshal because we can't add tags to the bugsnag.Configuration
+	// struct
+	bugconf := bugsnag.Configuration{
+		APIKey:       configuration.GetString("reporting.bugsnag.api_key"),
+		ReleaseStage: configuration.GetString("reporting.bugsnag.release_stage"),
+		Endpoint:     configuration.GetString("reporting.bugsnag.endpoint"),
+	}
+	if bugconf.APIKey == "" && bugconf.ReleaseStage == "" && bugconf.Endpoint == "" {
+		return nil, nil
+	}
+	if bugconf.APIKey == "" {
+		return nil, fmt.Errorf("must provide an API key for bugsnag")
+	}
+	return &bugconf, nil
+}
+
+// utilities for handling common configurations
+
+// SetUpBugsnag configures bugsnag and sets up a logrus hook
+func SetUpBugsnag(config *bugsnag.Configuration) error {
+	if config != nil {
+		bugsnag.Configure(*config)
+		hook, err := bugsnag_hook.NewBugsnagHook()
+		if err != nil {
+			return err
+		}
+		logrus.AddHook(hook)
+		logrus.Debug("Adding logrus hook for Bugsnag")
+	}
+	return nil
+}

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -274,6 +274,27 @@ func TestParseTLSWithTLS(t *testing.T) {
 	assert.Equal(t, expected, *tlsOpts)
 }
 
+func TestParseTLSWithTLSRelativeToConfigFile(t *testing.T) {
+	config := configure(`{
+		"server": {
+			"tls_cert_file": "path/to/cert",
+			"tls_key_file": "/abspath/to/key",
+			"client_ca_file": ""
+		}
+	}`)
+	config.SetConfigFile("/opt/me.json")
+
+	expected := ServerTLSOpts{
+		ServerCertFile: "/opt/path/to/cert",
+		ServerKeyFile:  "/abspath/to/key",
+		ClientCAFile:   "",
+	}
+
+	tlsOpts, err := ParseServerTLS(config, false)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *tlsOpts)
+}
+
 func TestParseTLSWithEnvironmentVariables(t *testing.T) {
 	config := configure(`{
 		"server": {

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -1,0 +1,220 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// initializes a viper object with test configuration
+func configure(jsonConfig string) *viper.Viper {
+	config := viper.New()
+	config.SetConfigType("json")
+	config.ReadConfig(bytes.NewBuffer([]byte(jsonConfig)))
+	return config
+}
+
+// An error is returned if the log level is not parsable
+func TestParseInvalidLogLevel(t *testing.T) {
+	_, err := ParseLogLevel(configure(`{"logging": {"level": "horatio"}}`),
+		logrus.DebugLevel)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid logrus Level")
+}
+
+// If there is no logging level configured it is set to the default level
+func TestParseNoLogLevel(t *testing.T) {
+	empties := []string{`{}`, `{"logging": {}}`}
+	for _, configJSON := range empties {
+		lvl, err := ParseLogLevel(configure(configJSON), logrus.DebugLevel)
+		assert.NoError(t, err)
+		assert.Equal(t, logrus.DebugLevel, lvl)
+	}
+}
+
+// If there is logging level configured, it is set to the configured one
+func TestParseLogLevel(t *testing.T) {
+	lvl, err := ParseLogLevel(configure(`{"logging": {"level": "error"}}`),
+		logrus.DebugLevel)
+	assert.NoError(t, err)
+	assert.Equal(t, logrus.ErrorLevel, lvl)
+}
+
+// An error is returned if there's no API key
+func TestParseInvalidBugsnag(t *testing.T) {
+	_, err := ParseBugsnag(configure(
+		`{"reporting": {"bugsnag": {"endpoint": "http://12345"}}}`))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must provide an API key")
+}
+
+// If there's no bugsnag, a nil pointer is returned
+func TestParseNoBugsnag(t *testing.T) {
+	empties := []string{`{}`, `{"reporting": {}}`}
+	for _, configJSON := range empties {
+		bugconf, err := ParseBugsnag(configure(configJSON))
+		assert.NoError(t, err)
+		assert.Nil(t, bugconf)
+	}
+}
+
+func TestParseBugsnag(t *testing.T) {
+	config := configure(`{
+		"reporting": {
+			"bugsnag": {
+				"api_key": "12345",
+				"release_stage": "production",
+				"endpoint": "http://1234.com"
+			}
+		}
+	}`)
+
+	expected := bugsnag.Configuration{
+		APIKey:       "12345",
+		ReleaseStage: "production",
+		Endpoint:     "http://1234.com",
+	}
+
+	bugconf, err := ParseBugsnag(config)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *bugconf)
+}
+
+// If the storage parameters are invalid, an error is returned
+func TestParseInvalidStorage(t *testing.T) {
+	invalids := []string{
+		`{"storage": {"backend": "memow", "db_url": "1234"}}`,
+		`{"storage": {"db_url": "12345"}}`,
+		`{"storage": {"backend": "mysql"}}`,
+		`{"storage": {"backend": "mysql", "db_url": ""}}`,
+	}
+	for _, configJSON := range invalids {
+		_, err := ParseStorage(configure(configJSON))
+		assert.Error(t, err, fmt.Sprintf("'%s' should be an error", configJSON))
+		if strings.Contains(configJSON, "mysql") {
+			assert.Contains(t, err.Error(),
+				"must provide a non-empty database URL")
+		} else {
+			assert.Contains(t, err.Error(),
+				"must specify one of these supported backends: mysql")
+		}
+	}
+}
+
+// If there is no storage, a nil pointer is returned
+func TestParseNoStorage(t *testing.T) {
+	empties := []string{`{}`, `{"storage": {}}`}
+	for _, configJSON := range empties {
+		store, err := ParseStorage(configure(configJSON))
+		assert.NoError(t, err)
+		assert.Nil(t, store)
+	}
+}
+
+func TestParseStorage(t *testing.T) {
+	config := configure(`{
+		"storage": {
+			"backend": "MySQL",
+			"db_url": "username:passord@tcp(hostname:1234)/dbname"
+		}
+	}`)
+
+	expected := Storage{
+		Backend: "mysql",
+		URL:     "username:passord@tcp(hostname:1234)/dbname",
+	}
+
+	store, err := ParseStorage(config)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *store)
+}
+
+// If the server section is missing or missing HTTP/GRPC addresses, an error is
+// returned
+func TestParseInvalidOrNoServer(t *testing.T) {
+	invalids := []string{`{}`, `{"server": {}}`}
+	for _, configJSON := range invalids {
+		_, err := ParseServer(configure(configJSON), false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must have an HTTP and/or GRPC address")
+	}
+}
+
+// If TLS is required and the parameters are missing, an error is returned
+func TestParseInvalidServerNoTLSWhenRequired(t *testing.T) {
+	invalids := []string{
+		`{"server": {"http_addr": ":443", "tls_cert_file": "path/to/cert"}}`,
+		`{"server": {"http_addr": ":443", "tls_key_file": "path/to/key"}}`,
+	}
+	for _, configJSON := range invalids {
+		_, err := ParseServer(configure(configJSON), true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(),
+			"both the TLS certificate and key are mandatory")
+	}
+}
+
+// If TLS is not and the cert/key are partially provided, an error is returned
+func TestParseInvalidServerPartialTLS(t *testing.T) {
+	invalids := []string{
+		`{"server": {"http_addr": ":443", "tls_cert_file": "path/to/cert"}}`,
+		`{"server": {"http_addr": ":443", "tls_key_file": "path/to/key"}}`,
+	}
+	for _, configJSON := range invalids {
+		_, err := ParseServer(configure(configJSON), false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(),
+			"either include both a cert and key file, or neither to disable TLS")
+	}
+}
+
+func TestParseServerNoTLS(t *testing.T) {
+	config := configure(`{
+		"server": {
+			"http_addr": ":4443",
+			"grpc_addr": ":7899"
+		}
+	}`)
+
+	expected := Server{
+		HTTPAddr:      ":4443",
+		GRPCAddr:      ":7899",
+		ServerTLSOpts: nil,
+	}
+
+	server, err := ParseServer(config, false)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *server)
+}
+
+func TestUnmarshalConfigServerWithTLS(t *testing.T) {
+	config := configure(`{
+		"server": {
+			"http_addr": ":4443",
+			"grpc_addr": ":7899",
+			"tls_cert_file": "path/to/cert",
+			"tls_key_file": "path/to/key",
+			"client_ca_file": "path/to/clientca"
+		}
+	}`)
+
+	expected := Server{
+		HTTPAddr: ":4443",
+		GRPCAddr: ":7899",
+		ServerTLSOpts: &ServerTLSOpts{
+			ServerCertFile: "path/to/cert",
+			ServerKeyFile:  "path/to/key",
+			ClientCAFile:   "path/to/clientca",
+		},
+	}
+
+	server, err := ParseServer(config, false)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *server)
+}

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,12 +13,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const envPrefix = "NOTARY_TESTING_ENV_PREFIX"
+
 // initializes a viper object with test configuration
 func configure(jsonConfig string) *viper.Viper {
 	config := viper.New()
+	SetupViper(config, envPrefix)
 	config.SetConfigType("json")
 	config.ReadConfig(bytes.NewBuffer([]byte(jsonConfig)))
 	return config
+}
+
+// Sets the environment variables in the given map, prefixed by envPrefix.
+func setupEnvironmentVariables(t *testing.T, vars map[string]string) {
+	for k, v := range vars {
+		err := os.Setenv(fmt.Sprintf("%s_%s", envPrefix, k), v)
+		assert.NoError(t, err)
+	}
+}
+
+// Unsets whatever environment variables were set with this map
+func cleanupEnvironmentVariables(t *testing.T, vars map[string]string) {
+	for k := range vars {
+		err := os.Unsetenv(fmt.Sprintf("%s_%s", envPrefix, k))
+		assert.NoError(t, err)
+	}
+
 }
 
 // An error is returned if the log level is not parsable
@@ -41,6 +62,17 @@ func TestParseNoLogLevel(t *testing.T) {
 // If there is logging level configured, it is set to the configured one
 func TestParseLogLevel(t *testing.T) {
 	lvl, err := ParseLogLevel(configure(`{"logging": {"level": "error"}}`),
+		logrus.DebugLevel)
+	assert.NoError(t, err)
+	assert.Equal(t, logrus.ErrorLevel, lvl)
+}
+
+func TestParseLogLevelWithEnvironmentVariables(t *testing.T) {
+	vars := map[string]string{"LOGGING_LEVEL": "error"}
+	setupEnvironmentVariables(t, vars)
+	defer cleanupEnvironmentVariables(t, vars)
+
+	lvl, err := ParseLogLevel(configure(`{}`),
 		logrus.DebugLevel)
 	assert.NoError(t, err)
 	assert.Equal(t, logrus.ErrorLevel, lvl)
@@ -86,23 +118,51 @@ func TestParseBugsnag(t *testing.T) {
 	assert.Equal(t, expected, *bugconf)
 }
 
+func TestParseBugsnagWithEnvironmentVariables(t *testing.T) {
+	config := configure(`{
+		"reporting": {
+			"bugsnag": {
+				"api_key": "12345",
+				"release_stage": "staging"
+			}
+		}
+	}`)
+
+	vars := map[string]string{
+		"REPORTING_BUGSNAG_RELEASE_STAGE": "production",
+		"REPORTING_BUGSNAG_ENDPOINT":      "http://1234.com",
+	}
+	setupEnvironmentVariables(t, vars)
+	defer cleanupEnvironmentVariables(t, vars)
+
+	expected := bugsnag.Configuration{
+		APIKey:       "12345",
+		ReleaseStage: "production",
+		Endpoint:     "http://1234.com",
+	}
+
+	bugconf, err := ParseBugsnag(config)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *bugconf)
+}
+
 // If the storage parameters are invalid, an error is returned
 func TestParseInvalidStorage(t *testing.T) {
 	invalids := []string{
-		`{"storage": {"backend": "memow", "db_url": "1234"}}`,
+		`{"storage": {"backend": "postgres", "db_url": "1234"}}`,
 		`{"storage": {"db_url": "12345"}}`,
 		`{"storage": {"backend": "mysql"}}`,
-		`{"storage": {"backend": "mysql", "db_url": ""}}`,
+		`{"storage": {"backend": "sqlite3", "db_url": ""}}`,
 	}
 	for _, configJSON := range invalids {
-		_, err := ParseStorage(configure(configJSON))
+		_, err := ParseStorage(configure(configJSON), []string{"mysql", "sqlite3"})
 		assert.Error(t, err, fmt.Sprintf("'%s' should be an error", configJSON))
-		if strings.Contains(configJSON, "mysql") {
+		if strings.Contains(configJSON, "mysql") || strings.Contains(configJSON, "sqlite3") {
 			assert.Contains(t, err.Error(),
-				"must provide a non-empty database URL")
+				"must provide a non-empty database source")
 		} else {
 			assert.Contains(t, err.Error(),
-				"must specify one of these supported backends: mysql")
+				"must specify one of these supported backends: mysql, sqlite3")
 		}
 	}
 }
@@ -111,7 +171,7 @@ func TestParseInvalidStorage(t *testing.T) {
 func TestParseNoStorage(t *testing.T) {
 	empties := []string{`{}`, `{"storage": {}}`}
 	for _, configJSON := range empties {
-		store, err := ParseStorage(configure(configJSON))
+		store, err := ParseStorage(configure(configJSON), []string{"mysql"})
 		assert.NoError(t, err)
 		assert.Nil(t, store)
 	}
@@ -127,33 +187,43 @@ func TestParseStorage(t *testing.T) {
 
 	expected := Storage{
 		Backend: "mysql",
-		URL:     "username:passord@tcp(hostname:1234)/dbname",
+		Source:  "username:passord@tcp(hostname:1234)/dbname",
 	}
 
-	store, err := ParseStorage(config)
+	store, err := ParseStorage(config, []string{"mysql"})
 	assert.NoError(t, err)
 	assert.Equal(t, expected, *store)
 }
 
-// If the server section is missing or missing HTTP/GRPC addresses, an error is
-// returned
-func TestParseInvalidOrNoServer(t *testing.T) {
-	invalids := []string{`{}`, `{"server": {}}`}
-	for _, configJSON := range invalids {
-		_, err := ParseServer(configure(configJSON), false)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "must have an HTTP and/or GRPC address")
+func TestParseStorageWithEnvironmentVariables(t *testing.T) {
+	config := configure(`{
+		"storage": {
+			"db_url": "username:passord@tcp(hostname:1234)/dbname"
+		}
+	}`)
+
+	vars := map[string]string{"STORAGE_BACKEND": "MySQL"}
+	setupEnvironmentVariables(t, vars)
+	defer cleanupEnvironmentVariables(t, vars)
+
+	expected := Storage{
+		Backend: "mysql",
+		Source:  "username:passord@tcp(hostname:1234)/dbname",
 	}
+
+	store, err := ParseStorage(config, []string{"mysql"})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *store)
 }
 
 // If TLS is required and the parameters are missing, an error is returned
-func TestParseInvalidServerNoTLSWhenRequired(t *testing.T) {
+func TestParseTLSNoTLSWhenRequired(t *testing.T) {
 	invalids := []string{
-		`{"server": {"http_addr": ":443", "tls_cert_file": "path/to/cert"}}`,
-		`{"server": {"http_addr": ":443", "tls_key_file": "path/to/key"}}`,
+		`{"server": {"tls_cert_file": "path/to/cert"}}`,
+		`{"server": {"tls_key_file": "path/to/key"}}`,
 	}
 	for _, configJSON := range invalids {
-		_, err := ParseServer(configure(configJSON), true)
+		_, err := ParseServerTLS(configure(configJSON), true)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(),
 			"both the TLS certificate and key are mandatory")
@@ -161,60 +231,71 @@ func TestParseInvalidServerNoTLSWhenRequired(t *testing.T) {
 }
 
 // If TLS is not and the cert/key are partially provided, an error is returned
-func TestParseInvalidServerPartialTLS(t *testing.T) {
+func TestParseTLSPartialTLS(t *testing.T) {
 	invalids := []string{
-		`{"server": {"http_addr": ":443", "tls_cert_file": "path/to/cert"}}`,
-		`{"server": {"http_addr": ":443", "tls_key_file": "path/to/key"}}`,
+		`{"server": {"tls_cert_file": "path/to/cert"}}`,
+		`{"server": {"tls_key_file": "path/to/key"}}`,
 	}
 	for _, configJSON := range invalids {
-		_, err := ParseServer(configure(configJSON), false)
+		_, err := ParseServerTLS(configure(configJSON), false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(),
 			"either include both a cert and key file, or neither to disable TLS")
 	}
 }
 
-func TestParseServerNoTLS(t *testing.T) {
+func TestParseTLSNoTLSNotRequired(t *testing.T) {
 	config := configure(`{
-		"server": {
-			"http_addr": ":4443",
-			"grpc_addr": ":7899"
-		}
+		"server": {}
 	}`)
 
-	expected := Server{
-		HTTPAddr:      ":4443",
-		GRPCAddr:      ":7899",
-		ServerTLSOpts: nil,
-	}
-
-	server, err := ParseServer(config, false)
+	tlsOpts, err := ParseServerTLS(config, false)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, *server)
+	assert.Nil(t, tlsOpts)
 }
 
-func TestUnmarshalConfigServerWithTLS(t *testing.T) {
+func TestParseTLSWithTLS(t *testing.T) {
 	config := configure(`{
 		"server": {
-			"http_addr": ":4443",
-			"grpc_addr": ":7899",
 			"tls_cert_file": "path/to/cert",
 			"tls_key_file": "path/to/key",
 			"client_ca_file": "path/to/clientca"
 		}
 	}`)
 
-	expected := Server{
-		HTTPAddr: ":4443",
-		GRPCAddr: ":7899",
-		ServerTLSOpts: &ServerTLSOpts{
-			ServerCertFile: "path/to/cert",
-			ServerKeyFile:  "path/to/key",
-			ClientCAFile:   "path/to/clientca",
-		},
+	expected := ServerTLSOpts{
+		ServerCertFile: "path/to/cert",
+		ServerKeyFile:  "path/to/key",
+		ClientCAFile:   "path/to/clientca",
 	}
 
-	server, err := ParseServer(config, false)
+	tlsOpts, err := ParseServerTLS(config, false)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, *server)
+	assert.Equal(t, expected, *tlsOpts)
+}
+
+func TestParseTLSWithEnvironmentVariables(t *testing.T) {
+	config := configure(`{
+		"server": {
+			"tls_cert_file": "path/to/cert",
+			"client_ca_file": "nosuchfile"
+		}
+	}`)
+
+	vars := map[string]string{
+		"SERVER_TLS_KEY_FILE":   "path/to/key",
+		"SERVER_CLIENT_CA_FILE": "path/to/clientca",
+	}
+	setupEnvironmentVariables(t, vars)
+	defer cleanupEnvironmentVariables(t, vars)
+
+	expected := ServerTLSOpts{
+		ServerCertFile: "path/to/cert",
+		ServerKeyFile:  "path/to/key",
+		ClientCAFile:   "path/to/clientca",
+	}
+
+	tlsOpts, err := ParseServerTLS(config, true)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, *tlsOpts)
 }

--- a/utils/tls_config.go
+++ b/utils/tls_config.go
@@ -44,10 +44,9 @@ func poolFromFile(filename string) (*x509.CertPool, error) {
 // ServerTLSOpts generates a tls configuration for servers using the
 // provided parameters.
 type ServerTLSOpts struct {
-	ServerCertFile    string
-	ServerKeyFile     string
-	RequireClientAuth bool
-	ClientCAFile      string
+	ServerCertFile string `mapstructure:"tls_cert_file"`
+	ServerKeyFile  string `mapstructure:"tls_key_file"`
+	ClientCAFile   string `mapstructure:"client_ca_file"`
 }
 
 // ConfigureServerTLS specifies a set of ciphersuites, the server cert and key,
@@ -73,16 +72,13 @@ func ConfigureServerTLS(opts *ServerTLSOpts) (*tls.Config, error) {
 		Rand:                     rand.Reader,
 	}
 
-	if opts.RequireClientAuth {
-		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	}
-
 	if opts.ClientCAFile != "" {
 		pool, err := poolFromFile(opts.ClientCAFile)
 		if err != nil {
 			return nil, err
 		}
 		tlsConfig.ClientCAs = pool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 
 	return tlsConfig, nil
@@ -91,11 +87,11 @@ func ConfigureServerTLS(opts *ServerTLSOpts) (*tls.Config, error) {
 // ClientTLSOpts is a struct that contains options to pass to
 // ConfigureClientTLS
 type ClientTLSOpts struct {
-	RootCAFile         string
-	ServerName         string
-	InsecureSkipVerify bool
-	ClientCertFile     string
-	ClientKeyFile      string
+	RootCAFile         string `json:"tls_ca_file"`
+	ServerName         string `json:"hostname"`
+	InsecureSkipVerify bool   `json:"-"`
+	ClientCertFile     string `json:"tls_client_cert"`
+	ClientKeyFile      string `json:"tls_client_key"`
 }
 
 // ConfigureClientTLS generates a tls configuration for clients using the

--- a/utils/tls_config.go
+++ b/utils/tls_config.go
@@ -44,9 +44,9 @@ func poolFromFile(filename string) (*x509.CertPool, error) {
 // ServerTLSOpts generates a tls configuration for servers using the
 // provided parameters.
 type ServerTLSOpts struct {
-	ServerCertFile string `mapstructure:"tls_cert_file"`
-	ServerKeyFile  string `mapstructure:"tls_key_file"`
-	ClientCAFile   string `mapstructure:"client_ca_file"`
+	ServerCertFile string
+	ServerKeyFile  string
+	ClientCAFile   string
 }
 
 // ConfigureServerTLS specifies a set of ciphersuites, the server cert and key,
@@ -87,11 +87,11 @@ func ConfigureServerTLS(opts *ServerTLSOpts) (*tls.Config, error) {
 // ClientTLSOpts is a struct that contains options to pass to
 // ConfigureClientTLS
 type ClientTLSOpts struct {
-	RootCAFile         string `json:"tls_ca_file"`
-	ServerName         string `json:"hostname"`
-	InsecureSkipVerify bool   `json:"-"`
-	ClientCertFile     string `json:"tls_client_cert"`
-	ClientKeyFile      string `json:"tls_client_key"`
+	RootCAFile         string
+	ServerName         string
+	InsecureSkipVerify bool
+	ClientCertFile     string
+	ClientKeyFile      string
 }
 
 // ConfigureClientTLS generates a tls configuration for clients using the

--- a/utils/tls_config_test.go
+++ b/utils/tls_config_test.go
@@ -60,10 +60,9 @@ func TestConfigServerTLSFailsIfUnableToLoadCerts(t *testing.T) {
 		files[i] = "not-real-file"
 
 		result, err := ConfigureServerTLS(&ServerTLSOpts{
-			ServerCertFile:    files[0],
-			ServerKeyFile:     files[1],
-			RequireClientAuth: true,
-			ClientCAFile:      files[2],
+			ServerCertFile: files[0],
+			ServerKeyFile:  files[1],
+			ClientCAFile:   files[2],
 		})
 		assert.Nil(t, result)
 		assert.Error(t, err)
@@ -106,7 +105,7 @@ func TestConfigServerTLSWithEmptyCACertFile(t *testing.T) {
 
 // If server cert and key are provided, and client cert file is provided with
 // one cert, a valid tls.Config is returned with the clientCAs set to that
-// cert.
+// cert.  ClientAuth is set to RequireAndVerifyClientCert.
 func TestConfigServerTLSWithOneCACert(t *testing.T) {
 	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
 	assert.NoError(t, err)
@@ -119,13 +118,13 @@ func TestConfigServerTLSWithOneCACert(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
 	assert.True(t, tlsConfig.PreferServerCipherSuites)
-	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
+	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 	assert.Len(t, tlsConfig.ClientCAs.Subjects(), 1)
 }
 
 // If server cert and key are provided, and client cert file is provided with
 // multiple certs, a valid tls.Config is returned with the clientCAs set to
-// the valid cert.
+// the valid cert.  ClientAuth is set to RequireAndVerifyClientCert.
 func TestConfigServerTLSWithMultipleCACerts(t *testing.T) {
 	tempFilename := generateMultiCert(t)
 	defer os.RemoveAll(tempFilename)
@@ -141,27 +140,8 @@ func TestConfigServerTLSWithMultipleCACerts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
 	assert.True(t, tlsConfig.PreferServerCipherSuites)
-	assert.Equal(t, tls.NoClientCert, tlsConfig.ClientAuth)
-	assert.Len(t, tlsConfig.ClientCAs.Subjects(), 2)
-}
-
-// If server cert and key are provided, and client auth is disabled, then
-// a valid tls.Config is returned with ClientAuth set to
-// RequireAndVerifyClientCert
-func TestConfigServerTLSClientAuthEnabled(t *testing.T) {
-	keypair, err := tls.LoadX509KeyPair(ServerCert, ServerKey)
-	assert.NoError(t, err)
-
-	tlsConfig, err := ConfigureServerTLS(&ServerTLSOpts{
-		ServerCertFile:    ServerCert,
-		ServerKeyFile:     ServerKey,
-		RequireClientAuth: true,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, []tls.Certificate{keypair}, tlsConfig.Certificates)
-	assert.True(t, tlsConfig.PreferServerCipherSuites)
 	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
-	assert.Nil(t, tlsConfig.ClientCAs)
+	assert.Len(t, tlsConfig.ClientCAs.Subjects(), 2)
 }
 
 // The skipVerify boolean gets set on the tls.Config's InsecureSkipBoolean


### PR DESCRIPTION
This factors out some config file parsing utilities common to server and signer.  This makes the config files look a lot more similar, but it also adds a few changes:

1.  Both server/signer server TLS have the following parameters now:
    - `tls_cert_file` (signer was previously `cert_file`)
    - `tls_key_file` (signer was previously `key_file`)

2. Both the server/signer have the following http parameters now:
   - `http_addr` (server was previously `addr`)

3. Both the server/signer have the following logging parameters now:
   - `debug` as a string value (signer was previously an int)

4. Both server/signer now support Bugsnag reporting (previously the signer did not)

5. The default alias for the signer DB store are also available as config file parameters under "storage" now.  The password remains the same, because I'm not sure how best to deal with that.

6. The tls files are now parsed as paths relative to the config file, if they aren't absolute paths or empty.

7. Both the server and signer have mandatory storage sections now, and both also now support a memory backend (previously, server's storage section was optional, and signer's storage section only supported mysql)

Apologies for the massive change.  Tested this with `docker-compose up` and initting/adding/publishing/listing a repo (but not the bugsnag part or alias change).

Fixes #304.