### PR TITLE
Renamed keystoremanager to certs, and KeyStoreManager to Manager.

### DIFF
--- a/certs/certmanager.go
+++ b/certs/certmanager.go
@@ -1,4 +1,4 @@
-package keystoremanager
+package certs
 
 import (
 	"crypto/x509"
@@ -13,17 +13,13 @@ import (
 	"github.com/docker/notary/tuf/signed"
 )
 
-// KeyStoreManager is an abstraction around the root and non-root key stores,
-// and related CA stores
-type KeyStoreManager struct {
+// Manager is an abstraction around trusted root CA stores
+type Manager struct {
 	trustedCAStore          trustmanager.X509Store
 	trustedCertificateStore trustmanager.X509Store
 }
 
-const (
-	trustDir       = "trusted_certificates"
-	rsaRootKeySize = 4096 // Used for new root keys
-)
+const trustDir = "trusted_certificates"
 
 // ErrValidationFail is returned when there is no valid trusted certificates
 // being served inside of the roots.json
@@ -49,9 +45,9 @@ func (err ErrRootRotationFail) Error() string {
 	return fmt.Sprintf("could not rotate trust to a new trusted root: %s", err.Reason)
 }
 
-// NewKeyStoreManager returns an initialized KeyStoreManager, or an error
-// if it fails to create the KeyFileStores or load certificates
-func NewKeyStoreManager(baseDir string) (*KeyStoreManager, error) {
+// NewManager returns an initialized Manager, or an error
+// if it fails to load certificates
+func NewManager(baseDir string) (*Manager, error) {
 	trustPath := filepath.Join(baseDir, trustDir)
 
 	// Load all CAs that aren't expired and don't use SHA1
@@ -78,32 +74,32 @@ func NewKeyStoreManager(baseDir string) (*KeyStoreManager, error) {
 		return nil, err
 	}
 
-	return &KeyStoreManager{
+	return &Manager{
 		trustedCAStore:          trustedCAStore,
 		trustedCertificateStore: trustedCertificateStore,
 	}, nil
 }
 
 // TrustedCertificateStore returns the trusted certificate store being managed
-// by this KeyStoreManager
-func (km *KeyStoreManager) TrustedCertificateStore() trustmanager.X509Store {
-	return km.trustedCertificateStore
+// by this Manager
+func (m *Manager) TrustedCertificateStore() trustmanager.X509Store {
+	return m.trustedCertificateStore
 }
 
-// TrustedCAStore returns the CA store being managed by this KeyStoreManager
-func (km *KeyStoreManager) TrustedCAStore() trustmanager.X509Store {
-	return km.trustedCAStore
+// TrustedCAStore returns the CA store being managed by this Manager
+func (m *Manager) TrustedCAStore() trustmanager.X509Store {
+	return m.trustedCAStore
 }
 
 // AddTrustedCert adds a cert to the trusted certificate store (not the CA
 // store)
-func (km *KeyStoreManager) AddTrustedCert(cert *x509.Certificate) {
-	km.trustedCertificateStore.AddCert(cert)
+func (m *Manager) AddTrustedCert(cert *x509.Certificate) {
+	m.trustedCertificateStore.AddCert(cert)
 }
 
 // AddTrustedCACert adds a cert to the trusted CA certificate store
-func (km *KeyStoreManager) AddTrustedCACert(cert *x509.Certificate) {
-	km.trustedCAStore.AddCert(cert)
+func (m *Manager) AddTrustedCACert(cert *x509.Certificate) {
+	m.trustedCAStore.AddCert(cert)
 }
 
 /*
@@ -133,7 +129,7 @@ we are using the current public PKI to validate the first download of the certif
 adding an extra layer of security over the normal (SSH style) trust model.
 We shall call this: TOFUS.
 */
-func (km *KeyStoreManager) ValidateRoot(root *data.Signed, gun string) error {
+func (m *Manager) ValidateRoot(root *data.Signed, gun string) error {
 	logrus.Debugf("entered ValidateRoot with dns: %s", gun)
 	signedRoot, err := data.RootFromSigned(root)
 	if err != nil {
@@ -148,7 +144,7 @@ func (km *KeyStoreManager) ValidateRoot(root *data.Signed, gun string) error {
 	}
 
 	// Retrieve all the trusted certificates that match this gun
-	certsForCN, err := km.trustedCertificateStore.GetCertificatesByCN(gun)
+	certsForCN, err := m.trustedCertificateStore.GetCertificatesByCN(gun)
 	if err != nil {
 		// If the error that we get back is different than ErrNoCertificatesFound
 		// we couldn't check if there are any certificates with this CN already
@@ -187,7 +183,7 @@ func (km *KeyStoreManager) ValidateRoot(root *data.Signed, gun string) error {
 	// Do root certificate rotation: we trust only the certs present in the new root
 	// First we add all the new certificates (even if they already exist)
 	for _, cert := range allValidCerts {
-		err := km.trustedCertificateStore.AddCert(cert)
+		err := m.trustedCertificateStore.AddCert(cert)
 		if err != nil {
 			// If the error is already exists we don't fail the rotation
 			if _, ok := err.(*trustmanager.ErrCertExists); ok {
@@ -201,7 +197,7 @@ func (km *KeyStoreManager) ValidateRoot(root *data.Signed, gun string) error {
 	// Now we delete old certificates that aren't present in the new root
 	for certID, cert := range certsToRemove(certsForCN, allValidCerts) {
 		logrus.Debugf("removing certificate with certID: %s", certID)
-		err = km.trustedCertificateStore.RemoveCert(cert)
+		err = m.trustedCertificateStore.RemoveCert(cert)
 		if err != nil {
 			logrus.Debugf("failed to remove trusted certificate with keyID: %s, %v", certID, err)
 			return &ErrRootRotationFail{Reason: "failed to rotate root keys"}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -146,7 +146,7 @@ func testInitRepo(t *testing.T, rootType string) {
 	_, err = os.Stat(filepath.Join(tempBaseDir, "private", "root_keys", rootKeyFilename))
 	assert.NoError(t, err, "missing root key")
 
-	certificates := repo.KeyStoreManager.TrustedCertificateStore().GetCertificates()
+	certificates := repo.CertManager.TrustedCertificateStore().GetCertificates()
 	assert.Len(t, certificates, 1, "unexpected number of certificates")
 
 	certID, err := trustmanager.FingerprintCert(certificates[0])

--- a/client/repo.go
+++ b/client/repo.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"path/filepath"
 
+	"github.com/docker/notary/certs"
 	"github.com/docker/notary/cryptoservice"
-	"github.com/docker/notary/keystoremanager"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/store"
@@ -24,7 +24,7 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 		return nil, fmt.Errorf("failed to create private key store in directory: %s", baseDir)
 	}
 
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(baseDir)
+	certManager, err := certs.NewManager(baseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -32,13 +32,13 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 	cryptoService := cryptoservice.NewCryptoService(gun, fileKeyStore)
 
 	nRepo := &NotaryRepository{
-		gun:             gun,
-		baseDir:         baseDir,
-		baseURL:         baseURL,
-		tufRepoPath:     filepath.Join(baseDir, tufDir, filepath.FromSlash(gun)),
-		CryptoService:   cryptoService,
-		roundTrip:       rt,
-		KeyStoreManager: keyStoreManager,
+		gun:           gun,
+		baseDir:       baseDir,
+		baseURL:       baseURL,
+		tufRepoPath:   filepath.Join(baseDir, tufDir, filepath.FromSlash(gun)),
+		CryptoService: cryptoService,
+		roundTrip:     rt,
+		CertManager:   certManager,
 	}
 
 	fileStore, err := store.NewFilesystemStore(

--- a/client/repo_pkcs11.go
+++ b/client/repo_pkcs11.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"path/filepath"
 
+	"github.com/docker/notary/certs"
 	"github.com/docker/notary/cryptoservice"
-	"github.com/docker/notary/keystoremanager"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/trustmanager/yubikey"
@@ -27,7 +27,7 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 		return nil, fmt.Errorf("failed to create private key store in directory: %s", baseDir)
 	}
 
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(baseDir)
+	certManager, err := certs.NewManager(baseDir)
 	yubiKeyStore, _ := yubikey.NewYubiKeyStore(fileKeyStore, retriever)
 	var cryptoService signed.CryptoService
 	if yubiKeyStore == nil {
@@ -37,13 +37,13 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 	}
 
 	nRepo := &NotaryRepository{
-		gun:             gun,
-		baseDir:         baseDir,
-		baseURL:         baseURL,
-		tufRepoPath:     filepath.Join(baseDir, tufDir, filepath.FromSlash(gun)),
-		CryptoService:   cryptoService,
-		roundTrip:       rt,
-		KeyStoreManager: keyStoreManager,
+		gun:           gun,
+		baseDir:       baseDir,
+		baseURL:       baseURL,
+		tufRepoPath:   filepath.Join(baseDir, tufDir, filepath.FromSlash(gun)),
+		CryptoService: cryptoService,
+		roundTrip:     rt,
+		CertManager:   certManager,
 	}
 
 	fileStore, err := store.NewFilesystemStore(

--- a/cmd/notary/cert.go
+++ b/cmd/notary/cert.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/docker/notary/keystoremanager"
+	"github.com/docker/notary/certs"
 	"github.com/docker/notary/trustmanager"
 
 	"github.com/spf13/cobra"
@@ -54,7 +54,7 @@ func certRemove(cmd *cobra.Command, args []string) {
 	parseConfig()
 
 	trustDir := mainViper.GetString("trust_dir")
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(trustDir)
+	certManager, err := certs.NewManager(trustDir)
 	if err != nil {
 		fatalf("Failed to create a new truststore manager with directory: %s", trustDir)
 	}
@@ -69,18 +69,19 @@ func certRemove(cmd *cobra.Command, args []string) {
 			fatalf("Invalid certificate ID provided: %s", certID)
 		}
 		// Attempt to find this certificates
-		cert, err := keyStoreManager.TrustedCertificateStore().GetCertificateByCertID(certID)
+		cert, err := certManager.TrustedCertificateStore().GetCertificateByCertID(certID)
 		if err != nil {
 			fatalf("Unable to retrieve certificate with cert ID: %s", certID)
 		}
 		certsToRemove = append(certsToRemove, cert)
 	} else {
 		// We got the -g flag, it's a GUN
-		certs, err := keyStoreManager.TrustedCertificateStore().GetCertificatesByCN(certRemoveGUN)
+		toRemove, err := certManager.TrustedCertificateStore().GetCertificatesByCN(
+			certRemoveGUN)
 		if err != nil {
 			fatalf("%v", err)
 		}
-		certsToRemove = append(certsToRemove, certs...)
+		certsToRemove = append(certsToRemove, toRemove...)
 	}
 
 	// List all the keys about to be removed
@@ -103,7 +104,7 @@ func certRemove(cmd *cobra.Command, args []string) {
 
 	// Remove all the certs
 	for _, cert := range certsToRemove {
-		err = keyStoreManager.TrustedCertificateStore().RemoveCert(cert)
+		err = certManager.TrustedCertificateStore().RemoveCert(cert)
 		if err != nil {
 			fatalf("Failed to remove root certificate for %s", cert.Subject.CommonName)
 		}
@@ -118,14 +119,14 @@ func certList(cmd *cobra.Command, args []string) {
 	parseConfig()
 
 	trustDir := mainViper.GetString("trust_dir")
-	keyStoreManager, err := keystoremanager.NewKeyStoreManager(trustDir)
+	certManager, err := certs.NewManager(trustDir)
 	if err != nil {
 		fatalf("Failed to create a new truststore manager with directory: %s", trustDir)
 	}
 
 	cmd.Println("")
 	cmd.Println("# Trusted Certificates:")
-	trustedCerts := keyStoreManager.TrustedCertificateStore().GetCertificates()
+	trustedCerts := certManager.TrustedCertificateStore().GetCertificates()
 	for _, c := range trustedCerts {
 		printCert(cmd, c)
 	}


### PR DESCRIPTION
Since it no longer depends upon KeyStore, nor does it manipulate keys
in any way.

Signed-off-by: Ying Li <ying.li@docker.com>