### PR TITLE
Add/Remove targets takes a list of roles to modify

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -260,8 +260,8 @@ func (r *NotaryRepository) Initialize(rootKeyID string, serverManagedRoles ...st
 }
 
 // adds a TUF Change template to the given roles
-func addChange(cl *changelist.FileChangelist, c changelist.Change,
-	roles ...string) error {
+func addChange(cl *changelist.FileChangelist, c changelist.Change, roles ...string) error {
+
 	if len(roles) == 0 {
 		roles = []string{data.CanonicalTargetsRole}
 	}
@@ -270,11 +270,9 @@ func addChange(cl *changelist.FileChangelist, c changelist.Change,
 	for _, role := range roles {
 		role = strings.ToLower(role)
 
-		if !data.ValidRole(role) {
-			return data.ErrInvalidRole{Role: role}
-		}
-
-		if _, ok := data.ValidRoles[role]; ok && role != data.CanonicalTargetsRole {
+		// Ensure we can only add targets to the CanonicalTargetsRole,
+		// or a Delegation role (which is <CanonicalTargetsRole>/something else)
+		if role != data.CanonicalTargetsRole && !data.IsDelegation(role) {
 			return data.ErrInvalidRole{
 				Role:   role,
 				Reason: "cannot add targets to this role",
@@ -302,6 +300,7 @@ func addChange(cl *changelist.FileChangelist, c changelist.Change,
 // in the repository when the changelist gets appied at publish time.
 // If roles are unspecified, the default role is "target".
 func (r *NotaryRepository) AddTarget(target *Target, roles ...string) error {
+
 	cl, err := changelist.NewFileChangelist(filepath.Join(r.tufRepoPath, "changelist"))
 	if err != nil {
 		return err
@@ -325,6 +324,7 @@ func (r *NotaryRepository) AddTarget(target *Target, roles ...string) error {
 // roles in the repository when the changelist gets applied at publish time.
 // If roles are unspecified, the default role is "target".
 func (r *NotaryRepository) RemoveTarget(targetName string, roles ...string) error {
+
 	cl, err := changelist.NewFileChangelist(filepath.Join(r.tufRepoPath, "changelist"))
 	if err != nil {
 		return err

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -98,16 +98,23 @@ func ValidRole(name string) bool {
 	if v, ok := ValidRoles[name]; ok {
 		return name == v
 	}
-	targetsBase := fmt.Sprintf("%s/", ValidRoles[CanonicalTargetsRole])
-	if strings.HasPrefix(name, targetsBase) {
+
+	if IsDelegation(name) {
 		return true
 	}
+
 	for _, v := range ValidRoles {
 		if name == v {
 			return true
 		}
 	}
 	return false
+}
+
+// IsDelegation checks if the role is a delegation or a root role
+func IsDelegation(role string) bool {
+	targetsBase := fmt.Sprintf("%s/", ValidRoles[CanonicalTargetsRole])
+	return strings.HasPrefix(role, targetsBase) && !strings.HasSuffix(role, "/")
 }
 
 // RootRole is a cut down role as it appears in the root.json
@@ -186,8 +193,7 @@ func (r Role) CheckPrefixes(hash string) bool {
 
 // IsDelegation checks if the role is a delegation or a root role
 func (r Role) IsDelegation() bool {
-	targetsBase := fmt.Sprintf("%s/", ValidRoles[CanonicalTargetsRole])
-	return strings.HasPrefix(r.Name, targetsBase)
+	return IsDelegation(r.Name)
 }
 
 // AddKeys merges the ids into the current list of role key ids

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -180,4 +181,38 @@ func TestErrNoSuchRole(t *testing.T) {
 func TestErrInvalidRole(t *testing.T) {
 	var err error = ErrInvalidRole{Role: "test"}
 	assert.False(t, strings.Contains(err.Error(), "Reason"))
+}
+
+func TestIsDelegation(t *testing.T) {
+	assert.True(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "level1")))
+	assert.True(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole, "level1", "level2", "level3")))
+
+	assert.False(t, IsDelegation(""))
+	assert.False(t, IsDelegation(CanonicalRootRole))
+	assert.False(t, IsDelegation(filepath.Join(CanonicalRootRole, "level1")))
+
+	assert.False(t, IsDelegation(CanonicalTargetsRole))
+	assert.False(t, IsDelegation(CanonicalTargetsRole+"/"))
+	assert.False(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "level1")+"/"))
+}
+
+func TestValidRoleFunction(t *testing.T) {
+	assert.True(t, ValidRole(CanonicalRootRole))
+	assert.True(t, ValidRole(CanonicalTimestampRole))
+	assert.True(t, ValidRole(CanonicalSnapshotRole))
+	assert.True(t, ValidRole(CanonicalTargetsRole))
+	assert.True(t, ValidRole(filepath.Join(CanonicalTargetsRole, "level1")))
+	assert.True(t, ValidRole(
+		filepath.Join(CanonicalTargetsRole, "level1", "level2", "level3")))
+
+	assert.False(t, ValidRole(""))
+	assert.False(t, ValidRole(CanonicalRootRole+"/"))
+	assert.False(t, ValidRole(CanonicalTimestampRole+"/"))
+	assert.False(t, ValidRole(CanonicalSnapshotRole+"/"))
+	assert.False(t, ValidRole(CanonicalTargetsRole+"/"))
+
+	assert.False(t, ValidRole(filepath.Join(CanonicalRootRole, "level1")))
+
+	assert.False(t, ValidRole(filepath.Join("role")))
 }


### PR DESCRIPTION
This allows us to add to more than 1 role.

From discussion with @endophage:  at publish time, we will try to sign the role - if there is no such role, and fall back the roles parent, and so forth.  If the role exists, and we just don't have a key, fail to sign.

This way if we integrate with docker, when adding targets it can specify the releases role to sign, so new clients will try to sign the releases role, and old clients will continue to sign the targets role.