### PR TITLE
Combine bootstrapClient and tuf/client's Client.Update into a single Update function 

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1516,7 +1516,7 @@ func TestNotInitializedOnPublish(t *testing.T) {
 
 	err = repo.Publish()
 	require.Error(t, err)
-	require.IsType(t, &ErrRepoNotInitialized{}, err)
+	require.IsType(t, ErrRepoNotInitialized{}, err)
 }
 
 type cannotCreateKeys struct {


### PR DESCRIPTION
- it is easier to understand what's going on in the online functions of NotaryRepository
- we can test NotaryRepository.Update independently (although it'd be nice to have some way
  of ensuring that the actual public functions of NotaryRepository like ListTargets,
  GetTargetByName, and Publish actually calls Update.
- distinct error if the remote repo doesn't exist.

This also stops wrapping signed.ErrExpired in client.ErrExpired, and just passes
signed.ErrExpired on directly.

Signed-off-by: Ying Li <ying.li@docker.com>

This is one step towards #345.