### PR TITLE
the empty string should be used in delegation Paths to indicate a role can sign everything

### DIFF
--- a/client/changelist/change_test.go
+++ b/client/changelist/change_test.go
@@ -17,6 +17,7 @@ func TestTufDelegation(t *testing.T) {
 		NewName:      "targets/new_name",
 		NewThreshold: 1,
 		AddKeys:      kl,
+		AddPaths:     []string{""},
 	}
 
 	r, err := td.ToNewRole("targets/old_name")
@@ -24,6 +25,6 @@ func TestTufDelegation(t *testing.T) {
 	assert.Equal(t, td.NewName, r.Name)
 	assert.Len(t, r.KeyIDs, 1)
 	assert.Equal(t, kl[0].ID(), r.KeyIDs[0])
-	assert.Len(t, r.Paths, 0)
+	assert.Len(t, r.Paths, 1)
 	assert.Len(t, r.PathHashPrefixes, 0)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -301,7 +301,7 @@ func addChange(cl *changelist.FileChangelist, c changelist.Change, roles ...stri
 // other than checking the name of the delegation to add - all that will happen
 // at publish time.
 func (r *NotaryRepository) AddDelegation(name string, threshold int,
-	delegationKeys []data.PublicKey) error {
+	delegationKeys []data.PublicKey, paths []string) error {
 
 	if !data.IsDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -319,6 +319,7 @@ func (r *NotaryRepository) AddDelegation(name string, threshold int,
 	tdJSON, err := json.Marshal(&changelist.TufDelegation{
 		NewThreshold: threshold,
 		AddKeys:      data.KeyList(delegationKeys),
+		AddPaths:     paths,
 	})
 	if err != nil {
 		return err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -948,7 +948,7 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	// setup delegated targets/level1 role
 	k, err := repo.CryptoService.Create("targets/level1", rootType)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, nil, nil)
+	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""}, nil)
 	assert.NoError(t, err)
 	repo.tufRepo.UpdateDelegations(r, []data.PublicKey{k})
 	delegatedTarget := addTarget(t, repo, "current", "../fixtures/root-ca.crt", "targets/level1")
@@ -957,7 +957,7 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	// setup delegated targets/level2 role
 	k, err = repo.CryptoService.Create("targets/level2", rootType)
 	assert.NoError(t, err)
-	r, err = data.NewRole("targets/level2", 1, []string{k.ID()}, nil, nil)
+	r, err = data.NewRole("targets/level2", 1, []string{k.ID()}, []string{""}, nil)
 	assert.NoError(t, err)
 	repo.tufRepo.UpdateDelegations(r, []data.PublicKey{k})
 	// this target should not show up as the one in targets/level1 takes higher priority
@@ -1610,13 +1610,13 @@ func TestAddDelegationChangefileValid(t *testing.T) {
 	targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
 	assert.NotNil(t, targetPubKey)
 
-	err = repo.AddDelegation("root", 1, []data.PublicKey{targetPubKey})
+	err = repo.AddDelegation("root", 1, []data.PublicKey{targetPubKey}, []string{""})
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
 	assert.Empty(t, getChanges(t, repo))
 
 	// to show that adding does not care about the hierarchy
-	err = repo.AddDelegation("targets/a/b/c", 1, []data.PublicKey{targetPubKey})
+	err = repo.AddDelegation("targets/a/b/c", 1, []data.PublicKey{targetPubKey}, []string{""})
 	assert.NoError(t, err)
 
 	// ensure that the changefiles is correct
@@ -1649,7 +1649,7 @@ func TestAddDelegationChangefileApplicable(t *testing.T) {
 	assert.NotNil(t, targetPubKey)
 
 	// this hierarchy has to be right to be applied
-	err = repo.AddDelegation("targets/a", 1, []data.PublicKey{targetPubKey})
+	err = repo.AddDelegation("targets/a", 1, []data.PublicKey{targetPubKey}, []string{""})
 	assert.NoError(t, err)
 	changes := getChanges(t, repo)
 	assert.Len(t, changes, 1)
@@ -1680,7 +1680,7 @@ func TestAddDelegationErrorWritingChanges(t *testing.T) {
 		targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
 		assert.NotNil(t, targetPubKey)
 
-		return repo.AddDelegation("targets/a", 1, []data.PublicKey{targetPubKey})
+		return repo.AddDelegation("targets/a", 1, []data.PublicKey{targetPubKey}, []string{""})
 	})
 }
 
@@ -1738,7 +1738,7 @@ func TestRemoveDelegationChangefileApplicable(t *testing.T) {
 	assert.NotNil(t, rootPubKey)
 
 	// add a delegation first so it can be removed
-	assert.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{rootPubKey}))
+	assert.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{rootPubKey}, []string{""}))
 	changes := getChanges(t, repo)
 	assert.Len(t, changes, 1)
 	assert.NoError(t, applyTargetsChange(repo.tufRepo, changes[0]))

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -833,7 +833,7 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, nil, nil)
+	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
@@ -880,7 +880,7 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, nil, nil)
+	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
@@ -934,7 +934,7 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, nil, nil)
+	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
@@ -968,7 +968,7 @@ func TestValidateTargetsRoleNotInParent(t *testing.T) {
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, nil, nil)
+	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	kdb.AddKey(k)

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -355,7 +355,7 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 		// create role
 		k, err := cs.Create(r, data.ED25519Key)
 		assert.NoError(t, err)
-		role, err := data.NewRole(r, 1, []string{k.ID()}, nil, nil)
+		role, err := data.NewRole(r, 1, []string{k.ID()}, []string{""}, nil)
 		assert.NoError(t, err)
 
 		// add role to repo

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -108,8 +108,18 @@ func TestSubtractStrSlicesEqual(t *testing.T) {
 	assert.Len(t, res, 0)
 }
 
