### PR TITLE
Add a function to parse viper

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -186,19 +184,9 @@ func main() {
 
 	ctx := context.Background()
 
-	filename := filepath.Base(configFile)
-	ext := filepath.Ext(configFile)
-	configPath := filepath.Dir(configFile)
-
-	mainViper.SetConfigType(strings.TrimPrefix(ext, "."))
-	mainViper.SetConfigName(strings.TrimSuffix(filename, ext))
-	mainViper.AddConfigPath(configPath)
-
-	err := mainViper.ReadInConfig()
-	if err != nil {
-		logrus.Error("Viper Error: ", err.Error())
-		logrus.Error("Could not read config at ", configFile)
-		os.Exit(1)
+	// parse viper config
+	if err := utils.ParseViper(mainViper, configFile); err != nil {
+		logrus.Fatal(err.Error())
 	}
 
 	// default is error level

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -181,17 +180,9 @@ func main() {
 	// when the signer starts print the version for debugging and issue logs later
 	logrus.Infof("Version: %s, Git commit: %s", version.NotaryVersion, version.GitCommit)
 
-	filename := filepath.Base(configFile)
-	ext := filepath.Ext(configFile)
-	configPath := filepath.Dir(configFile)
-
-	mainViper.SetConfigType(strings.TrimPrefix(ext, "."))
-	mainViper.SetConfigName(strings.TrimSuffix(filename, ext))
-	mainViper.AddConfigPath(configPath)
-
-	if err := mainViper.ReadInConfig(); err != nil {
-		logrus.Errorf("Could not read config at :%s, viper error: %v", configFile, err)
-		os.Exit(1)
+	// parse viper config
+	if err := utils.ParseViper(mainViper, configFile); err != nil {
+		logrus.Fatal(err.Error())
 	}
 
 	// default is error level

--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -159,3 +159,19 @@ func SetUpBugsnag(config *bugsnag.Configuration) error {
 	}
 	return nil
 }
+
+// ParseViper tries to parse out a Viper from a configuration file.
+func ParseViper(v *viper.Viper, configFile string) error {
+	filename := filepath.Base(configFile)
+	ext := filepath.Ext(configFile)
+	configPath := filepath.Dir(configFile)
+
+	v.SetConfigType(strings.TrimPrefix(ext, "."))
+	v.SetConfigName(strings.TrimSuffix(filename, ext))
+	v.AddConfigPath(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		return fmt.Errorf("Could not read config at :%s, viper error: %v", configFile, err)
+	}
+	return nil
+}

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -335,3 +335,28 @@ func TestParseTLSWithEnvironmentVariables(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, *tlsOpts)
 }
+
+func TestParseViperWithInvalidFile(t *testing.T) {
+	v := viper.New()
+	SetupViper(v, envPrefix)
+
+	err := ParseViper(v, "Chronicle_Of_Dark_Secrets.json")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Could not read config")
+}
+
+func TestParseViperWithValidFile(t *testing.T) {
+	file, err := os.Create("/tmp/Chronicle_Of_Dark_Secrets.json")
+	assert.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	file.WriteString(`{"logging": {"level": "debug"}}`)
+
+	v := viper.New()
+	SetupViper(v, envPrefix)
+
+	err = ParseViper(v, "/tmp/Chronicle_Of_Dark_Secrets.json")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "debug", v.GetString("logging.level"))
+}


### PR DESCRIPTION
None of these `filename`, `ext` or `configPath` should be in `main`,
they are all just for creating a instance of Viper and then nothing.
Do it in a separate function will make the function `main` more readable.

Signed-off-by: Hu Keping <hukeping@huawei.com>