### PR TITLE
Tiny refactor

### DIFF
--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -195,10 +195,9 @@ func main() {
 	mainViper.SetConfigType(strings.TrimPrefix(ext, "."))
 	mainViper.SetConfigName(strings.TrimSuffix(filename, ext))
 	mainViper.AddConfigPath(configPath)
-	err := mainViper.ReadInConfig()
-	if err != nil {
-		logrus.Error("Viper Error: ", err.Error())
-		logrus.Error("Could not read config at ", configFile)
+
+	if err := mainViper.ReadInConfig(); err != nil {
+		logrus.Errorf("Could not read config at :%s, viper error: %v", configFile, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
It's no need to keep the `err` after asserting it should be `nil`, and
we can merge these two logs into one I suppose.

Signed-off-by: Hu Keping <hukeping@huawei.com>