### PR TITLE
Adding a volume to MySQL container to ensure data persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ notarysigner:
    - notarymysql
   command: -config=fixtures/signer-config.json
 notarymysql:
+  volumes:
+    - notarymysql:/var/lib/mysql
   build: ./notarymysql/
   ports:
     - "3306:3306"


### PR DESCRIPTION
In case someone is deploying in production directly by doing `docker-compose up` from notary, we might as well make sure they don't lose data by accident.

Signed-off-by: Diogo Monica <diogo@docker.com>