### PR TITLE
Publishing delegation changes, and targets to delegations

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -584,12 +584,17 @@ func (r *NotaryRepository) Publish() error {
 		updatedFiles[data.CanonicalRootRole] = rootJSON
 	}
 
-	// we will always re-sign targets
-	targetsJSON, err := serializeCanonicalRole(r.tufRepo, data.CanonicalTargetsRole)
-	if err != nil {
-		return err
+	// iterate through all the targets files - if they are dirty, or if they
+	// are the canonical target role, then sign and update
+	for roleName, roleObj := range r.tufRepo.Targets {
+		if roleName == data.CanonicalTargetsRole || roleObj.Dirty {
+			targetsJSON, err := serializeCanonicalRole(r.tufRepo, roleName)
+			if err != nil {
+				return err
+			}
+			updatedFiles[roleName] = targetsJSON
+		}
 	}
-	updatedFiles[data.CanonicalTargetsRole] = targetsJSON
 
 	// if we initialized the repo while designating the server as the snapshot
 	// signer, then there won't be a snapshots file.  However, we might now

--- a/client/client.go
+++ b/client/client.go
@@ -245,7 +245,7 @@ func (r *NotaryRepository) Initialize(rootKeyID string, serverManagedRoles ...st
 		logrus.Debug("Error on InitRoot: ", err.Error())
 		return err
 	}
-	err = r.tufRepo.InitTargets(data.CanonicalTargetsRole)
+	_, err = r.tufRepo.InitTargets(data.CanonicalTargetsRole)
 	if err != nil {
 		logrus.Debug("Error on InitTargets: ", err.Error())
 		return err

--- a/client/client.go
+++ b/client/client.go
@@ -584,10 +584,9 @@ func (r *NotaryRepository) Publish() error {
 		updatedFiles[data.CanonicalRootRole] = rootJSON
 	}
 
-	// iterate through all the targets files - if they are dirty, or if they
-	// are the canonical target role, then sign and update
+	// iterate through all the targets files - if they are dirty, sign and update
 	for roleName, roleObj := range r.tufRepo.Targets {
-		if roleName == data.CanonicalTargetsRole || roleObj.Dirty {
+		if roleObj.Dirty {
 			targetsJSON, err := serializeCanonicalRole(r.tufRepo, roleName)
 			if err != nil {
 				return err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1496,7 +1496,7 @@ func TestPublishDelegations(t *testing.T) {
 	// targets/a, because these should execute in order
 	for _, delgName := range []string{"targets/a", "targets/a/b", "targets/c"} {
 		assert.NoError(t,
-			repo1.AddDelegation(delgName, 1, []data.PublicKey{delgKey}),
+			repo1.AddDelegation(delgName, 1, []data.PublicKey{delgKey}, []string{""}),
 			"error creating delegation")
 	}
 	assert.Len(t, getChanges(t, repo1), 3, "wrong number of changelist files found")
@@ -1505,7 +1505,7 @@ func TestPublishDelegations(t *testing.T) {
 
 	// this should not publish, because targets/z doesn't exist
 	assert.NoError(t,
-		repo1.AddDelegation("targets/z/y", 1, []data.PublicKey{delgKey}),
+		repo1.AddDelegation("targets/z/y", 1, []data.PublicKey{delgKey}, []string{""}),
 		"error creating delegation")
 	assert.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
 	assert.Error(t, repo1.Publish())
@@ -1587,7 +1587,7 @@ func TestPublishTargetsDelgationScopeNoFallbackIfNoKeys(t *testing.T) {
 	aPubKey := data.PublicKeyFromPrivate(aPrivKey)
 
 	// ensure that the role exists
-	assert.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{aPubKey}))
+	assert.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{aPubKey}, []string{""}))
 	assert.NoError(t, repo.Publish())
 
 	// add a target to targets/a/b - no role b, so it falls back on a, which
@@ -1624,7 +1624,7 @@ func TestPublishTargetsDelgationSuccessLocallyHasRoles(t *testing.T) {
 
 	for _, delgName := range []string{"targets/a", "targets/a/b"} {
 		assert.NoError(t,
-			repo.AddDelegation(delgName, 1, []data.PublicKey{delgKey}),
+			repo.AddDelegation(delgName, 1, []data.PublicKey{delgKey}, []string{""}),
 			"error creating delegation")
 	}
 
@@ -1672,10 +1672,10 @@ func TestPublishTargetsDelgationSuccessNeedsToDownloadRoles(t *testing.T) {
 
 	// owner creates delegations, adds the delegated key to them, and publishes them
 	assert.NoError(t,
-		ownerRepo.AddDelegation("targets/a", 1, []data.PublicKey{aKey}),
+		ownerRepo.AddDelegation("targets/a", 1, []data.PublicKey{aKey}, []string{""}),
 		"error creating delegation")
 	assert.NoError(t,
-		ownerRepo.AddDelegation("targets/a/b", 1, []data.PublicKey{bKey}),
+		ownerRepo.AddDelegation("targets/a/b", 1, []data.PublicKey{bKey}, []string{""}),
 		"error creating delegation")
 
 	assert.NoError(t, ownerRepo.Publish())

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1223,7 +1223,8 @@ func assertPublishToRolesSucceeds(t *testing.T, repo1 *NotaryRepository,
 			targets, err := repo.ListTargets(role)
 			assert.NoError(t, err)
 
-			assert.Len(t, targets, 2, "unexpected number of targets returned by ListTargets")
+			assert.Len(t, targets, 2,
+				"unexpected number of targets returned by ListTargets(%s)", role)
 
 			sort.Stable(targetSorter(targets))
 

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -216,14 +216,14 @@ func addKeyForRole(kdb *keys.KeyDB, role string, key data.PublicKey) error {
 // signs and serializes the metadata for a canonical role in a tuf repo to JSON
 func serializeCanonicalRole(tufRepo *tuf.Repo, role string) (out []byte, err error) {
 	var s *data.Signed
-	switch role {
-	case data.CanonicalRootRole:
+	if role == data.CanonicalRootRole {
 		s, err = tufRepo.SignRoot(data.DefaultExpires(role))
-	case data.CanonicalSnapshotRole:
+	} else if role == data.CanonicalSnapshotRole {
 		s, err = tufRepo.SignSnapshot(data.DefaultExpires(role))
-	case data.CanonicalTargetsRole:
-		s, err = tufRepo.SignTargets(role, data.DefaultExpires(role))
-	default:
+	} else if _, ok := tufRepo.Targets[role]; ok {
+		s, err = tufRepo.SignTargets(
+			role, data.DefaultExpires(data.CanonicalTargetsRole))
+	} else {
 		err = fmt.Errorf("%s not supported role to sign on the client", role)
 	}
 

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -245,14 +245,15 @@ func addKeyForRole(kdb *keys.KeyDB, role string, key data.PublicKey) error {
 // signs and serializes the metadata for a canonical role in a tuf repo to JSON
 func serializeCanonicalRole(tufRepo *tuf.Repo, role string) (out []byte, err error) {
 	var s *data.Signed
-	if role == data.CanonicalRootRole {
+	switch {
+	case role == data.CanonicalRootRole:
 		s, err = tufRepo.SignRoot(data.DefaultExpires(role))
-	} else if role == data.CanonicalSnapshotRole {
+	case role == data.CanonicalSnapshotRole:
 		s, err = tufRepo.SignSnapshot(data.DefaultExpires(role))
-	} else if _, ok := tufRepo.Targets[role]; ok {
+	case tufRepo.Targets[role] != nil:
 		s, err = tufRepo.SignTargets(
 			role, data.DefaultExpires(data.CanonicalTargetsRole))
-	} else {
+	default:
 		err = fmt.Errorf("%s not supported role to sign on the client", role)
 	}
 

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -6,21 +6,14 @@ import (
 	"testing"
 
 	"github.com/docker/notary/client/changelist"
-	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
-	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestApplyTargetsChange(t *testing.T) {
-	kdb := keys.NewDB()
-	role, err := data.NewRole("targets", 1, nil, nil, nil)
-	assert.NoError(t, err)
-	kdb.AddRole(role)
-
-	repo := tuf.NewRepo(kdb, nil)
-	err = repo.InitTargets(data.CanonicalTargetsRole)
+	_, repo, _ := testutils.EmptyRepo()
+	_, err := repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -57,13 +50,8 @@ func TestApplyTargetsChange(t *testing.T) {
 }
 
 func TestApplyChangelist(t *testing.T) {
-	kdb := keys.NewDB()
-	role, err := data.NewRole("targets", 1, nil, nil, nil)
-	assert.NoError(t, err)
-	kdb.AddRole(role)
-
-	repo := tuf.NewRepo(kdb, nil)
-	err = repo.InitTargets(data.CanonicalTargetsRole)
+	_, repo, _ := testutils.EmptyRepo()
+	_, err := repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -105,13 +93,8 @@ func TestApplyChangelist(t *testing.T) {
 }
 
 func TestApplyChangelistMulti(t *testing.T) {
-	kdb := keys.NewDB()
-	role, err := data.NewRole("targets", 1, nil, nil, nil)
-	assert.NoError(t, err)
-	kdb.AddRole(role)
-
-	repo := tuf.NewRepo(kdb, nil)
-	err = repo.InitTargets(data.CanonicalTargetsRole)
+	_, repo, _ := testutils.EmptyRepo()
+	_, err := repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -836,7 +836,11 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""}, nil)
 	assert.NoError(t, err)
 
-	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
+	err = baseRepo.UpdateDelegations(r, []data.PublicKey{k})
+	assert.NoError(t, err)
+
+	// no targets file is created for the new delegations, so force one
+	baseRepo.InitTargets("targets/level1")
 
 	// we're not going to validate things loaded from storage, so no need
 	// to sign the base targets, just Marshal it and set it into storage
@@ -884,6 +888,9 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
+
+	// no targets file is created for the new delegations, so force one
+	baseRepo.InitTargets("targets/level1")
 
 	targets, err := baseRepo.SignTargets("targets", data.DefaultExpires(data.CanonicalTargetsRole))
 
@@ -938,6 +945,9 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
+
+	// no targets file is created for the new delegations, so force one
+	baseRepo.InitTargets("targets/level1")
 
 	// generate the update object we're doing to use to call loadAndValidateTargets
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -500,7 +500,7 @@ func (c Client) getTargetsFile(role string, keyIDs []string, snapshotMeta data.F
 		// if we error when setting meta, we should continue.
 		err = c.cache.SetMeta(role, raw)
 		if err != nil {
-			logrus.Errorf("Failed to write snapshot to local cache: %s", err.Error())
+			logrus.Errorf("Failed to write %s to local cache: %s", role, err.Error())
 		}
 	}
 	return s, nil

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -99,8 +99,25 @@ func (tr *Repo) AddBaseKeys(role string, keys ...data.PublicKey) error {
 	}
 	tr.keysDB.AddRole(r)
 	tr.Root.Dirty = true
-	return nil
 
+	// also, whichever role was switched out needs to be re-signed
+	// root has already been marked dirty
+	switch role {
+	case data.CanonicalSnapshotRole:
+		if tr.Snapshot != nil {
+			tr.Snapshot.Dirty = true
+		}
+	case data.CanonicalTargetsRole:
+		target, ok := tr.Targets[data.CanonicalTargetsRole]
+		if ok {
+			target.Dirty = true
+		}
+	case data.CanonicalTimestampRole:
+		if tr.Timestamp != nil {
+			tr.Timestamp.Dirty = true
+		}
+	}
+	return nil
 }
 
 // ReplaceBaseKeys is used to replace all keys for the given role with the new keys

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -108,8 +108,7 @@ func (tr *Repo) AddBaseKeys(role string, keys ...data.PublicKey) error {
 			tr.Snapshot.Dirty = true
 		}
 	case data.CanonicalTargetsRole:
-		target, ok := tr.Targets[data.CanonicalTargetsRole]
-		if ok {
+		if target, ok := tr.Targets[data.CanonicalTargetsRole]; ok {
 			target.Dirty = true
 		}
 	case data.CanonicalTimestampRole:

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -228,7 +228,7 @@ func TestUpdateDelegationsMissingParentKey(t *testing.T) {
 	roleKey, err := ed25519.Create("Invalid Role", data.ED25519Key)
 	assert.NoError(t, err)
 
-	role, err := data.NewRole("targets/role", 1, []string{}, []string{}, []string{})
+	role, err := data.NewRole("targets/role", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.UpdateDelegations(role, data.KeyList{roleKey})
@@ -630,12 +630,12 @@ func TestGetDelegationRoleAndMetadataExistDelegationExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	role, err := data.NewRole(
-		"targets/level1", 1, []string{testKey.ID()}, []string{}, []string{})
+		"targets/level1", 1, []string{testKey.ID()}, []string{""}, []string{})
 	assert.NoError(t, err)
 	assert.NoError(t, repo.UpdateDelegations(role, data.KeyList{testKey}))
 
 	role, err = data.NewRole(
-		"targets/level1/level2", 1, []string{testKey.ID()}, []string{}, []string{})
+		"targets/level1/level2", 1, []string{testKey.ID()}, []string{""}, []string{})
 	assert.NoError(t, err)
 	assert.NoError(t, repo.UpdateDelegations(role, data.KeyList{testKey}))
 
@@ -655,7 +655,7 @@ func TestGetDelegationRoleAndMetadataExistDelegationDoesntExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	role, err := data.NewRole(
-		"targets/level1", 1, []string{testKey.ID()}, []string{}, []string{})
+		"targets/level1", 1, []string{testKey.ID()}, []string{""}, []string{})
 	assert.NoError(t, err)
 	assert.NoError(t, repo.UpdateDelegations(role, data.KeyList{testKey}))
 
@@ -677,7 +677,7 @@ func TestGetDelegationRoleAndMetadataDoesntExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	role, err := data.NewRole(
-		"targets/level1", 1, []string{testKey.ID()}, []string{}, []string{})
+		"targets/level1", 1, []string{testKey.ID()}, []string{""}, []string{})
 	assert.NoError(t, err)
 	assert.NoError(t, repo.UpdateDelegations(role, data.KeyList{testKey}))
 
@@ -744,7 +744,7 @@ func TestAddTargetsRoleExistsAndMetadataDoesntExist(t *testing.T) {
 	testKey, err := ed25519.Create("targets/test", data.ED25519Key)
 	assert.NoError(t, err)
 	role, err := data.NewRole(
-		"targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
+		"targets/test", 1, []string{testKey.ID()}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.UpdateDelegations(role, data.KeyList{testKey})
@@ -883,7 +883,7 @@ func TestRemoveTargetsNoSigningKeys(t *testing.T) {
 	testKey, err := ed25519.Create("targets/test", data.ED25519Key)
 	assert.NoError(t, err)
 	role, err := data.NewRole(
-		"targets/test", 1, []string{testKey.ID()}, []string{"test"}, []string{})
+		"targets/test", 1, []string{testKey.ID()}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.UpdateDelegations(role, data.KeyList{testKey})


### PR DESCRIPTION
This makes the following logic changes:

- publish now iterates over all targets marked dirty and publishes only those that are dirty (this means canonical targets will not always get pushed)
- if changes are applied to a role that doesn't exist, publish will fallback on its parent role and so forth until it finds a role that exists.  the changes will be applied to that role.
- delegations metadata is not always created when a delegation is created
- role checks now check keyDB rather than the metadata, because the metadata may not exist
- if the role exists, but metadata doesn't, it is now created before being modified (as opposed to just failing before)