### PR TITLE
add extra validation checks to isDelegation

### DIFF
--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -116,13 +116,21 @@ func ValidRole(name string) bool {
 // IsDelegation checks if the role is a delegation or a root role
 func IsDelegation(role string) bool {
 	targetsBase := fmt.Sprintf("%s/", ValidRoles[CanonicalTargetsRole])
-	whitelistedChars, err := regexp.MatchString("^[a-zA-Z0-9_/]*$", role)
+
+	whitelistedChars, err := regexp.MatchString("^[-a-z0-9_/]+$", role)
 	if err != nil {
 		return false
 	}
+
+	// Limit size of full role string to 255 chars for db column size limit
+	correctLength := len(role) < 256
+
 	// Removes ., .., extra slashes, and trailing slash
 	isClean := filepath.Clean(role) == role
-	return strings.HasPrefix(role, targetsBase) && whitelistedChars && isClean
+	return strings.HasPrefix(role, targetsBase) &&
+		whitelistedChars &&
+		correctLength &&
+		isClean
 }
 
 // RootRole is a cut down role as it appears in the root.json

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -3,6 +3,8 @@ package data
 import (
 	"fmt"
 	"strings"
+	"regexp"
+	"path/filepath"
 )
 
 // Canonical base role names
@@ -114,7 +116,9 @@ func ValidRole(name string) bool {
 // IsDelegation checks if the role is a delegation or a root role
 func IsDelegation(role string) bool {
 	targetsBase := fmt.Sprintf("%s/", ValidRoles[CanonicalTargetsRole])
-	return strings.HasPrefix(role, targetsBase) && !strings.HasSuffix(role, "/")
+	whitelistedChars, _ := regexp.MatchString("^[a-zA-Z0-9_/]*$", role)
+	isClean := filepath.Clean(role) == role
+	return strings.HasPrefix(role, targetsBase) && !strings.HasSuffix(role, "/") && whitelistedChars && isClean
 }
 
 // RootRole is a cut down role as it appears in the root.json

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -2,9 +2,9 @@ package data
 
 import (
 	"fmt"
-	"strings"
-	"regexp"
 	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 // Canonical base role names
@@ -116,9 +116,13 @@ func ValidRole(name string) bool {
 // IsDelegation checks if the role is a delegation or a root role
 func IsDelegation(role string) bool {
 	targetsBase := fmt.Sprintf("%s/", ValidRoles[CanonicalTargetsRole])
-	whitelistedChars, _ := regexp.MatchString("^[a-zA-Z0-9_/]*$", role)
+	whitelistedChars, err := regexp.MatchString("^[a-zA-Z0-9_/]*$", role)
+	if err != nil {
+		return false
+	}
+	// Removes ., .., extra slashes, and trailing slash
 	isClean := filepath.Clean(role) == role
-	return strings.HasPrefix(role, targetsBase) && !strings.HasSuffix(role, "/") && whitelistedChars && isClean
+	return strings.HasPrefix(role, targetsBase) && whitelistedChars && isClean
 }
 
 // RootRole is a cut down role as it appears in the root.json

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -195,6 +195,27 @@ func TestIsDelegation(t *testing.T) {
 	assert.False(t, IsDelegation(CanonicalTargetsRole))
 	assert.False(t, IsDelegation(CanonicalTargetsRole+"/"))
 	assert.False(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "level1")+"/"))
+
+	assert.False(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole, "directory") + "/../../traversal"))
+
+	assert.False(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole) + "///test/middle/slashes"))
+
+	assert.False(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole) + "/./././"))
+
+	assert.False(t, IsDelegation(
+		filepath.Join("  ", CanonicalTargetsRole, "level1")))
+
+	assert.False(t, IsDelegation(
+		filepath.Join("  " + CanonicalTargetsRole, "level1")))
+
+	assert.False(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole, "level1" + "  ")))
+
+	assert.False(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole, "white   space" + "level2")))
 }
 
 func TestValidRoleFunction(t *testing.T) {

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -197,25 +197,25 @@ func TestIsDelegation(t *testing.T) {
 	assert.False(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "level1")+"/"))
 
 	assert.False(t, IsDelegation(
-		filepath.Join(CanonicalTargetsRole, "directory") + "/../../traversal"))
+		filepath.Join(CanonicalTargetsRole, "directory")+"/../../traversal"))
 
 	assert.False(t, IsDelegation(
-		filepath.Join(CanonicalTargetsRole) + "///test/middle/slashes"))
+		filepath.Join(CanonicalTargetsRole)+"///test/middle/slashes"))
 
 	assert.False(t, IsDelegation(
-		filepath.Join(CanonicalTargetsRole) + "/./././"))
+		filepath.Join(CanonicalTargetsRole)+"/./././"))
 
 	assert.False(t, IsDelegation(
 		filepath.Join("  ", CanonicalTargetsRole, "level1")))
 
 	assert.False(t, IsDelegation(
-		filepath.Join("  " + CanonicalTargetsRole, "level1")))
+		filepath.Join("  "+CanonicalTargetsRole, "level1")))
 
 	assert.False(t, IsDelegation(
-		filepath.Join(CanonicalTargetsRole, "level1" + "  ")))
+		filepath.Join(CanonicalTargetsRole, "level1"+"  ")))
 
 	assert.False(t, IsDelegation(
-		filepath.Join(CanonicalTargetsRole, "white   space" + "level2")))
+		filepath.Join(CanonicalTargetsRole, "white   space"+"level2")))
 }
 
 func TestValidRoleFunction(t *testing.T) {

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -187,6 +187,10 @@ func TestIsDelegation(t *testing.T) {
 	assert.True(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "level1")))
 	assert.True(t, IsDelegation(
 		filepath.Join(CanonicalTargetsRole, "level1", "level2", "level3")))
+	assert.True(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "under_score")))
+	assert.True(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "hyphen-hyphen")))
+	assert.False(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole, strings.Repeat("x", 255-len(CanonicalTargetsRole)))))
 
 	assert.False(t, IsDelegation(""))
 	assert.False(t, IsDelegation(CanonicalRootRole))
@@ -195,6 +199,7 @@ func TestIsDelegation(t *testing.T) {
 	assert.False(t, IsDelegation(CanonicalTargetsRole))
 	assert.False(t, IsDelegation(CanonicalTargetsRole+"/"))
 	assert.False(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "level1")+"/"))
+	assert.False(t, IsDelegation(filepath.Join(CanonicalTargetsRole, "UpperCase")))
 
 	assert.False(t, IsDelegation(
 		filepath.Join(CanonicalTargetsRole, "directory")+"/../../traversal"))
@@ -216,6 +221,9 @@ func TestIsDelegation(t *testing.T) {
 
 	assert.False(t, IsDelegation(
 		filepath.Join(CanonicalTargetsRole, "white   space"+"level2")))
+
+	assert.False(t, IsDelegation(
+		filepath.Join(CanonicalTargetsRole, strings.Repeat("x", 256-len(CanonicalTargetsRole)))))
 }
 
 func TestValidRoleFunction(t *testing.T) {


### PR DESCRIPTION
Addresses https://github.com/docker/notary/issues/375, by adding two more checks.

The regex checks against  whitelisted characters: alphabetical, numerical, underscore, and slashes.
`filepath.Clean` removes extra slashes and dots from the URL, but does not handle whitespaces and other characters .

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>