### PR TITLE
Generalize server keys

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -112,7 +112,7 @@ func getStore(configuration *viper.Viper, allowedBackends []string) (
 
 	store, err := storage.NewSQLStorage(storeConfig.Backend, storeConfig.Source)
 	if err != nil {
-		return nil, fmt.Errorf("Error starting DB driver: ", err.Error())
+		return nil, fmt.Errorf("Error starting DB driver: %s", err.Error())
 	}
 	health.RegisterPeriodicFunc(
 		"DB operational", store.CheckHealth, time.Second*60)

--- a/migrations/server/mysql/0002_role_on_keys.down.sql
+++ b/migrations/server/mysql/0002_role_on_keys.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `timestamp_keys` DROP KEY `gun_role`, DROP COLUMN `role`, ADD UNIQUE KEY `gun` (`gun`);

--- a/migrations/server/mysql/0002_role_on_keys.up.sql
+++ b/migrations/server/mysql/0002_role_on_keys.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `timestamp_keys` ADD COLUMN `role` VARCHAR(255) NOT NULL, DROP KEY `gun`, ADD UNIQUE KEY `gun_role` (`gun`, `role`);

--- a/migrations/server/mysql/0002_role_on_keys.up.sql
+++ b/migrations/server/mysql/0002_role_on_keys.up.sql
@@ -1,1 +1,3 @@
 ALTER TABLE `timestamp_keys` ADD COLUMN `role` VARCHAR(255) NOT NULL, DROP KEY `gun`, ADD UNIQUE KEY `gun_role` (`gun`, `role`);
+
+UPDATE `timestamp_keys` SET `role`="timestamp";

--- a/notarymysql/migrate.sql
+++ b/notarymysql/migrate.sql
@@ -14,3 +14,7 @@ ADD COLUMN `deleted_at` timestamp NULL DEFAULT NULL AFTER `updated_at`,
 DROP PRIMARY KEY,
 ADD PRIMARY KEY (`id`),
 ADD UNIQUE (`gun`);
+
+ALTER TABLE `timestamp_keys` ADD COLUMN `role` VARCHAR(255) NOT NULL, DROP KEY `gun`, ADD UNIQUE KEY `gun_role` (`gun`, `role`);
+
+UPDATE `timestamp_keys` SET `role`="timestamp";

--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -277,7 +277,7 @@ func validateRoot(gun string, oldRoot, newRoot []byte, store storage.MetaStore) 
 	}
 
 	// Don't update if a timestamp key doesn't exist.
