### PR TITLE
Fix error handling on invalid root passphrase

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -209,11 +209,7 @@ func (r *NotaryRepository) Initialize(rootKeyID string) error {
 	err = r.tufRepo.InitRoot(false)
 	if err != nil {
 		logrus.Debug("Error on InitRoot: ", err.Error())
-		switch err.(type) {
-		case signed.ErrInsufficientSignatures, trustmanager.ErrPasswordInvalid:
-		default:
-			return err
-		}
+		return err
 	}
 	err = r.tufRepo.InitTargets()
 	if err != nil {

--- a/cryptoservice/crypto_service.go
+++ b/cryptoservice/crypto_service.go
@@ -82,10 +82,15 @@ func (cs *CryptoService) GetPrivateKey(keyID string) (k data.PrivateKey, role st
 	for _, ks := range cs.keyStores {
 		for _, keyPath := range keyPaths {
 			k, role, err = ks.GetKey(keyPath)
-			if err != nil {
+			if err == nil {
+				return
+			}
+			switch err.(type) {
+			case trustmanager.ErrPasswordInvalid, trustmanager.ErrAttemptsExceeded:
+				return
+			default:
 				continue
 			}
-			return
 		}
 	}
 	return // returns whatever the final values were

--- a/cryptoservice/crypto_service_test.go
+++ b/cryptoservice/crypto_service_test.go
@@ -23,9 +23,13 @@ var algoToSigType = map[string]data.SigAlgorithm{
 var passphraseRetriever = func(string, string, bool, int) (string, bool, error) { return "", false, nil }
 
 type CryptoServiceTester struct {
-	cryptoServiceFactory func() *CryptoService
-	role                 string
-	keyAlgo              string
+	role    string
+	keyAlgo string
+	gun     string
+}
+
+func (c CryptoServiceTester) cryptoServiceFactory() *CryptoService {
+	return NewCryptoService(c.gun, trustmanager.NewKeyMemoryStore(passphraseRetriever))
 }
 
 // asserts that created key exists
@@ -251,10 +255,6 @@ func (c CryptoServiceTester) errorMsg(message string, args ...interface{}) strin
 }
 
 func testCryptoService(t *testing.T, gun string) {
-	getTestingCryptoService := func() *CryptoService {
-		return NewCryptoService(
-			gun, trustmanager.NewKeyMemoryStore(passphraseRetriever))
-	}
 	roles := []string{
 		data.CanonicalRootRole,
 		data.CanonicalTargetsRole,
@@ -265,9 +265,9 @@ func testCryptoService(t *testing.T, gun string) {
 	for _, role := range roles {
 		for algo := range algoToSigType {
 			cst := CryptoServiceTester{
-				cryptoServiceFactory: getTestingCryptoService,
-				role:                 role,
-				keyAlgo:              algo,
+				role:    role,
+				keyAlgo: algo,
+				gun:     gun,
 			}
 			cst.TestCreateAndGetKey(t)
 			cst.TestCreateAndGetWhenMultipleKeystores(t)


### PR DESCRIPTION
When the user insists on an invalid passphrase (or aborts the operation), `CryptoService.GetPrivateKey` will try the correct root location first, correctly failing, and then try to look for the root key in the $gun subdirectory, and so will return the last error, a confusing
> open $path: no such file or directory


So, recognize the passphrase-related errors and fail with them directly.

Also remove misleading passphrase-related error handling in `NotaryRepository.Initialize`:
1. It is on a path where those errors can never happen
2. The specific error handling would silently ignore the error, which can’t be right anyway.
