### PR TITLE
Fix (make vet)

### DIFF
--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -350,7 +350,7 @@ type failStore struct {
 	storage.MemStorage
 }
 
-func (s failStore) GetCurrent(_, _ string) ([]byte, error) {
+func (s *failStore) GetCurrent(_, _ string) ([]byte, error) {
 	return nil, fmt.Errorf("oh no! storage has failed")
 }
 

--- a/tuf/store/httpstore_test.go
+++ b/tuf/store/httpstore_test.go
@@ -205,7 +205,7 @@ func Test400Error(t *testing.T) {
 // If it's a 400, translateStatusToError attempts to parse the body into
 // an error.  If successful (and a recognized error) that error is returned.
 func TestTranslateErrorsParse400Errors(t *testing.T) {
-	origErr := validation.ErrBadRoot{"bad"}
+	origErr := validation.ErrBadRoot{Msg: "bad"}
 
 	serialObj, err := validation.NewSerializableError(origErr)
 	assert.NoError(t, err)


### PR DESCRIPTION
```
server/handlers/default_test.go:353: GetCurrent passes Lock by value: handlers.failStore contains github.com/docker/notary/server/storage.MemStorage contains sync.Mutex
tuf/store/httpstore_test.go:208: github.com/docker/notary/tuf/validation.ErrBadRoot composite literal uses unkeyed fields
```

Signed-off-by: Miloslav Trmač <mitr@redhat.com>