### PR TITLE
Refactor the client TestInitRepo test into reusable helper functions.

### DIFF
--- a/client/client_root_validation_test.go
+++ b/client/client_root_validation_test.go
@@ -33,7 +33,7 @@ func validateRootSuccessfully(t *testing.T, rootType string) {
 
 	gun := "docker.com/notary"
 
-	ts, mux := simpleTestServer(t)
+	ts, mux, keys := simpleTestServer(t)
 	defer ts.Close()
 
 	repo, _ := initializeRepo(t, rootType, tempBaseDir, gun, ts.URL)
@@ -47,7 +47,7 @@ func validateRootSuccessfully(t *testing.T, rootType string) {
 	allCerts := repo.CertManager.TrustedCertificateStore().GetCertificates()
 	assert.Len(t, allCerts, 1)
 
-	fakeServerData(t, repo, mux)
+	fakeServerData(t, repo, mux, keys)
 
 	//
 	// Test TOFUS logic. We remove all certs and expect a new one to be added after ListTargets


### PR DESCRIPTION
Also, eliminate the timestamp JSON constant and just generate a new
one for the tests.

The client test now also uses KeyFileStore and certs.Manager to
verify the keys and certs on disk, rather than directly manipulating
the files themselves.  This way, if the exact implementation of
KeyFileStore or certs.Manager changes, this test won't fail so long
as KeyFileStore and certs.Manager are self-consistent.

Signed-off-by: Ying Li <ying.li@docker.com>