### PR TITLE
unify the timestamp handler with the handler for getting other tuf metadata

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -89,14 +89,10 @@ func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.Cry
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("UpdateTuf"),
 			hand(handlers.AtomicUpdateHandler, "push", "pull")))
-	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:(root|targets|snapshot)}.json").Handler(
+	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:(root|targets|snapshot|timestamp)}.json").Handler(
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("GetRole"),
 			hand(handlers.GetHandler, "pull")))
-	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/timestamp.json").Handler(
-		prometheus.InstrumentHandlerWithOpts(
-			prometheusOpts("GetTimestamp"),
-			hand(handlers.GetTimestampHandler, "pull")))
 	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/timestamp.key").Handler(
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("GetTimestampKey"),


### PR DESCRIPTION
Rather than further fragmenting the code as we add support for server side snapshotting, I'd rather unify the handler that serves requests to retrieve TUF metadata. Conceptually I think it will make some of the logic a little clearer.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)