### PR TITLE
Fix bug when parsing the storage

### DIFF
--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -110,10 +110,15 @@ func ParseStorage(configuration *viper.Viper, allowedBackends []string) (*Storag
 	if store.Backend == MemoryBackend {
 		return &Storage{Backend: MemoryBackend}, nil
 	}
-	if store.Source == "" {
+	if store.Backend == MySQLBackend && store.Source == "" {
 		return nil, fmt.Errorf(
 			"must provide a non-empty database source for %s", store.Backend)
 	}
+	if store.Backend == SqliteBackend && store.Source == "" {
+		return nil, fmt.Errorf(
+			"must provide a non-empty database source for %s", store.Backend)
+	}
+
 	return &store, nil
 }
 


### PR DESCRIPTION
Prior to this patch, everything seems fine because there are only two
backends that passed to `ParseStorage` via `allowedBackends`.

But it is possible that in the future, someone would add a new storage
backend to Notary and unfortunately it doesn't need the `storage.db_url`.
If that happened, the prior logical will return error which is wrong.

Signed-off-by: Hu Keping <hukeping@huawei.com>