+func TestNewRolePathsAndHashPrefixRejection(t *testing.T) {
+	_, err := NewRole("targets/level1", 1, []string{"abc"}, nil, nil)
+	assert.Error(t, err)
+	assert.IsType(t, ErrInvalidRole{}, err)
+
+	_, err = NewRole("targets/level1", 1, []string{"abc"}, []string{""}, []string{""})
+	assert.Error(t, err)
+	assert.IsType(t, ErrInvalidRole{}, err)
+}
+
 func TestAddRemoveKeys(t *testing.T) {
-	role, err := NewRole("targets", 1, []string{"abc"}, nil, nil)
+	role, err := NewRole("targets", 1, []string{"abc"}, []string{""}, nil)
 	assert.NoError(t, err)
 	role.AddKeys([]string{"abc"})
 	assert.Equal(t, []string{"abc"}, role.KeyIDs)

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -226,7 +226,7 @@ func TestUpdateDelegationsRoleMissingKey(t *testing.T) {
 	roleKey, err := ed25519.Create("Invalid Role", data.ED25519Key)
 	assert.NoError(t, err)
 
-	role, err := data.NewRole("targets/role", 1, []string{}, []string{}, []string{})
+	role, err := data.NewRole("targets/role", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	// key should get added to role as part of updating the delegation
@@ -250,7 +250,7 @@ func TestUpdateDelegationsNotEnoughKeys(t *testing.T) {
 	roleKey, err := ed25519.Create("Invalid Role", data.ED25519Key)
 	assert.NoError(t, err)
 
-	role, err := data.NewRole("targets/role", 2, []string{}, []string{}, []string{})
+	role, err := data.NewRole("targets/role", 2, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	// key should get added to role as part of updating the delegation
@@ -371,7 +371,7 @@ func TestDeleteDelegationsRoleNotExist(t *testing.T) {
 	// a role as dirty
 	repo.Targets[data.CanonicalTargetsRole].Dirty = false
 
-	role, err := data.NewRole("targets/test", 1, []string{}, []string{}, []string{})
+	role, err := data.NewRole("targets/test", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.DeleteDelegation(*role)
@@ -389,7 +389,7 @@ func TestDeleteDelegationsInvalidRole(t *testing.T) {
 
 	// data.NewRole errors if the role isn't a valid TUF role so use one of the non-delegation
 	// valid roles
-	invalidRole, err := data.NewRole("root", 1, []string{}, []string{}, []string{})
+	invalidRole, err := data.NewRole("root", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.DeleteDelegation(*invalidRole)
@@ -405,7 +405,7 @@ func TestDeleteDelegationsParentMissing(t *testing.T) {
 	keyDB := keys.NewDB()
 	repo := initRepo(t, ed25519, keyDB)
 
-	testRole, err := data.NewRole("targets/test/deep", 1, []string{}, []string{}, []string{})
+	testRole, err := data.NewRole("targets/test/deep", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.DeleteDelegation(*testRole)
@@ -423,19 +423,19 @@ func TestDeleteDelegationsMidSliceRole(t *testing.T) {
 
 	testKey, err := ed25519.Create("targets/test", data.ED25519Key)
 	assert.NoError(t, err)
-	role, err := data.NewRole("targets/test", 1, []string{}, []string{}, []string{})
+	role, err := data.NewRole("targets/test", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.UpdateDelegations(role, data.KeyList{testKey})
 	assert.NoError(t, err)
 
-	role2, err := data.NewRole("targets/test2", 1, []string{}, []string{}, []string{})
+	role2, err := data.NewRole("targets/test2", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.UpdateDelegations(role2, data.KeyList{testKey})
 	assert.NoError(t, err)
 
-	role3, err := data.NewRole("targets/test3", 1, []string{}, []string{}, []string{})
+	role3, err := data.NewRole("targets/test3", 1, []string{}, []string{""}, []string{})
 	assert.NoError(t, err)
 
 	err = repo.UpdateDelegations(role3, data.KeyList{testKey})

--- a/tuf/utils/utils_test.go
+++ b/tuf/utils/utils_test.go
@@ -9,7 +9,7 @@ import (
 func TestUnusedDelegationKeys(t *testing.T) {
 	targets := data.NewTargets()
 
-	role, err := data.NewRole("targets/test", 1, []string{}, nil, nil)
+	role, err := data.NewRole("targets/test", 1, []string{}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	discard := UnusedDelegationKeys(*targets)
@@ -30,7 +30,7 @@ func TestUnusedDelegationKeys(t *testing.T) {
 func TestRemoveUnusedKeys(t *testing.T) {
 	targets := data.NewTargets()
 
-	role, err := data.NewRole("targets/test", 1, []string{"123"}, nil, nil)
+	role, err := data.NewRole("targets/test", 1, []string{"123"}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	targets.Signed.Delegations.Keys["123"] = nil
@@ -47,7 +47,7 @@ func TestRemoveUnusedKeys(t *testing.T) {
 }
 
 func TestFindRoleIndexFound(t *testing.T) {
-	role, err := data.NewRole("targets/test", 1, []string{}, nil, nil)
+	role, err := data.NewRole("targets/test", 1, []string{}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(
@@ -58,7 +58,7 @@ func TestFindRoleIndexFound(t *testing.T) {
 }
 
 func TestFindRoleIndexNotFound(t *testing.T) {
-	role, err := data.NewRole("targets/test", 1, []string{}, nil, nil)
+	role, err := data.NewRole("targets/test", 1, []string{}, []string{""}, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(


### PR DESCRIPTION


Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)