### PR TITLE
Fix the exposed port in Dockerfile

### DIFF
--- a/Dockerfile.signer
+++ b/Dockerfile.signer
@@ -23,7 +23,7 @@ RUN softhsm2-util --init-token --slot 0 --label "test_token" --pin $NOTARY_SIGNE
 ENV NOTARYPKG github.com/docker/notary
 ENV GOPATH /go/src/${NOTARYPKG}/Godeps/_workspace:$GOPATH
 
-EXPOSE 4443
+EXPOSE 4444
 
 # Copy the local repo to the expected go path
 COPY . /go/src/github.com/docker/notary


### PR DESCRIPTION
4443 is default used by Server and 4444 is for Signer.

Signed-off-by: Hu Keping <hukeping@huawei.com>