### PR TITLE
Do not use strings.Compare

### DIFF
--- a/tuf/utils/role_sort.go
+++ b/tuf/utils/role_sort.go
@@ -20,7 +20,7 @@ func (r RoleList) Less(i, j int) bool {
 	segsI := strings.Split(r[i], "/")
 	segsJ := strings.Split(r[j], "/")
 	if len(segsI) == len(segsJ) {
-		return strings.Compare(r[i], r[j]) == -1
+		return r[i] < r[j]
 	}
 	return len(segsI) < len(segsJ)
 }


### PR DESCRIPTION
According to https://golang.org/src/strings/compare.go?s=491:520#L3
It's suggested to use the built-in string comparison operators.

And also, seems like this function does not exist in some arch
such as arm64. So we better not use it.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>