### PR TITLE
Refactor ParseServerTLS

### DIFF
--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -51,23 +51,16 @@ func ParseServerTLS(configuration *viper.Viper, tlsRequired bool) (*ServerTLSOpt
 		ServerKeyFile:  GetPathRelativeToConfig(configuration, "server.tls_key_file"),
 		ClientCAFile:   GetPathRelativeToConfig(configuration, "server.client_ca_file"),
 	}
-
 	cert, key := tlsOpts.ServerCertFile, tlsOpts.ServerKeyFile
-	if tlsRequired {
-		if cert == "" || key == "" {
-			return nil, fmt.Errorf("both the TLS certificate and key are mandatory")
-		}
-	} else {
-		if (cert == "" && key != "") || (cert != "" && key == "") {
-			return nil, fmt.Errorf(
-				"either include both a cert and key file, or neither to disable TLS")
-		}
-	}
 
-	if cert == "" && key == "" && tlsOpts.ClientCAFile == "" {
+	if !tlsRequired {
 		return nil, nil
 	}
 
+	// Both of the crt and key are needed if TLS was requred.
+	if cert == "" || key == "" {
+		return nil, fmt.Errorf("both the TLS certificate and key are mandatory")
+	}
 	return &tlsOpts, nil
 }
 


### PR DESCRIPTION
If I understand correctly, this function is used to generate a instance
of structure `ServerTLSOpts` if TLS is required and both of the certificate
and key are provided. Otherwise return nil.

So why should we check whether the one of certificate or key is empty
even if the TLS is not required. Will it miss something if just return
nil if the TLS is not required.

Signed-off-by: Hu Keping <hukeping@huawei.com>