### PR TITLE
Verbose health check information

### DIFF
--- a/signer/client/signer_trust.go
+++ b/signer/client/signer_trust.go
@@ -185,11 +185,16 @@ func (trust *NotarySigner) CheckHealth(timeout time.Duration) error {
 	status, err := trust.kmClient.CheckHealth(ctx, &pb.Void{})
 	defer cancel()
 	if err == nil && len(status.Status) > 0 {
-		return fmt.Errorf("Trust is not healthy")
-	} else if err != nil && grpc.Code(err) == codes.DeadlineExceeded {
-		return fmt.Errorf(
-			"Timed out reaching trust service after %s.", timeout)
+		var stats string
+		for k, v := range status.Status {
+			stats += k + ":" + v + "; "
+		}
+		return fmt.Errorf("Trust is not healthy: %s", stats)
 	}
+	if err != nil && grpc.Code(err) == codes.DeadlineExceeded {
+		return fmt.Errorf("Timed out reaching trust service after %s.", timeout)
+	}
+
 	return err
 }
 


### PR DESCRIPTION
When I deploy Notary, the health check of Notary-Server began to warn me:
```
level=error msg="Trust not fully operational: Trust is not healthy"
```  
I think the error message is not enough to find the problem, I spent much time to figured out that was because I forget to start the MySQL for Notary-Signer.

With this PR, if the same thing happened, the error message will be quite useful:
```
level=error msg="Trust not fully operational: Trust is not healthy: map[DB operational:Cannot access table: private_keys]"
```