### PR TITLE
use canonical json for all marshalling of TUF data

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -242,6 +242,11 @@
 			"Rev": "089c7181b8c728499929ff09b62d3fdd8df8adff"
 		},
 		{
+			"ImportPath": "github.com/stretchr/testify/require",
+			"Comment": "v1.0-17-g089c718",
+			"Rev": "089c7181b8c728499929ff09b62d3fdd8df8adff"
+		},
+		{
 			"ImportPath": "golang.org/x/crypto/bcrypt",
 			"Rev": "bfc286917c5fcb7420d7e3092b50bbfd31b38a98"
 		},

--- a/Godeps/_workspace/src/github.com/stretchr/testify/require/doc.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,77 @@
+// Alternative testing tools which stop test execution if test failed.
+//
+// Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//    import (
+//      "testing"
+//      "github.com/stretchr/testify/require"
+//    )
+//
+//    func TestSomething(t *testing.T) {
+//
+//      var a string = "Hello"
+//      var b string = "Hello"
+//
+//      require.Equal(t, a, b, "The two words should be the same.")
+//
+//    }
+//
+// Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+//
+// Here is an overview of the assert functions:
+//
+//    require.Equal(t, expected, actual [, message [, format-args])
+//
+//    require.NotEqual(t, notExpected, actual [, message [, format-args]])
+//
+//    require.True(t, actualBool [, message [, format-args]])
+//
+//    require.False(t, actualBool [, message [, format-args]])
+//
+//    require.Nil(t, actualObject [, message [, format-args]])
+//
+//    require.NotNil(t, actualObject [, message [, format-args]])
+//
+//    require.Empty(t, actualObject [, message [, format-args]])
+//
+//    require.NotEmpty(t, actualObject [, message [, format-args]])
+//
+//    require.Error(t, errorObject [, message [, format-args]])
+//
+//    require.NoError(t, errorObject [, message [, format-args]])
+//
+//    require.EqualError(t, theError, errString [, message [, format-args]])
+//
+//    require.Implements(t, (*MyInterface)(nil), new(MyObject) [,message [, format-args]])
+//
+//    require.IsType(t, expectedObject, actualObject [, message [, format-args]])
+//
+//    require.Contains(t, string, substring [, message [, format-args]])
+//
+//    require.NotContains(t, string, substring [, message [, format-args]])
+//
+//    require.Panics(t, func(){
+//
+//	    // call code that should panic
+//
+//    } [, message [, format-args]])
+//
+//    require.NotPanics(t, func(){
+//
+//	    // call code that should not panic
+//
+//    } [, message [, format-args]])
+//
+//    require.WithinDuration(t, timeA, timeB, deltaTime, [, message [, format-args]])
+//
+//    require.InDelta(t, numA, numB, delta, [, message [, format-args]])
+//
+//    require.InEpsilon(t, numA, numB, epsilon, [, message [, format-args]])
+package require

