### PR TITLE
More client writing/publishing negative tests

### DIFF
--- a/client/client_root_validation_test.go
+++ b/client/client_root_validation_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,21 +24,16 @@ func TestValidateRoot(t *testing.T) {
 }
 
 func validateRootSuccessfully(t *testing.T, rootType string) {
-	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	defer os.RemoveAll(tempBaseDir)
-
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
-
 	gun := "docker.com/notary"
 
 	ts, mux, keys := simpleTestServer(t)
 	defer ts.Close()
 
-	repo, _ := initializeRepo(t, rootType, tempBaseDir, gun, ts.URL, false)
+	repo, _ := initializeRepo(t, rootType, gun, ts.URL, false)
+	defer os.RemoveAll(repo.baseDir)
 
 	// tests need to manually boostrap timestamp as client doesn't generate it
-	err = repo.tufRepo.InitTimestamp()
+	err := repo.tufRepo.InitTimestamp()
 	assert.NoError(t, err, "error creating repository: %s", err)
 
 	// Initialize is supposed to have created new certificate for this repository

--- a/server/handlers/default.go
+++ b/server/handlers/default.go
@@ -129,7 +129,7 @@ func getHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, var
 	out, err := store.GetCurrent(gun, tufRole)
 	if err != nil {
 		if _, ok := err.(storage.ErrNotFound); ok {
-			logrus.Error(gun + ":" + tufRole)
+			logrus.Error("404 GET " + gun + ":" + tufRole)
 			return errors.ErrMetadataNotFound.WithDetail(nil)
 		}
 		logger.Error("500 GET")

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -82,7 +82,7 @@ func (c *Client) update() error {
 		// In this instance the root has not expired base on time, but is
 		// expired based on the snapshot dictating a new root has been produced.
 		logrus.Debug(err)
-		return tuf.ErrLocalRootExpired{}
+		return err
 	}
 	// will always need top level targets at a minimum
 	err = c.downloadTargets("targets")

--- a/tuf/store/filestore.go
+++ b/tuf/store/filestore.go
@@ -75,6 +75,9 @@ func (f *FilesystemStore) SetMeta(name string, meta []byte) error {
 		return err
 	}
 
+	// if something already exists, just delete it and re-write it
+	os.RemoveAll(path)
+
 	// Write the file to disk
 	if err = ioutil.WriteFile(path, meta, 0600); err != nil {
 		return err

--- a/tuf/store/filestore_test.go
+++ b/tuf/store/filestore_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,24 @@ func TestSetMetaWithNoParentDirectory(t *testing.T) {
 
 	content, err := ioutil.ReadFile(path.Join(testDir, "metadata", "noexist/testMeta.json"))
 	assert.Nil(t, err, "Error reading file: %v", err)
+	assert.Equal(t, testContent, content, "Content written to file was corrupted.")
+}
+
+// if something already existed there, remove it first and write a new file
+func TestSetMetaRemovesExistingFileBeforeWriting(t *testing.T) {
+	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
+	defer os.RemoveAll(testDir)
+
+	// make a directory where we want metadata to go
+	os.Mkdir(filepath.Join(testDir, "metadata", "root.json"), 0700)
+
+	testContent := []byte("test data")
+	err = s.SetMeta("root", testContent)
+	assert.NoError(t, err, "SetMeta returned unexpected error: %v", err)
+
+	content, err := ioutil.ReadFile(path.Join(testDir, "metadata", "root.json"))
+	assert.NoError(t, err, "Error reading file: %v", err)
 	assert.Equal(t, testContent, content, "Content written to file was corrupted.")
 }
 


### PR DESCRIPTION
A couple more negative test cases from https://github.com/docker/notary/issues/363

Semantic conflict with #385 