### PR TITLE
Use a .-relative bind-mounted volume in notarymysql compose section.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ notarysigner:
   command: -config=fixtures/signer-config.json
 notarymysql:
   volumes:
-    - notarymysql:/var/lib/mysql
+    - ./notarymysql:/var/lib/mysql
   build: ./notarymysql/
   ports:
     - "3306:3306"


### PR DESCRIPTION
See https://github.com/docker/notary/pull/359#discussion_r47570016

Signed-off-by: Ying Li <ying.li@docker.com>