### PR TITLE
fixes errors in notary for testing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -535,6 +535,9 @@ func (r *NotaryRepository) Publish() error {
 				// corrupt metadata.  We need better errors from bootstrapRepo.
 				logrus.Debugf("Unable to load repository from local files: %s",
 					err.Error())
+				if _, ok := err.(store.ErrMetaNotFound); ok {
+					return &ErrRepoNotInitialized{}
+				}
 				return err
 			}
 			// We had local data but the server doesn't know about the repo yet,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1473,6 +1473,26 @@ func testPublishBadMetadata(t *testing.T, roleName string, repo *NotaryRepositor
 	}
 }
 
+// If the repo is not initialized, calling repo.Publish() should return ErrRepoNotInitialized
+func TestNotInitializedOnPublish(t *testing.T) {
+	// Temporary directory where test files will be created
+	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	defer os.RemoveAll(tempBaseDir)
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+
+	gun := "docker.com/notary"
+	ts := fullTestServer(t)
+	defer ts.Close()
+
+	repo, _ := createRepoAndKey(t, data.ECDSAKey, tempBaseDir, gun, ts.URL)
+
+	addTarget(t, repo, "v1", "../fixtures/intermediate-ca.crt")
+
+	err = repo.Publish()
+	assert.Error(t, err)
+	assert.IsType(t, &ErrRepoNotInitialized{}, err)
+}
+
 type cannotCreateKeys struct {
 	signed.CryptoService
 }

--- a/tuf/store/errors.go
+++ b/tuf/store/errors.go
@@ -9,5 +9,5 @@ type ErrMetaNotFound struct {
 }
 
 func (err ErrMetaNotFound) Error() string {
-	return fmt.Sprintf("no %s trust data available", err.Role)
+	return fmt.Sprintf("%s trust data unavailable", err.Role)
 }


### PR DESCRIPTION
returns `ErrRepoNotInitialized` to guarantee proper repo initialization (calling `repo.Initialize()`) and also change the format of `ErrMetaNotFound` to simplify string matching in testing

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>