-	algo, keyBytes, err := store.GetTimestampKey(gun)
+	algo, keyBytes, err := store.GetKey(gun, data.CanonicalTimestampRole)
 	if err != nil || algo == "" || keyBytes == nil {
 		return nil, fmt.Errorf("no timestamp key for %s", gun)
 	}

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -27,7 +27,7 @@ func copyTimestampKey(t *testing.T, fromKeyDB *keys.KeyDB,
 	assert.NotNil(t, pubTimestampKey,
 		"Timestamp key specified by KeyDB role not in KeysDB")
 
-	err := toStore.SetTimestampKey(gun, pubTimestampKey.Algorithm(),
+	err := toStore.SetKey(gun, data.CanonicalTimestampRole, pubTimestampKey.Algorithm(),
 		pubTimestampKey.Public())
 	assert.NoError(t, err)
 }
@@ -244,7 +244,7 @@ func TestValidateRootNoTimestampKey(t *testing.T) {
 	updates := []storage.MetaUpdate{root, targets, snapshot}
 
 	// sanity check - no timestamp keys for the GUN
-	_, _, err = store.GetTimestampKey("testGUN")
+	_, _, err = store.GetKey("testGUN", data.CanonicalTimestampRole)
 	assert.Error(t, err)
 	assert.IsType(t, &storage.ErrNoKey{}, err)
 
@@ -255,7 +255,7 @@ func TestValidateRootNoTimestampKey(t *testing.T) {
 
 	// there should still be no timestamp keys - one should not have been
 	// created
-	_, _, err = store.GetTimestampKey("testGUN")
+	_, _, err = store.GetKey("testGUN", data.CanonicalTimestampRole)
 	assert.Error(t, err)
 }
 
@@ -276,7 +276,7 @@ func TestValidateRootInvalidTimestampKey(t *testing.T) {
 
 	key, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err)
-	err = store.SetTimestampKey("testGUN", key.Algorithm(), key.Public())
+	err = store.SetKey("testGUN", data.CanonicalRootRole, key.Algorithm(), key.Public())
 	assert.NoError(t, err)
 
 	err = validateUpdate("testGUN", updates, store)

--- a/server/storage/database.go
+++ b/server/storage/database.go
@@ -136,12 +136,12 @@ func (db *SQLStorage) Delete(gun string) error {
 	return db.Where(&TUFFile{Gun: gun}).Delete(TUFFile{}).Error
 }
 
-// GetTimestampKey returns the timestamps Public Key data
-func (db *SQLStorage) GetTimestampKey(gun string) (algorithm string, public []byte, err error) {
-	logrus.Debug("retrieving timestamp key for ", gun)
+// GetKey returns the Public Key data for a gun+role
+func (db *SQLStorage) GetKey(gun, role string) (algorithm string, public []byte, err error) {
+	logrus.Debugf("retrieving timestamp key for %s:%s", gun, role)
 
 	var row TimestampKey
-	query := db.Select("cipher, public").Where(&TimestampKey{Gun: gun}).Find(&row)
+	query := db.Select("cipher, public").Where(&TimestampKey{Gun: gun, Role: role}).Find(&row)
 
 	if query.RecordNotFound() {
 		return "", nil, &ErrNoKey{gun: gun}
@@ -152,11 +152,12 @@ func (db *SQLStorage) GetTimestampKey(gun string) (algorithm string, public []by
 	return row.Cipher, row.Public, nil
 }
 
-// SetTimestampKey attempts to write a TimeStamp key and returns an error if it already exists
-func (db *SQLStorage) SetTimestampKey(gun string, algorithm string, public []byte) error {
+// SetKey attempts to write a key and returns an error if it already exists for the gun and role
+func (db *SQLStorage) SetKey(gun, role, algorithm string, public []byte) error {
 
 	entry := TimestampKey{
 		Gun:    gun,
+		Role:   role,
 		Cipher: string(algorithm),
 		Public: public,
 	}

--- a/server/storage/database.go
+++ b/server/storage/database.go
@@ -140,8 +140,8 @@ func (db *SQLStorage) Delete(gun string) error {
 func (db *SQLStorage) GetKey(gun, role string) (algorithm string, public []byte, err error) {
 	logrus.Debugf("retrieving timestamp key for %s:%s", gun, role)
 
-	var row TimestampKey
-	query := db.Select("cipher, public").Where(&TimestampKey{Gun: gun, Role: role}).Find(&row)
+	var row Key
+	query := db.Select("cipher, public").Where(&Key{Gun: gun, Role: role}).Find(&row)
 
 	if query.RecordNotFound() {
 		return "", nil, &ErrNoKey{gun: gun}
@@ -155,26 +155,26 @@ func (db *SQLStorage) GetKey(gun, role string) (algorithm string, public []byte,
 // SetKey attempts to write a key and returns an error if it already exists for the gun and role
 func (db *SQLStorage) SetKey(gun, role, algorithm string, public []byte) error {
 
-	entry := TimestampKey{
+	entry := Key{
 		Gun:    gun,
 		Role:   role,
 		Cipher: string(algorithm),
 		Public: public,
 	}
 
-	if !db.Where(&entry).First(&TimestampKey{}).RecordNotFound() {
-		return &ErrTimestampKeyExists{gun: gun}
+	if !db.Where(&entry).First(&Key{}).RecordNotFound() {
+		return &ErrKeyExists{gun: gun, role: role}
 	}
 
 	return translateOldVersionError(
-		db.FirstOrCreate(&TimestampKey{}, &entry).Error)
+		db.FirstOrCreate(&Key{}, &entry).Error)
 }
 
 // CheckHealth asserts that both required tables are present
 func (db *SQLStorage) CheckHealth() error {
 	interfaces := []interface {
 		TableName() string
-	}{&TUFFile{}, &TimestampKey{}}
+	}{&TUFFile{}, &Key{}}
 
 	for _, model := range interfaces {
 		tableOk := db.HasTable(model)

--- a/server/storage/database.go
+++ b/server/storage/database.go
@@ -156,15 +156,16 @@ func (db *SQLStorage) GetKey(gun, role string) (algorithm string, public []byte,
 func (db *SQLStorage) SetKey(gun, role, algorithm string, public []byte) error {
 
 	entry := Key{
-		Gun:    gun,
-		Role:   role,
-		Cipher: string(algorithm),
-		Public: public,
+		Gun:  gun,
+		Role: role,
 	}
 
 	if !db.Where(&entry).First(&Key{}).RecordNotFound() {
 		return &ErrKeyExists{gun: gun, role: role}
 	}
+
+	entry.Cipher = algorithm
+	entry.Public = public
 
 	return translateOldVersionError(
 		db.FirstOrCreate(&Key{}, &entry).Error)

--- a/server/storage/errors.go
+++ b/server/storage/errors.go
@@ -20,14 +20,15 @@ func (err ErrNotFound) Error() string {
 	return fmt.Sprintf("No record found")
 }
 
-// ErrTimestampKeyExists is returned when a timestamp key already exists
-type ErrTimestampKeyExists struct {
-	gun string
+// ErrKeyExists is returned when a key already exists
+type ErrKeyExists struct {
+	gun  string
+	role string
 }
 
-// ErrTimestampKeyExists is returned when a timestamp key already exists
-func (err ErrTimestampKeyExists) Error() string {
-	return fmt.Sprintf("Error, timestamp key already exists for %s", err.gun)
+// ErrKeyExists is returned when a key already exists
+func (err ErrKeyExists) Error() string {
+	return fmt.Sprintf("Error, timestamp key already exists for %s:%s", err.gun, err.role)
 }
 
 // ErrNoKey is returned when no timestamp key is found

--- a/server/storage/interface.go
+++ b/server/storage/interface.go
@@ -22,11 +22,11 @@ type MetaStore interface {
 	// error if no metadata exists for the given GUN.
 	Delete(gun string) error
 
-	// GetTimestampKey returns the algorithm and public key for the given GUN.
-	// If the GUN doesn't exist, returns an error.
-	GetTimestampKey(gun string) (algorithm string, public []byte, err error)
+	// GetKey returns the algorithm and public key for the given GUN and role.
+	// If the GUN+role don't exist, returns an error.
+	GetKey(gun, role string) (algorithm string, public []byte, err error)
 
-	// SetTimeStampKey sets the algorithm and public key for the given GUN if
+	// SetKey sets the algorithm and public key for the given GUN and role if
 	// it doesn't already exist.  Otherwise an error is returned.
-	SetTimestampKey(gun string, algorithm string, public []byte) error
+	SetKey(gun, role, algorithm string, public []byte) error
 }

--- a/server/storage/memory.go
+++ b/server/storage/memory.go
@@ -106,7 +106,7 @@ func (st *MemStorage) SetKey(gun, role, algorithm string, public []byte) error {
 	// between checking and setting
 	_, _, err := st.GetKey(gun, role)
 	if _, ok := err.(*ErrNoKey); !ok {
-		return &ErrTimestampKeyExists{gun: gun}
+		return &ErrKeyExists{gun: gun, role: role}
 	}
 	_, ok := st.keys[gun]
 	if !ok {

--- a/server/storage/memory.go
+++ b/server/storage/memory.go
@@ -21,14 +21,14 @@ type ver struct {
 type MemStorage struct {
 	lock    sync.Mutex
 	tufMeta map[string][]*ver
-	tsKeys  map[string]*key
+	keys    map[string]map[string]*key
 }
 
 // NewMemStorage instantiates a memStorage instance
 func NewMemStorage() *MemStorage {
 	return &MemStorage{
 		tufMeta: make(map[string][]*ver),
-		tsKeys:  make(map[string]*key),
+		keys:    make(map[string]map[string]*key),
 	}
 }
 
@@ -80,11 +80,15 @@ func (st *MemStorage) Delete(gun string) error {
 	return nil
 }
 
-// GetTimestampKey returns the public key material of the timestamp key of a given gun
-func (st *MemStorage) GetTimestampKey(gun string) (algorithm string, public []byte, err error) {
+// GetKey returns the public key material of the timestamp key of a given gun
+func (st *MemStorage) GetKey(gun, role string) (algorithm string, public []byte, err error) {
 	// no need for lock. It's ok to return nil if an update
 	// wasn't observed
-	k, ok := st.tsKeys[gun]
+	g, ok := st.keys[gun]
+	if !ok {
+		return "", nil, &ErrNoKey{gun: gun}
+	}
+	k, ok := g[role]
 	if !ok {
 		return "", nil, &ErrNoKey{gun: gun}
 	}
@@ -92,15 +96,23 @@ func (st *MemStorage) GetTimestampKey(gun string) (algorithm string, public []by
 	return k.algorithm, k.public, nil
 }
 
-// SetTimestampKey sets a Timestamp key under a gun
-func (st *MemStorage) SetTimestampKey(gun string, algorithm string, public []byte) error {
+// SetKey sets a key under a gun and role
+func (st *MemStorage) SetKey(gun, role, algorithm string, public []byte) error {
 	k := &key{algorithm: algorithm, public: public}
 	st.lock.Lock()
 	defer st.lock.Unlock()
-	if _, ok := st.tsKeys[gun]; ok {
+
+	// we hold the lock so nothing will be able to race to write a key
+	// between checking and setting
+	_, _, err := st.GetKey(gun, role)
+	if _, ok := err.(*ErrNoKey); !ok {
 		return &ErrTimestampKeyExists{gun: gun}
 	}
-	st.tsKeys[gun] = k
+	_, ok := st.keys[gun]
+	if !ok {
+		st.keys[gun] = make(map[string]*key)
+	}
+	st.keys[gun][role] = k
 	return nil
 }
 

--- a/server/storage/memory_test.go
+++ b/server/storage/memory_test.go
@@ -44,25 +44,22 @@ func TestDelete(t *testing.T) {
 func TestGetTimestampKey(t *testing.T) {
 	s := NewMemStorage()
 
-	//_, _, err := s.GetTimestampKey("gun")
-	//assert.IsType(t, &ErrNoKey{}, err, "Expected err to be ErrNoKey")
+	s.SetKey("gun", data.CanonicalTimestampRole, data.RSAKey, []byte("test"))
 
-	s.SetTimestampKey("gun", data.RSAKey, []byte("test"))
-
-	c, k, err := s.GetTimestampKey("gun")
+	c, k, err := s.GetKey("gun", data.CanonicalTimestampRole)
 	assert.Nil(t, err, "Expected error to be nil")
 	assert.Equal(t, data.RSAKey, c, "Expected algorithm rsa, received %s", c)
 	assert.Equal(t, []byte("test"), k, "Key data was wrong")
 }
 
-func TestSetTimestampKey(t *testing.T) {
+func TestSetKey(t *testing.T) {
 	s := NewMemStorage()
-	s.SetTimestampKey("gun", data.RSAKey, []byte("test"))
+	s.SetKey("gun", data.CanonicalTimestampRole, data.RSAKey, []byte("test"))
 
-	err := s.SetTimestampKey("gun", data.RSAKey, []byte("test2"))
+	err := s.SetKey("gun", data.CanonicalTimestampRole, data.RSAKey, []byte("test2"))
 	assert.IsType(t, &ErrTimestampKeyExists{}, err, "Expected err to be ErrTimestampKeyExists")
 
-	k := s.tsKeys["gun"]
+	k := s.keys["gun"][data.CanonicalTimestampRole]
 	assert.Equal(t, data.RSAKey, k.algorithm, "Expected algorithm to be rsa, received %s", k.algorithm)
 	assert.Equal(t, []byte("test"), k.public, "Public key did not match expected")
 

--- a/server/storage/memory_test.go
+++ b/server/storage/memory_test.go
@@ -57,7 +57,7 @@ func TestSetKey(t *testing.T) {
 	s.SetKey("gun", data.CanonicalTimestampRole, data.RSAKey, []byte("test"))
 
 	err := s.SetKey("gun", data.CanonicalTimestampRole, data.RSAKey, []byte("test2"))
-	assert.IsType(t, &ErrTimestampKeyExists{}, err, "Expected err to be ErrTimestampKeyExists")
+	assert.IsType(t, &ErrKeyExists{}, err, "Expected err to be ErrKeyExists")
 
 	k := s.keys["gun"][data.CanonicalTimestampRole]
 	assert.Equal(t, data.RSAKey, k.algorithm, "Expected algorithm to be rsa, received %s", k.algorithm)

--- a/server/storage/models.go
+++ b/server/storage/models.go
@@ -19,7 +19,8 @@ func (g TUFFile) TableName() string {
 // TimestampKey represents a single timestamp key in the database
 type TimestampKey struct {
 	gorm.Model
-	Gun    string `sql:"type:varchar(255);unique;not null"`
+	Gun    string `sql:"type:varchar(255);not null"`
+	Role   string `sql:"type:varchar(255);not null"`
 	Cipher string `sql:"type:varchar(30);not null"`
 	Public []byte `sql:"type:blob;not null"`
 }
@@ -47,6 +48,11 @@ func CreateTUFTable(db gorm.DB) error {
 // CreateTimestampTable creates the DB table for TUFFile
 func CreateTimestampTable(db gorm.DB) error {
 	query := db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8").CreateTable(&TimestampKey{})
+	if query.Error != nil {
+		return query.Error
+	}
+	query = db.Model(&TimestampKey{}).AddUniqueIndex(
+		"idx_gun_role", "gun", "role")
 	if query.Error != nil {
 		return query.Error
 	}

--- a/server/storage/models.go
+++ b/server/storage/models.go
@@ -16,8 +16,8 @@ func (g TUFFile) TableName() string {
 	return "tuf_files"
 }
 
-// TimestampKey represents a single timestamp key in the database
-type TimestampKey struct {
+// Key represents a single timestamp key in the database
+type Key struct {
 	gorm.Model
 	Gun    string `sql:"type:varchar(255);not null"`
 	Role   string `sql:"type:varchar(255);not null"`
@@ -26,7 +26,7 @@ type TimestampKey struct {
 }
 
 // TableName sets a specific table name for our TimestampKey
-func (g TimestampKey) TableName() string {
+func (g Key) TableName() string {
 	return "timestamp_keys"
 }
 
@@ -45,13 +45,13 @@ func CreateTUFTable(db gorm.DB) error {
 	return nil
 }
 
-// CreateTimestampTable creates the DB table for TUFFile
-func CreateTimestampTable(db gorm.DB) error {
-	query := db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8").CreateTable(&TimestampKey{})
+// CreateKeyTable creates the DB table for TUFFile
+func CreateKeyTable(db gorm.DB) error {
+	query := db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8").CreateTable(&Key{})
 	if query.Error != nil {
 		return query.Error
 	}
-	query = db.Model(&TimestampKey{}).AddUniqueIndex(
+	query = db.Model(&Key{}).AddUniqueIndex(
 		"idx_gun_role", "gun", "role")
 	if query.Error != nil {
 		return query.Error

--- a/server/storage/models.go
+++ b/server/storage/models.go
@@ -19,8 +19,8 @@ func (g TUFFile) TableName() string {
 // Key represents a single timestamp key in the database
 type Key struct {
 	gorm.Model
-	Gun    string `sql:"type:varchar(255);not null"`
-	Role   string `sql:"type:varchar(255);not null"`
+	Gun    string `sql:"type:varchar(255);not null;unique_index:gun_role"`
+	Role   string `sql:"type:varchar(255);not null;unique_index:gun_role"`
 	Cipher string `sql:"type:varchar(30);not null"`
 	Public []byte `sql:"type:blob;not null"`
 }

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -33,7 +33,7 @@ func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.
 			return key, nil
 		}
 
-		if _, ok := err.(*storage.ErrTimestampKeyExists); ok {
+		if _, ok := err.(*storage.ErrKeyExists); ok {
 			keyAlgorithm, public, err = store.GetKey(gun, data.CanonicalTimestampRole)
 			if err != nil {
 				return nil, err

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -17,7 +17,7 @@ import (
 // create the key at the same time by simply querying the store a second time if it
 // receives a conflict when writing.
 func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.CryptoService, fallBackAlgorithm string) (data.PublicKey, error) {
-	keyAlgorithm, public, err := store.GetTimestampKey(gun)
+	keyAlgorithm, public, err := store.GetKey(gun, data.CanonicalTimestampRole)
 	if err == nil {
 		return data.NewPublicKey(keyAlgorithm, public), nil
 	}
@@ -28,13 +28,13 @@ func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.
 			return nil, err
 		}
 		logrus.Debug("Creating new timestamp key for ", gun, ". With algo: ", key.Algorithm())
-		err = store.SetTimestampKey(gun, key.Algorithm(), key.Public())
+		err = store.SetKey(gun, data.CanonicalTimestampRole, key.Algorithm(), key.Public())
 		if err == nil {
 			return key, nil
 		}
 
 		if _, ok := err.(*storage.ErrTimestampKeyExists); ok {
-			keyAlgorithm, public, err = store.GetTimestampKey(gun)
+			keyAlgorithm, public, err = store.GetKey(gun, data.CanonicalTimestampRole)
 			if err != nil {
 				return nil, err
 			}
@@ -111,7 +111,7 @@ func snapshotExpired(ts *data.SignedTimestamp, snapshot []byte) bool {
 // version number one higher than prev. The store is used to lookup the current
 // snapshot, this function does not save the newly generated timestamp.
 func CreateTimestamp(gun string, prev *data.SignedTimestamp, snapshot []byte, store storage.MetaStore, cryptoService signed.CryptoService) (*data.Signed, int, error) {
-	algorithm, public, err := store.GetTimestampKey(gun)
+	algorithm, public, err := store.GetKey(gun, data.CanonicalTimestampRole)
 	if err != nil {
 		// owner of gun must have generated a timestamp key otherwise
 		// we won't proceed with generating everything.

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -55,7 +55,7 @@ func TestGetTimestamp(t *testing.T) {
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
 	_, err := GetOrCreateTimestampKey("gun", store, crypto, data.ED25519Key)
-	assert.Nil(t, err, "GetTimestampKey errored")
+	assert.Nil(t, err, "GetKey errored")
 
 	_, err = GetOrCreateTimestamp("gun", store, crypto)
 	assert.Nil(t, err, "GetTimestamp errored")
@@ -72,7 +72,7 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
 	_, err := GetOrCreateTimestampKey("gun", store, crypto, data.ED25519Key)
-	assert.Nil(t, err, "GetTimestampKey errored")
+	assert.Nil(t, err, "GetKey errored")
 
 	ts1, err := GetOrCreateTimestamp("gun", store, crypto)
 	assert.Nil(t, err, "GetTimestamp errored")


### PR DESCRIPTION
Unfortunately the database is still called "timestamp_keys" and I'm not sure how to fix that cleanly. Everything else has been generalized though so that one piece of ugly legacy hangover is highly contained to the database migration files, and the `Key.TableName` method.