### PR TITLE
using JSON logging format

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -28,10 +28,14 @@ import (
 )
 
 // DebugAddress is the debug server address to listen on
-const DebugAddress = "localhost:8080"
+const (
+	jsonLogFormat = "json"
+	DebugAddress  = "localhost:8080"
+)
 
 var (
 	debug      bool
+	logFormat  string
 	configFile string
 	envPrefix  = "NOTARY_SERVER"
 	mainViper  = viper.New()
@@ -42,6 +46,12 @@ func init() {
 	// Setup flags
 	flag.StringVar(&configFile, "config", "", "Path to configuration file")
 	flag.BoolVar(&debug, "debug", false, "Enable the debugging server on localhost:8080")
+	flag.StringVar(&logFormat, "logf", "json", "Set the format of the logs. Only 'json' and 'logfmt' are supported at the moment.")
+
+	// this needs to be in init so that _ALL_ logs are in the correct format
+	if logFormat == jsonLogFormat {
+		logrus.SetFormatter(new(logrus.JSONFormatter))
+	}
 }
 
 // get the address for the HTTP server, and parses the optional TLS

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -37,6 +37,7 @@ import (
 )
 
 const (
+	jsonLogFormat   = "json"
 	debugAddr       = "localhost:8080"
 	envPrefix       = "NOTARY_SIGNER"
 	defaultAliasEnv = "DEFAULT_ALIAS"
@@ -44,6 +45,7 @@ const (
 
 var (
 	debug      bool
+	logFormat  string
 	configFile string
 	mainViper  = viper.New()
 )
@@ -53,6 +55,12 @@ func init() {
 	// Setup flags
 	flag.StringVar(&configFile, "config", "", "Path to configuration file")
 	flag.BoolVar(&debug, "debug", false, "show the version and exit")
+	flag.StringVar(&logFormat, "logf", "json", "Set the format of the logs. Only 'json' and 'logfmt' are supported at the moment.")
+
+	// this needs to be in init so that _ALL_ logs are in the correct format
+	if logFormat == jsonLogFormat {
+		logrus.SetFormatter(new(logrus.JSONFormatter))
+	}
 }
 
 func passphraseRetriever(keyName, alias string, createNew bool, attempts int) (passphrase string, giveup bool, err error) {


### PR DESCRIPTION
This defaults notary server and signer to use JSON as its output format for logging so that we can integrate it with Heka/Kibana.

It's possible to revert to the logfmt output by passing the CLI flag `-logf=logfmt` (default is `-logf=json`)

cc @diogomonica 

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)