### PR TITLE
Re-enable pushing coverage reports to codecov.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ _space := $(empty) $(empty)
 
 # go cover test variables
 COVERDIR=.cover
-COVERPROFILE=$(COVERDIR)/cover.out
+COVERPROFILE?=$(COVERDIR)/cover.out
 COVERMODE=count
 PKGS = $(shell go list ./... | tr '\n' ' ')
 

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,8 @@ machine:
     BASE_STABLE: ../../../$HOME/.gvm/pkgsets/stable/global/$BASE_DIR
   # Workaround Circle parsing dumb bugs and/or YAML wonkyness
     CIRCLE_PAIN: "mode: set"
+  # Put the coverage profile somewhere codecov's script can find it
+    COVERPROFILE: coverage.out
 
   hosts:
   # Not used yet
@@ -69,11 +71,10 @@ test:
         timeout: 600
         pwd: $BASE_STABLE
 
-  post:
     - gvm use stable && make covmerge:
         timeout: 600
         pwd: $BASE_STABLE
 
   # Report to codecov.io
-    # - bash <(curl -s https://codecov.io/bash):
-    #     pwd: $BASE_STABLE
+    - bash <(curl -s https://codecov.io/bash):
+        pwd: $BASE_STABLE

--- a/circle.yml
+++ b/circle.yml
@@ -71,10 +71,13 @@ test:
         timeout: 600
         pwd: $BASE_STABLE
 
+  post:
     - gvm use stable && make covmerge:
         timeout: 600
+        parallel: true
         pwd: $BASE_STABLE
 
   # Report to codecov.io
     - bash <(curl -s https://codecov.io/bash):
+        parallel: true
         pwd: $BASE_STABLE


### PR DESCRIPTION
Signed-off-by: Ying Li <ying.li@docker.com>

~~This needs someone with admin access to docker org needs to grant access to codecov and enable this repo in codecov.io.~~ Done

Also, [codecov.io](https://codecov.io), like [coveralls](https://coveralls.io), does line coverage rather than statement coverage, but this seems better than no coverage check.