### PR TITLE
initial database migration state

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,8 @@
+# Database Migrations
+
+This directory contains database migrations for the server and signer. They
+are being managed using [this tool](https://github.com/mattes/migrate).
+Within each of the server and signer directories are directories for different
+database backends. Notary server and signer use GORM and are therefore 
+capable of running on a number of different databases, however migrations
+may contain syntax specific to one backend.

--- a/migrations/server/mysql/0001_initial.down.sql
+++ b/migrations/server/mysql/0001_initial.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE `timestamp_keys`;
+
+DROP TABLE `tuf_files`;

--- a/migrations/server/mysql/0001_initial.up.sql
+++ b/migrations/server/mysql/0001_initial.up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE `timestamp_keys` (
+	  `id` int(11) NOT NULL AUTO_INCREMENT,
+	  `created_at` timestamp NULL DEFAULT NULL,
+	  `updated_at` timestamp NULL DEFAULT NULL,
+	  `deleted_at` timestamp NULL DEFAULT NULL,
+	  `gun` varchar(255) NOT NULL,
+	  `cipher` varchar(50) NOT NULL,
+	  `public` blob NOT NULL,
+	  PRIMARY KEY (`id`),
+	  UNIQUE KEY `gun` (`gun`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `tuf_files` (
+	  `id` int(11) NOT NULL AUTO_INCREMENT,
+	  `created_at` timestamp NULL DEFAULT NULL,
+	  `updated_at` timestamp NULL DEFAULT NULL,
+	  `deleted_at` timestamp NULL DEFAULT NULL,
+	  `gun` varchar(255) NOT NULL,
+	  `role` varchar(255) NOT NULL,
+	  `version` int(11) NOT NULL,
+	  `data` longblob NOT NULL,
+	  PRIMARY KEY (`id`),
+	  UNIQUE KEY `gun` (`gun`,`role`,`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/migrations/signer/mysql/0001_initial.down.sql
+++ b/migrations/signer/mysql/0001_initial.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE `private_keys`;

--- a/migrations/signer/mysql/0001_initial.up.sql
+++ b/migrations/signer/mysql/0001_initial.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `private_keys` (
+	  `id` int(11) NOT NULL AUTO_INCREMENT,
+	  `created_at` timestamp NULL DEFAULT NULL,
+	  `updated_at` timestamp NULL DEFAULT NULL,
+	  `deleted_at` timestamp NULL DEFAULT NULL,
+	  `key_id` varchar(255) NOT NULL,
+	  `encryption_alg` varchar(255) NOT NULL,
+	  `keywrap_alg` varchar(255) NOT NULL,
+	  `algorithm` varchar(50) NOT NULL,
+	  `passphrase_alias` varchar(50) NOT NULL,
+	  `public` blob NOT NULL,
+	  `private` blob NOT NULL,
+	  PRIMARY KEY (`id`),
+	  UNIQUE KEY `key_id` (`key_id`),
+	  UNIQUE KEY `key_id_2` (`key_id`,`algorithm`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Adds a super simple migrations solution to keep a handle on database changes. The initial files for the server and signer are current for the master branch.

cc @vikstrous @cyli @NathanMcCauley 

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)