### PR TITLE
Do not panic with invaild log level

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -190,10 +190,7 @@ func main() {
 	}
 
 	// default is error level
-	lvl, err := utils.ParseLogLevel(mainViper, logrus.ErrorLevel)
-	if err != nil {
-		logrus.Fatal(err.Error())
-	}
+	lvl := utils.ParseLogLevel(mainViper, logrus.ErrorLevel)
 	logrus.SetLevel(lvl)
 
 	// parse bugsnag config

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -186,10 +186,7 @@ func main() {
 	}
 
 	// default is error level
-	lvl, err := utils.ParseLogLevel(mainViper, logrus.ErrorLevel)
-	if err != nil {
-		logrus.Fatal(err.Error())
-	}
+	lvl := utils.ParseLogLevel(mainViper, logrus.ErrorLevel)
 	logrus.SetLevel(lvl)
 
 	// parse bugsnag config

--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -72,15 +72,16 @@ func ParseServerTLS(configuration *viper.Viper, tlsRequired bool) (*ServerTLSOpt
 }
 
 // ParseLogLevel tries to parse out a log level from a Viper.  If there is no
-// configuration, defaults to the provided error level
-func ParseLogLevel(configuration *viper.Viper, defaultLevel logrus.Level) (
-	logrus.Level, error) {
+// configuration, defaults to the provided log level
+func ParseLogLevel(configuration *viper.Viper, defaultLevel logrus.Level) logrus.Level {
 
-	logStr := configuration.GetString("logging.level")
-	if logStr == "" {
-		return defaultLevel, nil
+	lvl, err := logrus.ParseLevel(configuration.GetString("logging.level"))
+	if err != nil {
+		logrus.Errorf("Parsing log level error:%v, using %s instead", err, defaultLevel)
+		lvl = defaultLevel
 	}
-	return logrus.ParseLevel(logStr)
+
+	return lvl
 }
 
 // ParseStorage tries to parse out Storage from a Viper.  If backend and

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -40,29 +40,26 @@ func cleanupEnvironmentVariables(t *testing.T, vars map[string]string) {
 
 }
 
-// An error is returned if the log level is not parsable
+// Using default log level if the log level is not parsable
 func TestParseInvalidLogLevel(t *testing.T) {
-	_, err := ParseLogLevel(configure(`{"logging": {"level": "horatio"}}`),
+	lvl := ParseLogLevel(configure(`{"logging": {"level": "horatio"}}`),
 		logrus.DebugLevel)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not a valid logrus Level")
+	assert.Equal(t, logrus.DebugLevel, lvl)
 }
 
 // If there is no logging level configured it is set to the default level
 func TestParseNoLogLevel(t *testing.T) {
 	empties := []string{`{}`, `{"logging": {}}`}
 	for _, configJSON := range empties {
-		lvl, err := ParseLogLevel(configure(configJSON), logrus.DebugLevel)
-		assert.NoError(t, err)
+		lvl := ParseLogLevel(configure(configJSON), logrus.DebugLevel)
 		assert.Equal(t, logrus.DebugLevel, lvl)
 	}
 }
 
 // If there is logging level configured, it is set to the configured one
 func TestParseLogLevel(t *testing.T) {
-	lvl, err := ParseLogLevel(configure(`{"logging": {"level": "error"}}`),
+	lvl := ParseLogLevel(configure(`{"logging": {"level": "error"}}`),
 		logrus.DebugLevel)
-	assert.NoError(t, err)
 	assert.Equal(t, logrus.ErrorLevel, lvl)
 }
 
@@ -71,9 +68,8 @@ func TestParseLogLevelWithEnvironmentVariables(t *testing.T) {
 	setupEnvironmentVariables(t, vars)
 	defer cleanupEnvironmentVariables(t, vars)
 
-	lvl, err := ParseLogLevel(configure(`{}`),
+	lvl := ParseLogLevel(configure(`{}`),
 		logrus.DebugLevel)
-	assert.NoError(t, err)
 	assert.Equal(t, logrus.ErrorLevel, lvl)
 }
 


### PR DESCRIPTION
Since we have already specify a default log level for the project,
we can use it when coming across a invaild log level from configuration
file.

Besides, it is not a good idea to panic the whole project just because
of a wrong log level. Instead we can log it out and use the default one.

Signed-off-by: Hu Keping <hukeping@huawei.com>