--- a/Godeps/_workspace/src/github.com/stretchr/testify/require/forward_requirements.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,211 @@
+package require
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Assertions struct {
+	t TestingT
+}
+
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//    require.Equal(123, 123, "123 and 123 should be equal")
+func (a *Assertions) Equal(expected, actual interface{}, msgAndArgs ...interface{}) {
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactly asserts that two objects are equal is value and type.
+//
+//    require.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
+func (a *Assertions) Exactly(expected, actual interface{}, msgAndArgs ...interface{}) {
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    require.NotNil(err, "err should be something")
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    require.Nil(err, "err should be nothing")
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or a
+// slice with len == 0.
+//
+// require.Empty(obj)
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Empty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or a
+// slice with len == 0.
+//
+// if require.NotEmpty(obj) {
+//   require.Equal("two", obj[1])
+// }
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    require.Len(mySlice, 3, "The size of slice is not 3")
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// True asserts that the specified value is true.
+//
+//    require.True(myBool, "myBool should be true")
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	True(a.t, value, msgAndArgs...)
+}
+
+// False asserts that the specified value is true.
+//
+//    require.False(myBool, "myBool should be false")
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	False(a.t, value, msgAndArgs...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    require.NotEqual(obj1, obj2, "two objects shouldn't be equal")
+func (a *Assertions) NotEqual(expected, actual interface{}, msgAndArgs ...interface{}) {
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// Contains asserts that the specified string contains the specified substring.
+//
+//    require.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
+func (a *Assertions) Contains(s, contains interface{}, msgAndArgs ...interface{}) {
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContains asserts that the specified string does NOT contain the specified substring.
+//
+//    require.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
+func (a *Assertions) NotContains(s, contains interface{}, msgAndArgs ...interface{}) {
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// Uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   require.Panics(func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   require.NotPanics(func(){
+//     RemainCalm()
+//   }, "Calling RemainCalm() should NOT panic")
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   require.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
+func (a *Assertions) WithinDuration(expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 require.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+func (a *Assertions) InDelta(expected, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if require.NoError(err) {
+//	   require.Equal(actualObj, expectedObj)
+//   }
+func (a *Assertions) NoError(theError error, msgAndArgs ...interface{}) {
+	NoError(a.t, theError, msgAndArgs...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if require.Error(err, "An error was expected") {
+//	   require.Equal(err, expectedError)
+//   }
+func (a *Assertions) Error(theError error, msgAndArgs ...interface{}) {
+	Error(a.t, theError, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   if require.Error(err, "An error was expected") {
+//	   require.Equal(err, expectedError)
+//   }
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  require.Regexp(t, "start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  require.NotRegexp(t, "^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}

--- a/Godeps/_workspace/src/github.com/stretchr/testify/require/forward_requirements_test.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/require/forward_requirements_test.go
@@ -1,0 +1,260 @@
+package require
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestImplementsWrapper(t *testing.T) {
+	require := New(t)
+
+	require.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestIsTypeWrapper(t *testing.T) {
+	require := New(t)
+	require.IsType(new(AssertionTesterConformingObject), new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.IsType(new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEqualWrapper(t *testing.T) {
+	require := New(t)
+	require.Equal(1, 1)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Equal(1, 2)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotEqualWrapper(t *testing.T) {
+	require := New(t)
+	require.NotEqual(1, 2)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotEqual(2, 2)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestExactlyWrapper(t *testing.T) {
+	require := New(t)
+
+	a := float32(1)
+	b := float32(1)
+	c := float64(1)
+
+	require.Exactly(a, b)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Exactly(a, c)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotNilWrapper(t *testing.T) {
+	require := New(t)
+	require.NotNil(t, new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotNil(nil)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNilWrapper(t *testing.T) {
+	require := New(t)
+	require.Nil(nil)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Nil(new(AssertionTesterConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestTrueWrapper(t *testing.T) {
+	require := New(t)
+	require.True(true)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.True(false)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestFalseWrapper(t *testing.T) {
+	require := New(t)
+	require.False(false)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.False(true)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestContainsWrapper(t *testing.T) {
+	require := New(t)
+	require.Contains("Hello World", "Hello")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Contains("Hello World", "Salut")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotContainsWrapper(t *testing.T) {
+	require := New(t)
+	require.NotContains("Hello World", "Hello!")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotContains("Hello World", "Hello")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestPanicsWrapper(t *testing.T) {
+	require := New(t)
+	require.Panics(func() {
+		panic("Panic!")
+	})
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Panics(func() {})
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotPanicsWrapper(t *testing.T) {
+	require := New(t)
+	require.NotPanics(func() {})
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotPanics(func() {
+		panic("Panic!")
+	})
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNoErrorWrapper(t *testing.T) {
+	require := New(t)
+	require.NoError(nil)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NoError(errors.New("some error"))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestErrorWrapper(t *testing.T) {
+	require := New(t)
+	require.Error(errors.New("some error"))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Error(nil)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEqualErrorWrapper(t *testing.T) {
+	require := New(t)
+	require.EqualError(errors.New("some error"), "some error")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.EqualError(errors.New("some error"), "Not some error")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEmptyWrapper(t *testing.T) {
+	require := New(t)
+	require.Empty("")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Empty("x")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotEmptyWrapper(t *testing.T) {
+	require := New(t)
+	require.NotEmpty("x")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotEmpty("")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestWithinDurationWrapper(t *testing.T) {
+	require := New(t)
+	a := time.Now()
+	b := a.Add(10 * time.Second)
+
+	require.WithinDuration(a, b, 15*time.Second)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.WithinDuration(a, b, 5*time.Second)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestInDeltaWrapper(t *testing.T) {
+	require := New(t)
+	require.InDelta(1.001, 1, 0.01)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.InDelta(1, 2, 0.5)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}

--- a/Godeps/_workspace/src/github.com/stretchr/testify/require/requirements.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,271 @@
+package require
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+// Fail reports a failure through
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	assert.Fail(t, failureMessage, msgAndArgs...)
+	t.FailNow()
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    require.Implements(t, (*MyInterface)(nil), new(MyObject), "MyObject")
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// IsType asserts that the specified objects are of the same type.
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.IsType(t, expectedType, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Equal asserts that two objects are equal.
+//
+//    require.Equal(t, 123, 123, "123 and 123 should be equal")
+func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Equal(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualValues asserts that two objects are equal or convertable to each other.
+//
+//    require.EqualValues(t, uint32(123), int32(123), "123 and 123 should be equal")
+func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Exactly asserts that two objects are equal is value and type.
+//
+//    require.Exactly(t, int32(123), int64(123), "123 and 123 should NOT be equal")
+func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    require.NotNil(t, err, "err should be something")
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotNil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    require.Nil(t, err, "err should be nothing")
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Nil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+// require.Empty(t, obj)
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Empty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+// require.NotEmpty(t, obj)
+// require.Equal(t, "one", obj[0])
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEmpty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    require.Len(t, mySlice, 3, "The size of slice is not 3")
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if !assert.Len(t, object, length, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// True asserts that the specified value is true.
+//
+//    require.True(t, myBool, "myBool should be true")
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.True(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// False asserts that the specified value is true.
+//
+//    require.False(t, myBool, "myBool should be false")
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.False(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    require.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
+func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Contains asserts that the specified string contains the specified substring.
+//
+//    require.Contains(t, "Hello World", "World", "But 'Hello World' does contain 'World'")
+func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.Contains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotContains asserts that the specified string does NOT contain the specified substring.
+//
+//    require.NotContains(t, "Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
+func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotContains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if !assert.Condition(t, comp, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   require.Panics(t, func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.Panics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   require.NotPanics(t, func(){
+//     RemainCalm()
+//   }, "Calling RemainCalm() should NOT panic")
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.NotPanics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
+func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//   require.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  require.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.Regexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  require.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+/*
+	Errors
+*/
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   require.NoError(t, err)
+//   require.Equal(t, actualObj, expectedObj)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.NoError(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   require.Error(t, err, "An error was expected")
+//   require.Equal(t, err, expectedError)
+//   }
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.Error(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   require.Error(t, err, "An error was expected")
+//   require.Equal(t, err, expectedError)
+//   }
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
+		t.FailNow()
+	}
+}

--- a/Godeps/_workspace/src/github.com/stretchr/testify/require/requirements_test.go
+++ b/Godeps/_workspace/src/github.com/stretchr/testify/require/requirements_test.go
@@ -1,0 +1,266 @@
+package require
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// AssertionTesterInterface defines an interface to be used for testing assertion methods
+type AssertionTesterInterface interface {
+	TestMethod()
+}
+
+// AssertionTesterConformingObject is an object that conforms to the AssertionTesterInterface interface
+type AssertionTesterConformingObject struct {
+}
+
+func (a *AssertionTesterConformingObject) TestMethod() {
+}
+
+// AssertionTesterNonConformingObject is an object that does not conform to the AssertionTesterInterface interface
+type AssertionTesterNonConformingObject struct {
+}
+
+type MockT struct {
+	Failed bool
+}
+
+func (t *MockT) FailNow() {
+	t.Failed = true
+}
+
+func (t *MockT) Errorf(format string, args ...interface{}) {
+	_, _ = format, args
+}
+
+func TestImplements(t *testing.T) {
+
+	Implements(t, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestIsType(t *testing.T) {
+
+	IsType(t, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEqual(t *testing.T) {
+
+	Equal(t, 1, 1)
+
+	mockT := new(MockT)
+	Equal(mockT, 1, 2)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+
+}
+
+func TestNotEqual(t *testing.T) {
+
+	NotEqual(t, 1, 2)
+	mockT := new(MockT)
+	NotEqual(mockT, 2, 2)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestExactly(t *testing.T) {
+
+	a := float32(1)
+	b := float32(1)
+	c := float64(1)
+
+	Exactly(t, a, b)
+
+	mockT := new(MockT)
+	Exactly(mockT, a, c)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotNil(t *testing.T) {
+
+	NotNil(t, new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	NotNil(mockT, nil)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNil(t *testing.T) {
+
+	Nil(t, nil)
+
+	mockT := new(MockT)
+	Nil(mockT, new(AssertionTesterConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestTrue(t *testing.T) {
+
+	True(t, true)
+
+	mockT := new(MockT)
+	True(mockT, false)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestFalse(t *testing.T) {
+
+	False(t, false)
+
+	mockT := new(MockT)
+	False(mockT, true)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestContains(t *testing.T) {
+
+	Contains(t, "Hello World", "Hello")
+
+	mockT := new(MockT)
+	Contains(mockT, "Hello World", "Salut")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotContains(t *testing.T) {
+
+	NotContains(t, "Hello World", "Hello!")
+
+	mockT := new(MockT)
+	NotContains(mockT, "Hello World", "Hello")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestPanics(t *testing.T) {
+
+	Panics(t, func() {
+		panic("Panic!")
+	})
+
+	mockT := new(MockT)
+	Panics(mockT, func() {})
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotPanics(t *testing.T) {
+
+	NotPanics(t, func() {})
+
+	mockT := new(MockT)
+	NotPanics(mockT, func() {
+		panic("Panic!")
+	})
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNoError(t *testing.T) {
+
+	NoError(t, nil)
+
+	mockT := new(MockT)
+	NoError(mockT, errors.New("some error"))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestError(t *testing.T) {
+
+	Error(t, errors.New("some error"))
+
+	mockT := new(MockT)
+	Error(mockT, nil)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEqualError(t *testing.T) {
+
+	EqualError(t, errors.New("some error"), "some error")
+
+	mockT := new(MockT)
+	EqualError(mockT, errors.New("some error"), "Not some error")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEmpty(t *testing.T) {
+
+	Empty(t, "")
+
+	mockT := new(MockT)
+	Empty(mockT, "x")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotEmpty(t *testing.T) {
+
+	NotEmpty(t, "x")
+
+	mockT := new(MockT)
+	NotEmpty(mockT, "")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestWithinDuration(t *testing.T) {
+
+	a := time.Now()
+	b := a.Add(10 * time.Second)
+
+	WithinDuration(t, a, b, 15*time.Second)
+
+	mockT := new(MockT)
+	WithinDuration(mockT, a, b, 5*time.Second)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestInDelta(t *testing.T) {
+
+	InDelta(t, 1.001, 1, 0.01)
+
+	mockT := new(MockT)
+	InDelta(mockT, 1, 2, 0.5)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}

--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // recursively copies the contents of one directory into another - ignores
@@ -63,8 +63,8 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	// and publishing will modify the files
 	tmpDir, err := ioutil.TempDir("", "notary-backwards-compat-test")
 	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
-	assert.NoError(t, recursiveCopy("../fixtures/compatibility/notary0.1", tmpDir))
+	require.NoError(t, err)
+	require.NoError(t, recursiveCopy("../fixtures/compatibility/notary0.1", tmpDir))
 
 	gun := "docker.io/notary0.1/samplerepo"
 	passwd := "randompass"
@@ -74,28 +74,28 @@ func Test0Dot1RepoFormat(t *testing.T) {
 
 	repo, err := NewNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd))
-	assert.NoError(t, err, "error creating repo: %s", err)
+	require.NoError(t, err, "error creating repo: %s", err)
 
 	// rotate the timestamp key, since the server doesn't have that one
 	timestampPubKey, err := getRemoteKey(ts.URL, gun, data.CanonicalTimestampRole, http.DefaultTransport)
-	assert.NoError(t, err)
-	assert.NoError(
+	require.NoError(t, err)
+	require.NoError(
 		t, repo.rootFileKeyChange(data.CanonicalTimestampRole, changelist.ActionCreate, timestampPubKey))
 
-	assert.NoError(t, repo.Publish())
+	require.NoError(t, repo.Publish())
 
 	targets, err := repo.ListTargets()
-	assert.NoError(t, err)
-	assert.Len(t, targets, 1)
-	assert.Equal(t, "v1", targets[0].Name)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, "v1", targets[0].Name)
 
 	// Also check that we can add/remove keys by rotating keys
 	oldTargetsKeys := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
-	assert.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false))
-	assert.NoError(t, repo.Publish())
+	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false))
+	require.NoError(t, repo.Publish())
 	newTargetsKeys := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
 
-	assert.Len(t, oldTargetsKeys, 1)
-	assert.Len(t, newTargetsKeys, 1)
-	assert.NotEqual(t, oldTargetsKeys[0], newTargetsKeys[0])
+	require.Len(t, oldTargetsKeys, 1)
+	require.Len(t, newTargetsKeys, 1)
+	require.NotEqual(t, oldTargetsKeys[0], newTargetsKeys[0])
 }

--- a/client/client.go
+++ b/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -13,6 +12,8 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/jfrazelle/go/canonical/json"
+
 	"github.com/docker/notary/certs"
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/cryptoservice"
@@ -323,7 +324,7 @@ func (r *NotaryRepository) AddDelegation(name string, threshold int,
 	logrus.Debugf(`Adding delegation "%s" with threshold %d, and %d keys\n`,
 		name, threshold, len(delegationKeys))
 
-	tdJSON, err := json.Marshal(&changelist.TufDelegation{
+	tdJSON, err := json.MarshalCanonical(&changelist.TufDelegation{
 		NewThreshold: threshold,
 		AddKeys:      data.KeyList(delegationKeys),
 		AddPaths:     paths,
@@ -385,7 +386,7 @@ func (r *NotaryRepository) AddTarget(target *Target, roles ...string) error {
 	logrus.Debugf("Adding target \"%s\" with sha256 \"%x\" and size %d bytes.\n", target.Name, target.Hashes["sha256"], target.Length)
 
 	meta := data.FileMeta{Length: target.Length, Hashes: target.Hashes}
-	metaJSON, err := json.Marshal(meta)
+	metaJSON, err := json.MarshalCanonical(meta)
 	if err != nil {
 		return err
 	}
@@ -719,7 +720,7 @@ func (r *NotaryRepository) saveMetadata(ignoreSnapshot bool) error {
 		if err != nil {
 			return err
 		}
-		targetsJSON, err := json.Marshal(signedTargets)
+		targetsJSON, err := json.MarshalCanonical(signedTargets)
 		if err != nil {
 			return err
 		}
@@ -845,7 +846,7 @@ func (r *NotaryRepository) rootFileKeyChange(role, action string, key data.Publi
 		RoleName: role,
 		Keys:     kl,
 	}
-	metaJSON, err := json.Marshal(meta)
+	metaJSON, err := json.MarshalCanonical(meta)
 	if err != nil {
 		return err
 	}

--- a/client/client_root_validation_test.go
+++ b/client/client_root_validation_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary/certs"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var passphraseRetriever = func(string, string, bool, int) (string, bool, error) { return "passphrase", false, nil }
@@ -34,12 +34,12 @@ func validateRootSuccessfully(t *testing.T, rootType string) {
 
 	// tests need to manually boostrap timestamp as client doesn't generate it
 	err := repo.tufRepo.InitTimestamp()
-	assert.NoError(t, err, "error creating repository: %s", err)
+	require.NoError(t, err, "error creating repository: %s", err)
 
 	// Initialize is supposed to have created new certificate for this repository
 	// Lets check for it and store it for later use
 	allCerts := repo.CertManager.TrustedCertificateStore().GetCertificates()
-	assert.Len(t, allCerts, 1)
+	require.Len(t, allCerts, 1)
 
 	fakeServerData(t, repo, mux, keys)
 
@@ -47,13 +47,13 @@ func validateRootSuccessfully(t *testing.T, rootType string) {
 	// Test TOFUS logic. We remove all certs and expect a new one to be added after ListTargets
 	//
 	err = repo.CertManager.TrustedCertificateStore().RemoveAll()
-	assert.NoError(t, err)
-	assert.Len(t, repo.CertManager.TrustedCertificateStore().GetCertificates(), 0)
+	require.NoError(t, err)
+	require.Len(t, repo.CertManager.TrustedCertificateStore().GetCertificates(), 0)
 
 	// This list targets is expected to succeed and the certificate store to have the new certificate
 	_, err = repo.ListTargets(data.CanonicalTargetsRole)
-	assert.NoError(t, err)
-	assert.Len(t, repo.CertManager.TrustedCertificateStore().GetCertificates(), 1)
+	require.NoError(t, err)
+	require.Len(t, repo.CertManager.TrustedCertificateStore().GetCertificates(), 1)
 
 	//
 	// Test certificate mismatch logic. We remove all certs, add a different cert to the
@@ -62,20 +62,19 @@ func validateRootSuccessfully(t *testing.T, rootType string) {
 
 	// First, remove all certs
 	err = repo.CertManager.TrustedCertificateStore().RemoveAll()
-	assert.NoError(t, err)
-	assert.Len(t, repo.CertManager.TrustedCertificateStore().GetCertificates(), 0)
+	require.NoError(t, err)
+	require.Len(t, repo.CertManager.TrustedCertificateStore().GetCertificates(), 0)
 
 	// Add a previously generated certificate with CN=docker.com/notary
 	err = repo.CertManager.TrustedCertificateStore().AddCertFromFile(
 		"../fixtures/self-signed_docker.com-notary.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// This list targets is expected to fail, since there already exists a certificate
 	// in the store for the dnsName docker.com/notary, so TOFUS doesn't apply
 	_, err = repo.ListTargets(data.CanonicalTargetsRole)
-	if assert.Error(t, err, "An error was expected") {
-		assert.Equal(t, err, &certs.ErrValidationFail{
-			Reason: "failed to validate data with current trusted certificates",
-		})
-	}
+	require.Error(t, err, "An error was expected")
+	require.Equal(t, err, &certs.ErrValidationFail{
+		Reason: "failed to validate data with current trusted certificates",
+	})
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -1,13 +1,14 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/jfrazelle/go/canonical/json"
+
 	"github.com/docker/notary/client/changelist"
 	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
@@ -261,5 +262,5 @@ func serializeCanonicalRole(tufRepo *tuf.Repo, role string) (out []byte, err err
 		return
 	}
 
-	return json.Marshal(s)
+	return json.MarshalCanonical(s)
 }

--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -2,27 +2,26 @@ package handlers
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"golang.org/x/net/context"
-
 	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/jfrazelle/go/canonical/json"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
 	"github.com/docker/notary/server/errors"
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
-	"github.com/docker/notary/tuf/validation"
-
 	"github.com/docker/notary/tuf/testutils"
+	"github.com/docker/notary/tuf/validation"
 	"github.com/docker/notary/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 type handlerState struct {
@@ -179,7 +178,7 @@ func TestGetHandlerRoot(t *testing.T) {
 	ctx = context.WithValue(ctx, "metaStore", metaStore)
 
 	root, err := repo.SignRoot(data.DefaultExpires("root"))
-	rootJSON, err := json.Marshal(root)
+	rootJSON, err := json.MarshalCanonical(root)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 1, Data: rootJSON})
 
@@ -205,13 +204,13 @@ func TestGetHandlerTimestamp(t *testing.T) {
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
 
 	sn, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
-	snJSON, err := json.Marshal(sn)
+	snJSON, err := json.MarshalCanonical(sn)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent(
 		"gun", storage.MetaUpdate{Role: "snapshot", Version: 1, Data: snJSON})
 
 	ts, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
-	tsJSON, err := json.Marshal(ts)
+	tsJSON, err := json.MarshalCanonical(ts)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent(
 		"gun", storage.MetaUpdate{Role: "timestamp", Version: 1, Data: tsJSON})
@@ -238,7 +237,7 @@ func TestGetHandlerSnapshot(t *testing.T) {
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
 
 	sn, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
-	snJSON, err := json.Marshal(sn)
+	snJSON, err := json.MarshalCanonical(sn)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent(
 		"gun", storage.MetaUpdate{Role: "snapshot", Version: 1, Data: snJSON})

--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	cjson "github.com/jfrazelle/go/canonical/json"
 
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf"
@@ -246,7 +247,7 @@ func generateSnapshot(gun string, kdb *keys.KeyDB, repo *tuf.Repo, store storage
 	if err != nil {
 		return nil, validation.ErrBadSnapshot{Msg: err.Error()}
 	}
-	sgndJSON, err := json.Marshal(sgnd)
+	sgndJSON, err := cjson.MarshalCanonical(sgnd)
 	if err != nil {
 		return nil, validation.ErrBadSnapshot{Msg: err.Error()}
 	}

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -2,11 +2,14 @@ package handlers
 
 import (
 	"crypto/rand"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/jfrazelle/go/canonical/json"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
@@ -14,9 +17,6 @@ import (
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/testutils"
 	"github.com/docker/notary/tuf/validation"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/docker/notary/server/storage"
 )
 
 func copyTimestampKey(t *testing.T, fromKeyDB *keys.KeyDB,
@@ -797,7 +797,7 @@ func TestLoadTargetsFromStore(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	tgs, err := json.Marshal(st)
+	tgs, err := json.MarshalCanonical(st)
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -844,7 +844,7 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 
 	// we're not going to validate things loaded from storage, so no need
 	// to sign the base targets, just Marshal it and set it into storage
-	tgtsJSON, err := json.Marshal(baseRepo.Targets["targets"])
+	tgtsJSON, err := json.MarshalCanonical(baseRepo.Targets["targets"])
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -856,7 +856,7 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 	// generate the update object we're doing to use to call loadAndValidateTargets
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.Marshal(del)
+	delJSON, err := json.MarshalCanonical(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{
@@ -894,7 +894,7 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 
 	targets, err := baseRepo.SignTargets("targets", data.DefaultExpires(data.CanonicalTargetsRole))
 
-	tgtsJSON, err := json.Marshal(targets)
+	tgtsJSON, err := json.MarshalCanonical(targets)
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -905,7 +905,7 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.Marshal(del)
+	delJSON, err := json.MarshalCanonical(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{
@@ -952,7 +952,7 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 	// generate the update object we're doing to use to call loadAndValidateTargets
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.Marshal(del)
+	delJSON, err := json.MarshalCanonical(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{
@@ -989,7 +989,7 @@ func TestValidateTargetsRoleNotInParent(t *testing.T) {
 
 	targets, err := baseRepo.SignTargets("targets", data.DefaultExpires(data.CanonicalTargetsRole))
 
-	tgtsJSON, err := json.Marshal(targets)
+	tgtsJSON, err := json.MarshalCanonical(targets)
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -1000,7 +1000,7 @@ func TestValidateTargetsRoleNotInParent(t *testing.T) {
 
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.Marshal(del)
+	delJSON, err := json.MarshalCanonical(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -1,9 +1,8 @@
 package snapshot
 
 import (
-	"encoding/json"
-
 	"github.com/Sirupsen/logrus"
+	"github.com/jfrazelle/go/canonical/json"
 
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf/data"
@@ -70,7 +69,7 @@ func GetOrCreateSnapshot(gun string, store storage.MetaStore, cryptoService sign
 		logrus.Error("Failed to create a new snapshot")
 		return nil, err
 	}
-	out, err := json.Marshal(sgnd)
+	out, err := json.MarshalCanonical(sgnd)
 	if err != nil {
 		logrus.Error("Failed to marshal new snapshot")
 		return nil, err

--- a/server/snapshot/snapshot_test.go
+++ b/server/snapshot/snapshot_test.go
@@ -2,10 +2,10 @@ package snapshot
 
 import (
 	"bytes"
-	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/jfrazelle/go/canonical/json"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/notary/server/storage"
@@ -140,7 +140,7 @@ func TestGetSnapshotCurrValid(t *testing.T) {
 			},
 		},
 	}
-	snapJSON, _ := json.Marshal(snapshot)
+	snapJSON, _ := json.MarshalCanonical(snapshot)
 
 	// test when db is missing the role data
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
@@ -165,7 +165,7 @@ func TestGetSnapshotCurrExpired(t *testing.T) {
 	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
 
 	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.Marshal(snapshot)
+	snapJSON, _ := json.MarshalCanonical(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	_, err = GetOrCreateSnapshot("gun", store, crypto)
@@ -179,7 +179,7 @@ func TestGetSnapshotCurrCorrupt(t *testing.T) {
 	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
 
 	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.Marshal(snapshot)
+	snapJSON, _ := json.MarshalCanonical(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON[1:]})
 	_, err = GetOrCreateSnapshot("gun", store, crypto)

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -77,7 +77,7 @@ func GetOrCreateTimestamp(gun string, store storage.MetaStore, cryptoService sig
 		logrus.Error("Failed to create a new timestamp")
 		return nil, err
 	}
-	out, err := json.Marshal(sgnd)
+	out, err := json.MarshalCanonical(sgnd)
 	if err != nil {
 		logrus.Error("Failed to marshal new timestamp")
 		return nil, err

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -1,15 +1,15 @@
 package timestamp
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/docker/notary/tuf/data"
-	"github.com/docker/notary/tuf/signed"
+	"github.com/jfrazelle/go/canonical/json"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/notary/server/storage"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
 )
 
 func TestTimestampExpired(t *testing.T) {
@@ -53,7 +53,7 @@ func TestGetTimestamp(t *testing.T) {
 	crypto := signed.NewEd25519()
 
 	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.Marshal(snapshot)
+	snapJSON, _ := json.MarshalCanonical(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
@@ -70,7 +70,7 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 
 	snapshot := data.SignedSnapshot{}
 	snapshot.Signed.Version = 0
-	snapJSON, _ := json.Marshal(snapshot)
+	snapJSON, _ := json.MarshalCanonical(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
@@ -82,7 +82,7 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 
 	snapshot = data.SignedSnapshot{}
 	snapshot.Signed.Version = 1
-	snapJSON, _ = json.Marshal(snapshot)
+	snapJSON, _ = json.MarshalCanonical(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 1, Data: snapJSON})
 

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -2,20 +2,20 @@ package client
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	tuf "github.com/docker/notary/tuf"
-	"github.com/docker/notary/tuf/testutils"
+	"github.com/jfrazelle/go/canonical/json"
 	"github.com/stretchr/testify/assert"
 
+	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
+	"github.com/docker/notary/tuf/testutils"
 )
 
 func TestRotation(t *testing.T) {
@@ -204,7 +204,7 @@ func TestCheckRootExpired(t *testing.T) {
 
 	signedRoot, err := root.ToSigned()
 	assert.NoError(t, err)
-	rootJSON, err := json.Marshal(signedRoot)
+	rootJSON, err := json.MarshalCanonical(signedRoot)
 	assert.NoError(t, err)
 
 	rootHash := sha256.Sum256(rootJSON)
@@ -238,7 +238,7 @@ func TestChecksumMismatch(t *testing.T) {
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
-	orig, err := json.Marshal(sampleTargets)
+	orig, err := json.MarshalCanonical(sampleTargets)
 	origSha256 := sha256.Sum256(orig)
 	orig[0] = '}' // corrupt data, should be a {
 	assert.NoError(t, err)
@@ -256,7 +256,7 @@ func TestChecksumMatch(t *testing.T) {
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
-	orig, err := json.Marshal(sampleTargets)
+	orig, err := json.MarshalCanonical(sampleTargets)
 	origSha256 := sha256.Sum256(orig)
 	assert.NoError(t, err)
 
@@ -273,7 +273,7 @@ func TestSizeMismatchLong(t *testing.T) {
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
-	orig, err := json.Marshal(sampleTargets)
+	orig, err := json.MarshalCanonical(sampleTargets)
 	origSha256 := sha256.Sum256(orig)
 	assert.NoError(t, err)
 	l := int64(len(orig))
@@ -296,7 +296,7 @@ func TestSizeMismatchShort(t *testing.T) {
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
-	orig, err := json.Marshal(sampleTargets)
+	orig, err := json.MarshalCanonical(sampleTargets)
 	origSha256 := sha256.Sum256(orig)
 	assert.NoError(t, err)
 	l := int64(len(orig))
@@ -319,7 +319,7 @@ func TestDownloadTargetsHappy(t *testing.T) {
 
 	signedOrig, err := repo.SignTargets("targets", data.DefaultExpires("targets"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("targets", orig)
 	assert.NoError(t, err)
@@ -369,7 +369,7 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 		// serialize and store role
 		signedOrig, err := repo.SignTargets(r, data.DefaultExpires("targets"))
 		assert.NoError(t, err)
-		orig, err := json.Marshal(signedOrig)
+		orig, err := json.MarshalCanonical(signedOrig)
 		assert.NoError(t, err)
 		err = remoteStorage.SetMeta(r, orig)
 		assert.NoError(t, err)
@@ -378,7 +378,7 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 	// serialize and store targets after adding all delegations
 	signedOrig, err := repo.SignTargets("targets", data.DefaultExpires("targets"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("targets", orig)
 	assert.NoError(t, err)
@@ -414,7 +414,7 @@ func TestDownloadTargetChecksumMismatch(t *testing.T) {
 	// create and "upload" sample targets
 	signedOrig, err := repo.SignTargets("targets", data.DefaultExpires("targets"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	origSha256 := sha256.Sum256(orig)
 	orig[0] = '}' // corrupt data, should be a {
@@ -454,7 +454,7 @@ func TestDownloadTargetsNoChecksum(t *testing.T) {
 	// create and "upload" sample targets
 	signedOrig, err := repo.SignTargets("targets", data.DefaultExpires("targets"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("targets", orig)
 	assert.NoError(t, err)
@@ -476,7 +476,7 @@ func TestDownloadTargetsNoSnapshot(t *testing.T) {
 	// create and "upload" sample targets
 	signedOrig, err := repo.SignTargets("targets", data.DefaultExpires("targets"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("targets", orig)
 	assert.NoError(t, err)
@@ -496,7 +496,7 @@ func TestBootstrapDownloadRootHappy(t *testing.T) {
 	// create and "upload" sample root
 	signedOrig, err := repo.SignRoot(data.DefaultExpires("root"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("root", orig)
 	assert.NoError(t, err)
@@ -517,7 +517,7 @@ func TestUpdateDownloadRootHappy(t *testing.T) {
 	// create and "upload" sample root, snapshot, and timestamp
 	signedOrig, err := repo.SignRoot(data.DefaultExpires("root"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("root", orig)
 	assert.NoError(t, err)
@@ -542,7 +542,7 @@ func TestUpdateDownloadRootBadChecksum(t *testing.T) {
 	// create and "upload" sample root, snapshot, and timestamp
 	signedOrig, err := repo.SignRoot(data.DefaultExpires("root"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("root", orig)
 	assert.NoError(t, err)
@@ -562,7 +562,7 @@ func TestDownloadTimestampHappy(t *testing.T) {
 	// create and "upload" sample timestamp
 	signedOrig, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("timestamp", orig)
 	assert.NoError(t, err)
@@ -580,14 +580,14 @@ func TestDownloadSnapshotHappy(t *testing.T) {
 	// create and "upload" sample snapshot and timestamp
 	signedOrig, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("snapshot", orig)
 	assert.NoError(t, err)
 
 	signedOrig, err = repo.SignTimestamp(data.DefaultExpires("timestamp"))
 	assert.NoError(t, err)
-	orig, err = json.Marshal(signedOrig)
+	orig, err = json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("timestamp", orig)
 	assert.NoError(t, err)
@@ -607,7 +607,7 @@ func TestDownloadSnapshotNoTimestamp(t *testing.T) {
 	// create and "upload" sample snapshot and timestamp
 	signedOrig, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("snapshot", orig)
 	assert.NoError(t, err)
@@ -627,7 +627,7 @@ func TestDownloadSnapshotNoChecksum(t *testing.T) {
 	// create and "upload" sample snapshot and timestamp
 	signedOrig, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("snapshot", orig)
 	assert.NoError(t, err)
@@ -651,7 +651,7 @@ func TestDownloadSnapshotBadChecksum(t *testing.T) {
 	// create and "upload" sample snapshot and timestamp
 	signedOrig, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
 	assert.NoError(t, err)
-	orig, err := json.Marshal(signedOrig)
+	orig, err := json.MarshalCanonical(signedOrig)
 	assert.NoError(t, err)
 	err = remoteStorage.SetMeta("snapshot", orig)
 	assert.NoError(t, err)

--- a/tuf/data/snapshot.go
+++ b/tuf/data/snapshot.go
@@ -27,12 +27,12 @@ type Snapshot struct {
 // and targets objects
 func NewSnapshot(root *Signed, targets *Signed) (*SignedSnapshot, error) {
 	logrus.Debug("generating new snapshot...")
-	targetsJSON, err := json.Marshal(targets)
+	targetsJSON, err := json.MarshalCanonical(targets)
 	if err != nil {
 		logrus.Debug("Error Marshalling Targets")
 		return nil, err
 	}
-	rootJSON, err := json.Marshal(root)
+	rootJSON, err := json.MarshalCanonical(root)
 	if err != nil {
 		logrus.Debug("Error Marshalling Root")
 		return nil, err

--- a/tuf/data/timestamp.go
+++ b/tuf/data/timestamp.go
@@ -24,7 +24,7 @@ type Timestamp struct {
 
 // NewTimestamp initializes a timestamp with an existing snapshot
 func NewTimestamp(snapshot *Signed) (*SignedTimestamp, error) {
-	snapshotJSON, err := json.Marshal(snapshot)
+	snapshotJSON, err := json.MarshalCanonical(snapshot)
 	if err != nil {
 		return nil, err
 	}

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -1,17 +1,17 @@
 package testutils
 
 import (
-	"encoding/json"
 	"math/rand"
 	"time"
 
-	"github.com/docker/notary/tuf/data"
-	"github.com/docker/notary/tuf/utils"
 	fuzz "github.com/google/gofuzz"
+	"github.com/jfrazelle/go/canonical/json"
 
 	tuf "github.com/docker/notary/tuf"
+	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/tuf/utils"
 )
 
 // EmptyRepo creates an in memory key database, crypto service
@@ -83,19 +83,19 @@ func Sign(repo *tuf.Repo) (root, targets, snapshot, timestamp *data.Signed, err 
 
 // Serialize takes the Signed objects for the 4 top level roles and serializes them all to JSON
 func Serialize(sRoot, sTargets, sSnapshot, sTimestamp *data.Signed) (root, targets, snapshot, timestamp []byte, err error) {
-	root, err = json.Marshal(sRoot)
+	root, err = json.MarshalCanonical(sRoot)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	targets, err = json.Marshal(sTargets)
+	targets, err = json.MarshalCanonical(sTargets)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	snapshot, err = json.Marshal(sSnapshot)
+	snapshot, err = json.MarshalCanonical(sSnapshot)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	timestamp, err = json.Marshal(sTimestamp)
+	timestamp, err = json.MarshalCanonical(sTimestamp)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -5,13 +5,14 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/jfrazelle/go/canonical/json"
+
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
@@ -606,7 +607,7 @@ func (tr *Repo) RemoveTargets(role string, targets ...string) error {
 
 // UpdateSnapshot updates the FileMeta for the given role based on the Signed object
 func (tr *Repo) UpdateSnapshot(role string, s *data.Signed) error {
-	jsonData, err := json.Marshal(s)
+	jsonData, err := json.MarshalCanonical(s)
 	if err != nil {
 		return err
 	}
@@ -621,7 +622,7 @@ func (tr *Repo) UpdateSnapshot(role string, s *data.Signed) error {
 
 // UpdateTimestamp updates the snapshot meta in the timestamp based on the Signed object
 func (tr *Repo) UpdateTimestamp(s *data.Signed) error {
-	jsonData, err := json.Marshal(s)
+	jsonData, err := json.MarshalCanonical(s)
 	if err != nil {
 		return err
 	}

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -2,17 +2,18 @@ package tuf
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 
+	"github.com/jfrazelle/go/canonical/json"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
-	"github.com/stretchr/testify/assert"
 )
 
 func initRepo(t *testing.T, cryptoService signed.CryptoService, keyDB *keys.KeyDB) *Repo {
@@ -112,13 +113,13 @@ func writeRepo(t *testing.T, dir string, repo *Repo) {
 	assert.NoError(t, err)
 	signedRoot, err := repo.SignRoot(data.DefaultExpires("root"))
 	assert.NoError(t, err)
-	rootJSON, _ := json.Marshal(signedRoot)
+	rootJSON, _ := json.MarshalCanonical(signedRoot)
 	ioutil.WriteFile(dir+"/root.json", rootJSON, 0755)
 
 	for r := range repo.Targets {
 		signedTargets, err := repo.SignTargets(r, data.DefaultExpires("targets"))
 		assert.NoError(t, err)
-		targetsJSON, _ := json.Marshal(signedTargets)
+		targetsJSON, _ := json.MarshalCanonical(signedTargets)
 		p := path.Join(dir, r+".json")
 		parentDir := filepath.Dir(p)
 		os.MkdirAll(parentDir, 0755)
@@ -127,12 +128,12 @@ func writeRepo(t *testing.T, dir string, repo *Repo) {
 
 	signedSnapshot, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
 	assert.NoError(t, err)
-	snapshotJSON, _ := json.Marshal(signedSnapshot)
+	snapshotJSON, _ := json.MarshalCanonical(signedSnapshot)
 	ioutil.WriteFile(dir+"/snapshot.json", snapshotJSON, 0755)
 
 	signedTimestamp, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
 	assert.NoError(t, err)
-	timestampJSON, _ := json.Marshal(signedTimestamp)
+	timestampJSON, _ := json.MarshalCanonical(signedTimestamp)
 	ioutil.WriteFile(dir+"/timestamp.json", timestampJSON, 0755)
 }
 


### PR DESCRIPTION
Related to #366.

It's safe to change serialization because all deserialization is done AFTER checking hashes and sizes.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)