### PR TITLE
fixing bootstrapClient to prefer cached root

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -774,6 +774,12 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Cl
 			if err != nil {
 				return nil, err
 			}
+
+			err = r.fileStore.SetMeta("root", tmpJSON)
+			if err != nil {
+				// if we can't write cache we should still continue, just log error
+				logrus.Errorf("could not save root to cache: %s", err.Error())
+			}
 		}
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -737,6 +737,11 @@ func (r *NotaryRepository) Update(forWrite bool) (*tufclient.Client, error) {
 	return c, nil
 }
 
+// bootstrapClient attempts to bootstrap a root.json to be used as the trust
+// anchor for a repository. The checkInitialized argument indicates whether
+// we should always attempt to contact the server to determine if the repository
+// is initialized or not. If set to true, we will always attempt to download
+// and return an error if the remote repository errors.
 func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Client, error) {
 	var (
 		rootJSON   []byte

--- a/client/client.go
+++ b/client/client.go
@@ -772,9 +772,8 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Cl
 			return nil, err
 		}
 		if cachedRootErr != nil {
-			// if we entered the remote download code because there was a cache
-			// error and not simply to check the initialization state of the
-			// repo, we want to use the downloaded data as our root.
+			// we always want to use the downloaded root if there was a cache
+			// error.
 			signedRoot, err = r.validateRoot(tmpJSON)
 			if err != nil {
 				return nil, err
@@ -790,6 +789,10 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Cl
 
 	kdb := keys.NewDB()
 	r.tufRepo = tuf.NewRepo(kdb, r.CryptoService)
+
+	if signedRoot == nil {
+		return nil, ErrRepoNotInitialized{}
+	}
 
 	err = r.tufRepo.SetRoot(signedRoot)
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2401,3 +2401,32 @@ func TestRemoveDelegationErrorWritingChanges(t *testing.T) {
 		return repo.RemoveDelegation("targets/a")
 	})
 }
+
+// TestBootstrapClientBadURL checks that bootstrapClient correctly
+// returns an error when the URL is valid but does not point to
+// a TUF server
+func TestBootstrapClientBadURL(t *testing.T) {
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	repo, err := NewNotaryRepository(
+		tempBaseDir,
+		"testGun",
+		"http://localhost:9998",
+		http.DefaultTransport,
+		passphraseRetriever,
+	)
+	assert.NoError(t, err, "error creating repo: %s", err)
+
+	c, err := repo.bootstrapClient(false)
+	assert.Nil(t, c)
+	assert.Error(t, err)
+
+	c, err2 := repo.bootstrapClient(true)
+	assert.Nil(t, c)
+	assert.Error(t, err2)
+
+	// same error should be returned because we don't have local data
+	// and are requesting remote root regardless of checkInitialized
+	// value
+	assert.EqualError(t, err, err2.Error())
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2407,7 +2407,7 @@ func TestRemoveDelegationErrorWritingChanges(t *testing.T) {
 // a TUF server
 func TestBootstrapClientBadURL(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	repo, err := NewNotaryRepository(
 		tempBaseDir,
 		"testGun",
@@ -2415,18 +2415,47 @@ func TestBootstrapClientBadURL(t *testing.T) {
 		http.DefaultTransport,
 		passphraseRetriever,
 	)
-	assert.NoError(t, err, "error creating repo: %s", err)
+	require.NoError(t, err, "error creating repo: %s", err)
 
 	c, err := repo.bootstrapClient(false)
-	assert.Nil(t, c)
-	assert.Error(t, err)
+	require.Nil(t, c)
+	require.Error(t, err)
 
 	c, err2 := repo.bootstrapClient(true)
-	assert.Nil(t, c)
-	assert.Error(t, err2)
+	require.Nil(t, c)
+	require.Error(t, err2)
 
 	// same error should be returned because we don't have local data
 	// and are requesting remote root regardless of checkInitialized
 	// value
-	assert.EqualError(t, err, err2.Error())
+	require.EqualError(t, err, err2.Error())
+}
+
+// TestBootstrapClientInvalidURL checks that bootstrapClient correctly
+// returns an error when the URL is valid but does not point to
+// a TUF server
+func TestBootstrapClientInvalidURL(t *testing.T) {
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	repo, err := NewNotaryRepository(
+		tempBaseDir,
+		"testGun",
+		"#!*)&!)#*^%!#)%^!#",
+		http.DefaultTransport,
+		passphraseRetriever,
+	)
+	require.NoError(t, err, "error creating repo: %s", err)
+
+	c, err := repo.bootstrapClient(false)
+	require.Nil(t, c)
+	require.Error(t, err)
+
+	c, err2 := repo.bootstrapClient(true)
+	require.Nil(t, c)
+	require.Error(t, err2)
+
+	// same error should be returned because we don't have local data
+	// and are requesting remote root regardless of checkInitialized
+	// value
+	require.EqualError(t, err, err2.Error())
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -18,7 +18,7 @@ import (
 
 // Use this to initialize remote HTTPStores from the config settings
 func getRemoteStore(baseURL, gun string, rt http.RoundTripper) (store.RemoteStore, error) {
-	return store.NewHTTPStore(
+	s, err := store.NewHTTPStore(
 		baseURL+"/v2/"+gun+"/_trust/tuf/",
 		"",
 		"json",
@@ -26,6 +26,10 @@ func getRemoteStore(baseURL, gun string, rt http.RoundTripper) (store.RemoteStor
 		"key",
 		rt,
 	)
+	if err != nil {
+		return store.OfflineStore{}, err
+	}
+	return s, err
 }
 
 func applyChangelist(repo *tuf.Repo, cl changelist.Changelist) error {

--- a/tuf/store/offlinestore.go
+++ b/tuf/store/offlinestore.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"io"
+)
+
+// ErrOffline is used to indicate we are operating offline
+type ErrOffline struct{}
+
+func (e ErrOffline) Error() string {
+	return "client is offline"
+}
+
+var err = ErrOffline{}
+
+// OfflineStore is to be used as a placeholder for a nil store. It simply
+// return ErrOffline for every operation
+type OfflineStore struct{}
+
+// GetMeta return ErrOffline
+func (es OfflineStore) GetMeta(name string, size int64) ([]byte, error) {
+	return nil, err
+}
+
+// SetMeta return ErrOffline
+func (es OfflineStore) SetMeta(name string, blob []byte) error {
+	return err
+}
+
+// SetMultiMeta return ErrOffline
+func (es OfflineStore) SetMultiMeta(map[string][]byte) error {
+	return err
+}
+
+// GetKey return ErrOffline
+func (es OfflineStore) GetKey(role string) ([]byte, error) {
+	return nil, err
+}
+
+// GetTarget return ErrOffline
+func (es OfflineStore) GetTarget(path string) (io.ReadCloser, error) {
+	return nil, err
+}

--- a/tuf/store/offlinestore_test.go
+++ b/tuf/store/offlinestore_test.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOfflineStore(t *testing.T) {
+	s := OfflineStore{}
+	_, err := s.GetMeta("", 0)
+	require.Error(t, err)
+	require.IsType(t, ErrOffline{}, err)
+
+	err = s.SetMeta("", nil)
+	require.Error(t, err)
+	require.IsType(t, ErrOffline{}, err)
+
+	err = s.SetMultiMeta(nil)
+	require.Error(t, err)
+	require.IsType(t, ErrOffline{}, err)
+
+	_, err = s.GetKey("")
+	require.Error(t, err)
+	require.IsType(t, ErrOffline{}, err)
+
+	_, err = s.GetTarget("")
+	require.Error(t, err)
+	require.IsType(t, ErrOffline{}, err)
+}
+
+func TestErrOffline(t *testing.T) {
+	var _ error = ErrOffline{}
+}


### PR DESCRIPTION
Necessary precursor to making root rotations workable. Currently we always download the root.json, regardless of whether we have it in cache. This changes that logic to only download if we don't have one in cache. A newer root may then be downloaded later, as part of a repo update, if a problem is detected per the TUF update rules.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)