### PR TITLE
Delegation primitives up to changelist level

### DIFF
--- a/client/changelist/change.go
+++ b/client/changelist/change.go
@@ -77,3 +77,26 @@ func (c TufChange) Path() string {
 func (c TufChange) Content() []byte {
 	return c.Data
 }
+
+// TufDelegation represents a modification to a target delegation
+// this includes creating a delegations. This format is used to avoid
+// unexpected race conditions between humans modifying the same delegation
+type TufDelegation struct {
+	NewName                string       `json:"new_name,omitempty"`
+	NewThreshold           int          `json:"threshold, omitempty"`
+	AddKeys                data.KeyList `json:"add_keys, omitempty"`
+	RemoveKeys             []string     `json:"remove_keys,omitempty"`
+	AddPaths               []string     `json:"add_paths,omitempty"`
+	RemovePaths            []string     `json:"remove_paths,omitempty"`
+	AddPathHashPrefixes    []string     `json:"add_prefixes,omitempty"`
+	RemovePathHashPrefixes []string     `json:"remove_prefixes,omitempty"`
+}
+
+// ToNewRole creates a fresh role object from the TufDelegation data
+func (td TufDelegation) ToNewRole(scope string) (*data.Role, error) {
+	name := scope
+	if td.NewName != "" {
+		name = td.NewName
+	}
+	return data.NewRole(name, td.NewThreshold, td.AddKeys.IDs(), td.AddPaths, td.AddPathHashPrefixes)
+}

--- a/client/changelist/change_test.go
+++ b/client/changelist/change_test.go
@@ -1,0 +1,29 @@
+package changelist
+
+import (
+	"testing"
+
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTufDelegation(t *testing.T) {
+	cs := signed.NewEd25519()
+	key, err := cs.Create("targets/new_name", data.ED25519Key)
+	assert.NoError(t, err)
+	kl := data.KeyList{key}
+	td := TufDelegation{
+		NewName:      "targets/new_name",
+		NewThreshold: 1,
+		AddKeys:      kl,
+	}
+
+	r, err := td.ToNewRole("targets/old_name")
+	assert.NoError(t, err)
+	assert.Equal(t, td.NewName, r.Name)
+	assert.Len(t, r.KeyIDs, 1)
+	assert.Equal(t, kl[0].ID(), r.KeyIDs[0])
+	assert.Len(t, r.Paths, 0)
+	assert.Len(t, r.PathHashPrefixes, 0)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -273,7 +273,13 @@ func (r *NotaryRepository) AddTarget(target *Target) error {
 		return err
 	}
 
-	c := changelist.NewTufChange(changelist.ActionCreate, changelist.ScopeTargets, "target", target.Name, metaJSON)
+	c := changelist.NewTufChange(
+		changelist.ActionCreate,
+		changelist.ScopeTargets,
+		changelist.TypeTargetsTarget,
+		target.Name,
+		metaJSON,
+	)
 	err = cl.Add(c)
 	if err != nil {
 		return err

--- a/client/client.go
+++ b/client/client.go
@@ -244,7 +244,7 @@ func (r *NotaryRepository) Initialize(rootKeyID string, serverManagedRoles ...st
 		logrus.Debug("Error on InitRoot: ", err.Error())
 		return err
 	}
-	err = r.tufRepo.InitTargets()
+	err = r.tufRepo.InitTargets(data.CanonicalTargetsRole)
 	if err != nil {
 		logrus.Debug("Error on InitTargets: ", err.Error())
 		return err

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
+	"github.com/docker/notary/tuf/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -146,4 +147,432 @@ func TestApplyChangelistMulti(t *testing.T) {
 	assert.NoError(t, err)
 	_, ok := repo.Targets["targets"].Signed.Targets["latest"]
 	assert.False(t, ok)
+}
+
+func TestApplyTargetsDelegationCreateDelete(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		AddPaths:     []string{"level1"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	tgts := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, tgts.Signed.Delegations.Roles, 1)
+	assert.Len(t, tgts.Signed.Delegations.Keys, 1)
+
+	_, ok := tgts.Signed.Delegations.Keys[newKey.ID()]
+	assert.True(t, ok)
+
+	role := tgts.Signed.Delegations.Roles[0]
+	assert.Equal(t, newKey.ID(), role.KeyIDs[0])
+	assert.Equal(t, "targets/level1", role.Name)
+	assert.Equal(t, "level1", role.Paths[0])
+
+	// delete delegation
+	ch = changelist.NewTufChange(
+		changelist.ActionDelete,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		nil,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	assert.Len(t, tgts.Signed.Delegations.Roles, 0)
+	assert.Len(t, tgts.Signed.Delegations.Keys, 0)
+}
+
+func TestApplyTargetsDelegationCreate2SharedKey(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create first delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		AddPaths:     []string{"level1"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	// create second delegation
+	kl = data.KeyList{newKey}
+	td = &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		AddPaths:     []string{"level2"},
+	}
+
+	tdJSON, err = json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch = changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level2",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	tgts := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, tgts.Signed.Delegations.Roles, 2)
+	assert.Len(t, tgts.Signed.Delegations.Keys, 1)
+
+	role1 := tgts.Signed.Delegations.Roles[0]
+	assert.Equal(t, newKey.ID(), role1.KeyIDs[0])
+	assert.Equal(t, "targets/level1", role1.Name)
+	assert.Equal(t, "level1", role1.Paths[0])
+
+	role2 := tgts.Signed.Delegations.Roles[1]
+	assert.Equal(t, newKey.ID(), role2.KeyIDs[0])
+	assert.Equal(t, "targets/level2", role2.Name)
+	assert.Equal(t, "level2", role2.Paths[0])
+
+	// delete one delegation, ensure key remains
+	ch = changelist.NewTufChange(
+		changelist.ActionDelete,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		nil,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	assert.Len(t, tgts.Signed.Delegations.Roles, 1)
+	assert.Len(t, tgts.Signed.Delegations.Keys, 1)
+
+	// delete other delegation, ensure key cleaned up
+	ch = changelist.NewTufChange(
+		changelist.ActionDelete,
+		"targets/level2",
+		changelist.TypeTargetsDelegation,
+		"",
+		nil,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	assert.Len(t, tgts.Signed.Delegations.Roles, 0)
+	assert.Len(t, tgts.Signed.Delegations.Keys, 0)
+}
+
+func TestApplyTargetsDelegationCreateEdit(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		AddPaths:     []string{"level1"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	// edit delegation
+	newKey2, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	kl = data.KeyList{newKey2}
+	td = &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		RemoveKeys:   []string{newKey.ID()},
+	}
+
+	tdJSON, err = json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch = changelist.NewTufChange(
+		changelist.ActionUpdate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	tgts := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, tgts.Signed.Delegations.Roles, 1)
+	assert.Len(t, tgts.Signed.Delegations.Keys, 1)
+
+	_, ok := tgts.Signed.Delegations.Keys[newKey2.ID()]
+	assert.True(t, ok)
+
+	role := tgts.Signed.Delegations.Roles[0]
+	assert.Len(t, role.KeyIDs, 1)
+	assert.Equal(t, newKey2.ID(), role.KeyIDs[0])
+	assert.Equal(t, "targets/level1", role.Name)
+	assert.Equal(t, "level1", role.Paths[0])
+}
+
+func TestApplyTargetsDelegationInvalidRole(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		AddPaths:     []string{"level1"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"bad role",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.Error(t, err)
+}
+
+func TestApplyTargetsDelegationInvalidJSONContent(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		AddPaths:     []string{"level1"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON[1:],
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.Error(t, err)
+}
+
+func TestApplyTargetsDelegationInvalidAction(t *testing.T) {
+	_, repo, _ := testutils.EmptyRepo()
+
+	ch := changelist.NewTufChange(
+		"bad action",
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		nil,
+	)
+
+	err := applyTargetsChange(repo, ch)
+	assert.Error(t, err)
+}
+
+func TestApplyTargetsChangeInvalidType(t *testing.T) {
+	_, repo, _ := testutils.EmptyRepo()
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		"badType",
+		"",
+		nil,
+	)
+
+	err := applyTargetsChange(repo, ch)
+	assert.Error(t, err)
+}
+
+func TestApplyTargetsDelegationConflictPathsPrefixes(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold: 1,
+		AddKeys:      kl,
+		AddPaths:     []string{"level1"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	// add prefixes and update
+	td.AddPathHashPrefixes = []string{"abc"}
+
+	tdJSON, err = json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch = changelist.NewTufChange(
+		changelist.ActionUpdate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.Error(t, err)
+}
+
+func TestApplyTargetsDelegationConflictPrefixesPaths(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold:        1,
+		AddKeys:             kl,
+		AddPathHashPrefixes: []string{"abc"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.NoError(t, err)
+
+	// add paths and update
+	td.AddPaths = []string{"level1"}
+
+	tdJSON, err = json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch = changelist.NewTufChange(
+		changelist.ActionUpdate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.Error(t, err)
+}
+
+func TestApplyTargetsDelegationCreateInvalid(t *testing.T) {
+	_, repo, cs := testutils.EmptyRepo()
+
+	newKey, err := cs.Create("targets/level1", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// create delegation
+	kl := data.KeyList{newKey}
+	td := &changelist.TufDelegation{
+		NewThreshold:        1,
+		AddKeys:             kl,
+		AddPaths:            []string{"level1"},
+		AddPathHashPrefixes: []string{"abc"},
+	}
+
+	tdJSON, err := json.Marshal(td)
+	assert.NoError(t, err)
+
+	ch := changelist.NewTufChange(
+		changelist.ActionCreate,
+		"targets/level1",
+		changelist.TypeTargetsDelegation,
+		"",
+		tdJSON,
+	)
+
+	err = applyTargetsChange(repo, ch)
+	assert.Error(t, err)
 }

--- a/tuf/data/keys.go
+++ b/tuf/data/keys.go
@@ -77,6 +77,15 @@ func (ks *KeyList) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// IDs generates a list of the hex encoded key IDs in the KeyList
+func (ks KeyList) IDs() []string {
+	keyIDs := make([]string, 0, len(ks))
+	for _, k := range ks {
+		keyIDs = append(keyIDs, k.ID())
+	}
+	return keyIDs
+}
+
 func typedPublicKey(tk tufKey) PublicKey {
 	switch tk.Algorithm() {
 	case ECDSAKey:

--- a/tuf/data/snapshot.go
+++ b/tuf/data/snapshot.go
@@ -88,6 +88,15 @@ func (sp *SignedSnapshot) AddMeta(role string, meta FileMeta) {
 	sp.Dirty = true
 }
 
+// DeleteMeta removes a role from the snapshot. If the role doesn't
+// exist in the snapshot, it's a noop.
+func (sp *SignedSnapshot) DeleteMeta(role string) {
+	if _, ok := sp.Signed.Meta[role]; ok {
+		delete(sp.Signed.Meta, role)
+		sp.Dirty = true
+	}
+}
+
 // SnapshotFromSigned fully unpacks a Signed object into a SignedSnapshot
 func SnapshotFromSigned(s *Signed) (*SignedSnapshot, error) {
 	sp := Snapshot{}

--- a/tuf/data/snapshot_test.go
+++ b/tuf/data/snapshot_test.go
@@ -1,0 +1,28 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteMeta(t *testing.T) {
+	sp := &SignedSnapshot{
+		Signatures: make([]Signature, 0),
+		Signed: Snapshot{
+			Type:    TUFTypes["snapshot"],
+			Version: 0,
+			Expires: DefaultExpires("snapshot"),
+			Meta: Files{
+				ValidRoles["root"]:    FileMeta{},
+				ValidRoles["targets"]: FileMeta{},
+			},
+		},
+	}
+	_, ok := sp.Signed.Meta["root"]
+	assert.True(t, ok)
+	sp.DeleteMeta("root")
+	_, ok = sp.Signed.Meta["root"]
+	assert.False(t, ok)
+	assert.True(t, sp.Dirty)
+}

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
+	"github.com/stretchr/testify/assert"
 )
 
 func initRepo(t *testing.T, cryptoService signed.CryptoService, keyDB *keys.KeyDB) *Repo {
@@ -147,6 +148,13 @@ func TestUpdateDelegations(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	keyIDs := r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 1)
+	assert.Equal(t, testKey.ID(), keyIDs[0])
+
 	testDeepKey, err := ed25519.Create("targets/test/deep", data.ED25519Key)
 	if err != nil {
 		t.Fatal(err)
@@ -161,5 +169,282 @@ func TestUpdateDelegations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	writeRepo(t, "/tmp/tufdelegation", repo)
+	r = repo.Targets["targets/test"]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	keyIDs = r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 1)
+	assert.Equal(t, testDeepKey.ID(), keyIDs[0])
+	assert.True(t, r.Dirty)
+}
+
+func TestUpdateDelegationsParentMissing(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	testDeepKey, err := ed25519.Create("targets/test/deep", data.ED25519Key)
+	assert.NoError(t, err)
+	roleDeep, err := data.NewRole("targets/test/deep", 1, []string{testDeepKey.ID()}, []string{"test/deep"}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(roleDeep, data.KeyList{testDeepKey}, "")
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 0)
+}
+
+func TestUpdateDelegationsInvalidRole(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	roleKey, err := ed25519.Create("Invalid Role", data.ED25519Key)
+	assert.NoError(t, err)
+
+	// data.NewRole errors if the role isn't a valid TUF role so use one of the non-delegation
+	// valid roles
+	invalidRole, err := data.NewRole("root", 1, []string{roleKey.ID()}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(invalidRole, data.KeyList{roleKey}, "")
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 0)
+}
+
+func TestUpdateDelegationsRoleMissingKey(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	roleKey, err := ed25519.Create("Invalid Role", data.ED25519Key)
+	assert.NoError(t, err)
+
+	role, err := data.NewRole("targets/role", 1, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	// key should get added to role as part of updating the delegation
+	err = repo.UpdateDelegations(role, data.KeyList{roleKey}, "")
+	assert.NoError(t, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	keyIDs := r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 1)
+	assert.Equal(t, roleKey.ID(), keyIDs[0])
+	assert.True(t, r.Dirty)
+}
+
+func TestUpdateDelegationsNotEnoughKeys(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	roleKey, err := ed25519.Create("Invalid Role", data.ED25519Key)
+	assert.NoError(t, err)
+
+	role, err := data.NewRole("targets/role", 2, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	// key should get added to role as part of updating the delegation
+	err = repo.UpdateDelegations(role, data.KeyList{roleKey}, "")
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
+}
+
+func TestUpdateDelegationsReplaceRole(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	testKey, err := ed25519.Create("targets/test", data.ED25519Key)
+	assert.NoError(t, err)
+	role, err := data.NewRole("targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	assert.NoError(t, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	keyIDs := r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 1)
+	assert.Equal(t, testKey.ID(), keyIDs[0])
+
+	// create another role with the same name and ensure it replaces the
+	// previous role
+	testKey2, err := ed25519.Create("targets/test", data.ED25519Key)
+	assert.NoError(t, err)
+	role2, err := data.NewRole("targets/test", 1, []string{testKey2.ID()}, []string{"test"}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role2, data.KeyList{testKey2}, "")
+	assert.NoError(t, err)
+
+	r = repo.Targets["targets"]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	keyIDs = r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 1)
+	assert.Equal(t, testKey2.ID(), keyIDs[0])
+	assert.True(t, r.Dirty)
+}
+
+func TestUpdateDelegationsAddKeyToRole(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	testKey, err := ed25519.Create("targets/test", data.ED25519Key)
+	assert.NoError(t, err)
+	role, err := data.NewRole("targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	assert.NoError(t, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	keyIDs := r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 1)
+	assert.Equal(t, testKey.ID(), keyIDs[0])
+
+	testKey2, err := ed25519.Create("targets/test", data.ED25519Key)
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role, data.KeyList{testKey2}, "")
+	assert.NoError(t, err)
+
+	r = repo.Targets["targets"]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 2)
+	keyIDs = r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 2)
+	// it does an append so the order is deterministic (but not meaningful to TUF)
+	assert.Equal(t, testKey.ID(), keyIDs[0])
+	assert.Equal(t, testKey2.ID(), keyIDs[1])
+	assert.True(t, r.Dirty)
+}
+
+func TestDeleteDelegations(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	testKey, err := ed25519.Create("targets/test", data.ED25519Key)
+	assert.NoError(t, err)
+	role, err := data.NewRole("targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	assert.NoError(t, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 1)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	keyIDs := r.Signed.Delegations.Roles[0].KeyIDs
+	assert.Len(t, keyIDs, 1)
+	assert.Equal(t, testKey.ID(), keyIDs[0])
+
+	err = repo.DeleteDelegation(role)
+	assert.Len(t, r.Signed.Delegations.Roles, 0)
+	assert.Len(t, r.Signed.Delegations.Keys, 0)
+	assert.True(t, r.Dirty)
+}
+
+func TestDeleteDelegationsRoleNotExist(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	// initRepo leaves all the roles as Dirty. Set to false
+	// to test removing a non-existant role doesn't mark
+	// a role as dirty
+	repo.Targets[data.CanonicalTargetsRole].Dirty = false
+
+	role, err := data.NewRole("targets/test", 1, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.DeleteDelegation(role)
+	assert.NoError(t, err)
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 0)
+	assert.Len(t, r.Signed.Delegations.Keys, 0)
+	assert.False(t, r.Dirty)
+}
+
+func TestDeleteDelegationsInvalidRole(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	// data.NewRole errors if the role isn't a valid TUF role so use one of the non-delegation
+	// valid roles
+	invalidRole, err := data.NewRole("root", 1, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.DeleteDelegation(invalidRole)
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 0)
+}
+
+func TestDeleteDelegationsParentMissing(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	testRole, err := data.NewRole("targets/test/deep", 1, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.DeleteDelegation(testRole)
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 0)
+}
+
+func TestDeleteDelegationsMidSliceRole(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	testKey, err := ed25519.Create("targets/test", data.ED25519Key)
+	assert.NoError(t, err)
+	role, err := data.NewRole("targets/test", 1, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	assert.NoError(t, err)
+
+	role2, err := data.NewRole("targets/test2", 1, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role2, data.KeyList{testKey}, "")
+	assert.NoError(t, err)
+
+	role3, err := data.NewRole("targets/test3", 1, []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+
+	err = repo.UpdateDelegations(role3, data.KeyList{testKey}, "")
+	assert.NoError(t, err)
+
+	err = repo.DeleteDelegation(role2)
+	assert.NoError(t, err)
+
+	r := repo.Targets[data.CanonicalTargetsRole]
+	assert.Len(t, r.Signed.Delegations.Roles, 2)
+	assert.Len(t, r.Signed.Delegations.Keys, 1)
+	assert.True(t, r.Dirty)
 }

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -143,7 +143,7 @@ func TestUpdateDelegations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{testKey})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestUpdateDelegations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = repo.UpdateDelegations(roleDeep, data.KeyList{testDeepKey}, "")
+	err = repo.UpdateDelegations(roleDeep, data.KeyList{testDeepKey})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestUpdateDelegationsParentMissing(t *testing.T) {
 	roleDeep, err := data.NewRole("targets/test/deep", 1, []string{testDeepKey.ID()}, []string{"test/deep"}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(roleDeep, data.KeyList{testDeepKey}, "")
+	err = repo.UpdateDelegations(roleDeep, data.KeyList{testDeepKey})
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
 
@@ -209,7 +209,7 @@ func TestUpdateDelegationsInvalidRole(t *testing.T) {
 	invalidRole, err := data.NewRole("root", 1, []string{roleKey.ID()}, []string{}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(invalidRole, data.KeyList{roleKey}, "")
+	err = repo.UpdateDelegations(invalidRole, data.KeyList{roleKey})
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
 
@@ -229,7 +229,7 @@ func TestUpdateDelegationsRoleMissingKey(t *testing.T) {
 	assert.NoError(t, err)
 
 	// key should get added to role as part of updating the delegation
-	err = repo.UpdateDelegations(role, data.KeyList{roleKey}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{roleKey})
 	assert.NoError(t, err)
 
 	r := repo.Targets[data.CanonicalTargetsRole]
@@ -253,7 +253,7 @@ func TestUpdateDelegationsNotEnoughKeys(t *testing.T) {
 	assert.NoError(t, err)
 
 	// key should get added to role as part of updating the delegation
-	err = repo.UpdateDelegations(role, data.KeyList{roleKey}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{roleKey})
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
 }
@@ -268,7 +268,7 @@ func TestUpdateDelegationsReplaceRole(t *testing.T) {
 	role, err := data.NewRole("targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{testKey})
 	assert.NoError(t, err)
 
 	r := repo.Targets[data.CanonicalTargetsRole]
@@ -285,7 +285,7 @@ func TestUpdateDelegationsReplaceRole(t *testing.T) {
 	role2, err := data.NewRole("targets/test", 1, []string{testKey2.ID()}, []string{"test"}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role2, data.KeyList{testKey2}, "")
+	err = repo.UpdateDelegations(role2, data.KeyList{testKey2})
 	assert.NoError(t, err)
 
 	r = repo.Targets["targets"]
@@ -307,7 +307,7 @@ func TestUpdateDelegationsAddKeyToRole(t *testing.T) {
 	role, err := data.NewRole("targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{testKey})
 	assert.NoError(t, err)
 
 	r := repo.Targets[data.CanonicalTargetsRole]
@@ -320,7 +320,7 @@ func TestUpdateDelegationsAddKeyToRole(t *testing.T) {
 	testKey2, err := ed25519.Create("targets/test", data.ED25519Key)
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role, data.KeyList{testKey2}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{testKey2})
 	assert.NoError(t, err)
 
 	r = repo.Targets["targets"]
@@ -344,7 +344,7 @@ func TestDeleteDelegations(t *testing.T) {
 	role, err := data.NewRole("targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{testKey})
 	assert.NoError(t, err)
 
 	r := repo.Targets[data.CanonicalTargetsRole]
@@ -425,19 +425,19 @@ func TestDeleteDelegationsMidSliceRole(t *testing.T) {
 	role, err := data.NewRole("targets/test", 1, []string{}, []string{}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role, data.KeyList{testKey}, "")
+	err = repo.UpdateDelegations(role, data.KeyList{testKey})
 	assert.NoError(t, err)
 
 	role2, err := data.NewRole("targets/test2", 1, []string{}, []string{}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role2, data.KeyList{testKey}, "")
+	err = repo.UpdateDelegations(role2, data.KeyList{testKey})
 	assert.NoError(t, err)
 
 	role3, err := data.NewRole("targets/test3", 1, []string{}, []string{}, []string{})
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations(role3, data.KeyList{testKey}, "")
+	err = repo.UpdateDelegations(role3, data.KeyList{testKey})
 	assert.NoError(t, err)
 
 	err = repo.DeleteDelegation(*role2)

--- a/tuf/utils/utils_test.go
+++ b/tuf/utils/utils_test.go
@@ -12,18 +12,18 @@ func TestUnusedDelegationKeys(t *testing.T) {
 	role, err := data.NewRole("targets/test", 1, []string{}, nil, nil)
 	assert.NoError(t, err)
 
-	discard := UnusedDelegationKeys(*targets, []string{"123"})
-	assert.Len(t, discard, 1)
+	discard := UnusedDelegationKeys(*targets)
+	assert.Len(t, discard, 0)
 
 	targets.Signed.Delegations.Roles = []*data.Role{role}
 	targets.Signed.Delegations.Keys["123"] = nil
 
-	discard = UnusedDelegationKeys(*targets, []string{"123"})
+	discard = UnusedDelegationKeys(*targets)
 	assert.Len(t, discard, 1)
 
 	role.KeyIDs = []string{"123"}
 
-	discard = UnusedDelegationKeys(*targets, []string{"123"})
+	discard = UnusedDelegationKeys(*targets)
 	assert.Len(t, discard, 0)
 }
 
@@ -35,14 +35,14 @@ func TestRemoveUnusedKeys(t *testing.T) {
 
 	targets.Signed.Delegations.Keys["123"] = nil
 
-	RemoveUnusedKeys(targets, []string{"123"})
+	RemoveUnusedKeys(targets)
 	assert.Len(t, targets.Signed.Delegations.Keys, 0)
 
 	// when role is present that uses key, it shouldn't get removed
 	targets.Signed.Delegations.Roles = []*data.Role{role}
 	targets.Signed.Delegations.Keys["123"] = nil
 
-	RemoveUnusedKeys(targets, []string{"123"})
+	RemoveUnusedKeys(targets)
 	assert.Len(t, targets.Signed.Delegations.Keys, 1)
 }
 

--- a/tuf/utils/utils_test.go
+++ b/tuf/utils/utils_test.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"github.com/docker/notary/tuf/data"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUnusedDelegationKeys(t *testing.T) {
+	targets := data.NewTargets()
+
+	role, err := data.NewRole("targets/test", 1, []string{}, nil, nil)
+	assert.NoError(t, err)
+
+	discard := UnusedDelegationKeys(*targets, []string{"123"})
+	assert.Len(t, discard, 1)
+
+	targets.Signed.Delegations.Roles = []*data.Role{role}
+	targets.Signed.Delegations.Keys["123"] = nil
+
+	discard = UnusedDelegationKeys(*targets, []string{"123"})
+	assert.Len(t, discard, 1)
+
+	role.KeyIDs = []string{"123"}
+
+	discard = UnusedDelegationKeys(*targets, []string{"123"})
+	assert.Len(t, discard, 0)
+}
+
+func TestRemoveUnusedKeys(t *testing.T) {
+	targets := data.NewTargets()
+
+	role, err := data.NewRole("targets/test", 1, []string{"123"}, nil, nil)
+	assert.NoError(t, err)
+
+	targets.Signed.Delegations.Keys["123"] = nil
+
+	RemoveUnusedKeys(targets, []string{"123"})
+	assert.Len(t, targets.Signed.Delegations.Keys, 0)
+
+	// when role is present that uses key, it shouldn't get removed
+	targets.Signed.Delegations.Roles = []*data.Role{role}
+	targets.Signed.Delegations.Keys["123"] = nil
+
+	RemoveUnusedKeys(targets, []string{"123"})
+	assert.Len(t, targets.Signed.Delegations.Keys, 1)
+}
+
+func TestFindRoleIndexFound(t *testing.T) {
+	role, err := data.NewRole("targets/test", 1, []string{}, nil, nil)
+	assert.NoError(t, err)
+
+	assert.Equal(
+		t,
+		0,
+		FindRoleIndex([]*data.Role{role}, role.Name),
+	)
+}
+
+func TestFindRoleIndexNotFound(t *testing.T) {
+	role, err := data.NewRole("targets/test", 1, []string{}, nil, nil)
+	assert.NoError(t, err)
+
+	assert.Equal(
+		t,
+		-1,
+		FindRoleIndex(nil, role.Name),
+	)
+}


### PR DESCRIPTION
I debated on whether `UpdateDelegations` should create the delegations file in the case it doesn't exist, but that's not necessarily possible in the general TUF case due to what keys the parent owner wants present on the delegation. Creation of this file will happen at a higher level (i.e. in NotaryRepository). When adding that functionality, we will likely want to update `repo.InitTargets` to take a role name.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)