### PR TITLE
added /usr/lib64 to search paths

### DIFF
--- a/trustmanager/yubikey/pkcs11_linux.go
+++ b/trustmanager/yubikey/pkcs11_linux.go
@@ -4,6 +4,7 @@ package yubikey
 
 var possiblePkcs11Libs = []string{
 	"/usr/lib/libykcs11.so",
+	"/usr/lib64/libykcs11.so",
 	"/usr/lib/x86_64-linux-gnu/libykcs11.so",
 	"/usr/local/lib/libykcs11.so",
 }


### PR DESCRIPTION
On some x86_64 Linux distributions the libaries are installed in /usr/lib64, e.g. Fedora. Without that notary does not work with the Yubikey on these Linux distributions. Adding that path to the search list fixes that issue and makes workrounds like copying/installing the libraries in /usr/lib or /usr/local/lib unnecessary.