### PR TITLE
improve message for ErrMetaNotFound

### DIFF
--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -272,7 +272,7 @@ func (c *Client) downloadTimestamp() error {
 			if err == nil {
 				// couldn't retrieve data from server and don't have valid
 				// data in cache.
-				return store.ErrMetaNotFound{}
+				return store.ErrMetaNotFound{Resource: data.CanonicalTimestampRole}
 			}
 			return err
 		}

--- a/tuf/store/errors.go
+++ b/tuf/store/errors.go
@@ -5,9 +5,9 @@ import "fmt"
 // ErrMetaNotFound indicates we did not find a particular piece
 // of metadata in the store
 type ErrMetaNotFound struct {
-	Role string
+	Resource string
 }
 
 func (err ErrMetaNotFound) Error() string {
-	return fmt.Sprintf("%s trust data unavailable", err.Role)
+	return fmt.Sprintf("%s trust data unavailable.  Has a notary repository been initialized?", err.Resource)
 }

--- a/tuf/store/filestore.go
+++ b/tuf/store/filestore.go
@@ -46,7 +46,7 @@ func (f *FilesystemStore) GetMeta(name string, size int64) ([]byte, error) {
 	meta, err := ioutil.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			err = ErrMetaNotFound{Role: name}
+			err = ErrMetaNotFound{Resource: name}
 		}
 		return nil, err
 	}

--- a/tuf/store/memorystore.go
+++ b/tuf/store/memorystore.go
@@ -39,7 +39,7 @@ func (m *memoryStore) GetMeta(name string, size int64) ([]byte, error) {
 		}
 		return d[:size], nil
 	}
-	return nil, ErrMetaNotFound{}
+	return nil, ErrMetaNotFound{Resource: name}
 }
 
 func (m *memoryStore) SetMeta(name string, meta []byte) error {
@@ -75,7 +75,7 @@ func (m *memoryStore) WalkStagedTargets(paths []string, targetsFn targetsWalkFun
 	for _, path := range paths {
 		dat, ok := m.files[path]
 		if !ok {
-			return ErrMetaNotFound{}
+			return ErrMetaNotFound{Resource: path}
 		}
 		meta, err := data.NewFileMeta(bytes.NewReader(dat), "sha256")
 		if err != nil {


### PR DESCRIPTION
Improve the error message for `ErrMetaNotFound` by always specifying the missing resource in the error message string.  This is the first part of https://github.com/docker/docker/issues/15463 (the other errors are from the docker repo)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>