### PR TITLE
Revert "switching out to consistently use canonical json for all marshalling of TUF data

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 // recursively copies the contents of one directory into another - ignores
@@ -63,8 +63,8 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	// and publishing will modify the files
 	tmpDir, err := ioutil.TempDir("", "notary-backwards-compat-test")
 	defer os.RemoveAll(tmpDir)
-	require.NoError(t, err)
-	require.NoError(t, recursiveCopy("../fixtures/compatibility/notary0.1", tmpDir))
+	assert.NoError(t, err)
+	assert.NoError(t, recursiveCopy("../fixtures/compatibility/notary0.1", tmpDir))
 
 	gun := "docker.io/notary0.1/samplerepo"
 	passwd := "randompass"
@@ -74,28 +74,28 @@ func Test0Dot1RepoFormat(t *testing.T) {
 
 	repo, err := NewNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd))
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 
 	// rotate the timestamp key, since the server doesn't have that one
 	timestampPubKey, err := getRemoteKey(ts.URL, gun, data.CanonicalTimestampRole, http.DefaultTransport)
-	require.NoError(t, err)
-	require.NoError(
+	assert.NoError(t, err)
+	assert.NoError(
 		t, repo.rootFileKeyChange(data.CanonicalTimestampRole, changelist.ActionCreate, timestampPubKey))
 
-	require.NoError(t, repo.Publish())
+	assert.NoError(t, repo.Publish())
 
 	targets, err := repo.ListTargets()
-	require.NoError(t, err)
-	require.Len(t, targets, 1)
-	require.Equal(t, "v1", targets[0].Name)
+	assert.NoError(t, err)
+	assert.Len(t, targets, 1)
+	assert.Equal(t, "v1", targets[0].Name)
 
 	// Also check that we can add/remove keys by rotating keys
 	oldTargetsKeys := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
-	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false))
-	require.NoError(t, repo.Publish())
+	assert.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false))
+	assert.NoError(t, repo.Publish())
 	newTargetsKeys := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
 
-	require.Len(t, oldTargetsKeys, 1)
-	require.Len(t, newTargetsKeys, 1)
-	require.NotEqual(t, oldTargetsKeys[0], newTargetsKeys[0])
+	assert.Len(t, oldTargetsKeys, 1)
+	assert.Len(t, newTargetsKeys, 1)
+	assert.NotEqual(t, oldTargetsKeys[0], newTargetsKeys[0])
 }

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,8 +13,6 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/go/canonical/json"
-
 	"github.com/docker/notary/certs"
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/cryptoservice"
@@ -324,7 +323,7 @@ func (r *NotaryRepository) AddDelegation(name string, threshold int,
 	logrus.Debugf(`Adding delegation "%s" with threshold %d, and %d keys\n`,
 		name, threshold, len(delegationKeys))
 
-	tdJSON, err := json.MarshalCanonical(&changelist.TufDelegation{
+	tdJSON, err := json.Marshal(&changelist.TufDelegation{
 		NewThreshold: threshold,
 		AddKeys:      data.KeyList(delegationKeys),
 		AddPaths:     paths,
@@ -386,7 +385,7 @@ func (r *NotaryRepository) AddTarget(target *Target, roles ...string) error {
 	logrus.Debugf("Adding target \"%s\" with sha256 \"%x\" and size %d bytes.\n", target.Name, target.Hashes["sha256"], target.Length)
 
 	meta := data.FileMeta{Length: target.Length, Hashes: target.Hashes}
-	metaJSON, err := json.MarshalCanonical(meta)
+	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return err
 	}
@@ -690,7 +689,7 @@ func (r *NotaryRepository) saveMetadata(ignoreSnapshot bool) error {
 		if err != nil {
 			return err
 		}
-		targetsJSON, err := json.MarshalCanonical(signedTargets)
+		targetsJSON, err := json.Marshal(signedTargets)
 		if err != nil {
 			return err
 		}
@@ -838,7 +837,7 @@ func (r *NotaryRepository) rootFileKeyChange(role, action string, key data.Publi
 		RoleName: role,
 		Keys:     kl,
 	}
-	metaJSON, err := json.MarshalCanonical(meta)
+	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"crypto/rand"
+	regJson "encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -18,10 +19,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	ctxu "github.com/docker/distribution/context"
-	"github.com/jfrazelle/go/canonical/json"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
-
 	"github.com/docker/notary/certs"
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/cryptoservice"
@@ -33,6 +30,9 @@ import (
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
 	"github.com/docker/notary/tuf/validation"
+	"github.com/jfrazelle/go/canonical/json"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 func simpleTestServer(t *testing.T, roles ...string) (
@@ -46,12 +46,12 @@ func simpleTestServer(t *testing.T, roles ...string) (
 
 	for _, role := range roles {
 		key, err := trustmanager.GenerateECDSAKey(rand.Reader)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		keys[role] = key
 		pubKey := data.PublicKeyFromPrivate(key)
 		jsonBytes, err := json.MarshalCanonical(&pubKey)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		keyJSON := string(jsonBytes)
 
 		// TUF will request /v2/docker.com/notary/_trust/tuf/<role>.key
@@ -102,7 +102,7 @@ func initializeRepo(t *testing.T, rootType, gun, url string,
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	serverManagedRoles := []string{}
 	if serverManagesSnapshot {
@@ -112,7 +112,7 @@ func initializeRepo(t *testing.T, rootType, gun, url string,
 	repo, rootPubKeyID := createRepoAndKey(t, rootType, tempBaseDir, gun, url)
 
 	err = repo.Initialize(rootPubKeyID, serverManagedRoles...)
-	require.NoError(t, err, "error creating repository: %s", err)
+	assert.NoError(t, err, "error creating repository: %s", err)
 	if err != nil {
 		os.RemoveAll(tempBaseDir)
 	}
@@ -126,10 +126,10 @@ func createRepoAndKey(t *testing.T, rootType, tempBaseDir, gun, url string) (
 
 	repo, err := NewNotaryRepository(
 		tempBaseDir, gun, url, http.DefaultTransport, passphraseRetriever)
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 
 	rootPubKey, err := repo.CryptoService.Create("root", rootType)
-	require.NoError(t, err, "error generating root key: %s", err)
+	assert.NoError(t, err, "error generating root key: %s", err)
 
 	return repo, rootPubKey.ID()
 }
@@ -138,12 +138,12 @@ func createRepoAndKey(t *testing.T, rootType, tempBaseDir, gun, url string) (
 // repo, so that it can be used to pull the trust data the original repo pushed
 func newRepoToTestRepo(t *testing.T, existingRepo *NotaryRepository) *NotaryRepository {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory")
+	assert.NoError(t, err, "failed to create a temporary directory")
 
 	repo, err := NewNotaryRepository(
 		tempBaseDir, existingRepo.gun, existingRepo.baseURL,
 		http.DefaultTransport, passphraseRetriever)
-	require.NoError(t, err, "error creating repository: %s", err)
+	assert.NoError(t, err, "error creating repository: %s", err)
 	if err != nil {
 		defer os.RemoveAll(tempBaseDir)
 	}
@@ -156,16 +156,16 @@ func newRepoToTestRepo(t *testing.T, existingRepo *NotaryRepository) *NotaryRepo
 func TestInitRepositoryManagedRolesIncludingRoot(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory")
+	assert.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
 	repo, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", "http://localhost")
 	err = repo.Initialize(rootPubKeyID, data.CanonicalRootRole)
-	require.Error(t, err)
-	require.IsType(t, ErrInvalidRemoteRole{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, ErrInvalidRemoteRole{}, err)
 	// Just testing the error message here in this one case
-	require.Equal(t, err.Error(),
+	assert.Equal(t, err.Error(),
 		"notary does not support the server managing the root key")
 }
 
@@ -174,14 +174,14 @@ func TestInitRepositoryManagedRolesIncludingRoot(t *testing.T) {
 func TestInitRepositoryManagedRolesInvalidRole(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory")
+	assert.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
 	repo, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", "http://localhost")
 	err = repo.Initialize(rootPubKeyID, "randomrole")
-	require.Error(t, err)
-	require.IsType(t, ErrInvalidRemoteRole{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, ErrInvalidRemoteRole{}, err)
 }
 
 // Initializing a new repo while specifying that the server should manage the
@@ -189,14 +189,14 @@ func TestInitRepositoryManagedRolesInvalidRole(t *testing.T) {
 func TestInitRepositoryManagedRolesIncludingTargets(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory")
+	assert.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
 	repo, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", "http://localhost")
 	err = repo.Initialize(rootPubKeyID, data.CanonicalTargetsRole)
-	require.Error(t, err)
-	require.IsType(t, ErrInvalidRemoteRole{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, ErrInvalidRemoteRole{}, err)
 }
 
 // Initializing a new repo while specifying that the server should manage the
@@ -204,7 +204,7 @@ func TestInitRepositoryManagedRolesIncludingTargets(t *testing.T) {
 func TestInitRepositoryManagedRolesIncludingTimestamp(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory")
+	assert.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
 	ts, _, _ := simpleTestServer(t)
@@ -213,7 +213,7 @@ func TestInitRepositoryManagedRolesIncludingTimestamp(t *testing.T) {
 	repo, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
 	err = repo.Initialize(rootPubKeyID, data.CanonicalTimestampRole)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 // Initializing a new repo fails if unable to get the timestamp key, even if
@@ -221,7 +221,7 @@ func TestInitRepositoryManagedRolesIncludingTimestamp(t *testing.T) {
 func TestInitRepositoryNeedsRemoteTimestampKey(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory")
+	assert.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
 	ts, _, _ := simpleTestServer(t, data.CanonicalSnapshotRole)
@@ -230,8 +230,8 @@ func TestInitRepositoryNeedsRemoteTimestampKey(t *testing.T) {
 	repo, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
 	err = repo.Initialize(rootPubKeyID, data.CanonicalTimestampRole)
-	require.Error(t, err)
-	require.IsType(t, store.ErrMetaNotFound{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, store.ErrMetaNotFound{}, err)
 }
 
 // Initializing a new repo with remote server signing fails if unable to get
@@ -239,7 +239,7 @@ func TestInitRepositoryNeedsRemoteTimestampKey(t *testing.T) {
 func TestInitRepositoryNeedsRemoteSnapshotKey(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory")
+	assert.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
 	ts, _, _ := simpleTestServer(t, data.CanonicalTimestampRole)
@@ -248,8 +248,8 @@ func TestInitRepositoryNeedsRemoteSnapshotKey(t *testing.T) {
 	repo, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
 	err = repo.Initialize(rootPubKeyID, data.CanonicalSnapshotRole)
-	require.Error(t, err)
-	require.IsType(t, store.ErrMetaNotFound{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, store.ErrMetaNotFound{}, err)
 }
 
 // passing timestamp + snapshot, or just snapshot, is tested in the next two
@@ -280,71 +280,71 @@ func TestInitRepoServerManagesTimestampAndSnapshotKeys(t *testing.T) {
 
 // This creates a new KeyFileStore in the repo's base directory and makes sure
 // the repo has the right number of keys
-func requireRepoHasExpectedKeys(t *testing.T, repo *NotaryRepository,
+func assertRepoHasExpectedKeys(t *testing.T, repo *NotaryRepository,
 	rootKeyID string, expectedSnapshotKey bool) {
 
 	// The repo should have a keyFileStore and have created keys using it,
 	// so create a new KeyFileStore, and check that the keys do exist and are
 	// valid
 	ks, err := trustmanager.NewKeyFileStore(repo.baseDir, passphraseRetriever)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	roles := make(map[string]bool)
 	for keyID, role := range ks.ListKeys() {
 		if role == data.CanonicalRootRole {
-			require.Equal(t, rootKeyID, keyID, "Unexpected root key ID")
+			assert.Equal(t, rootKeyID, keyID, "Unexpected root key ID")
 		}
 		// just to ensure the content of the key files created are valid
 		_, r, err := ks.GetKey(keyID)
-		require.NoError(t, err)
-		require.Equal(t, role, r)
+		assert.NoError(t, err)
+		assert.Equal(t, role, r)
 		roles[role] = true
 	}
 	// there is a root key and a targets key
 	alwaysThere := []string{data.CanonicalRootRole, data.CanonicalTargetsRole}
 	for _, role := range alwaysThere {
 		_, ok := roles[role]
-		require.True(t, ok, "missing %s key", role)
+		assert.True(t, ok, "missing %s key", role)
 	}
 
 	// there may be a snapshots key, depending on whether the server is managing
 	// the snapshots key
 	_, ok := roles[data.CanonicalSnapshotRole]
 	if expectedSnapshotKey {
-		require.True(t, ok, "missing snapshot key")
+		assert.True(t, ok, "missing snapshot key")
 	} else {
-		require.False(t, ok,
+		assert.False(t, ok,
 			"there should be no snapshot key because the server manages it")
 	}
 
 	// The server manages the timestamp key - there should not be a timestamp
 	// key
 	_, ok = roles[data.CanonicalTimestampRole]
-	require.False(t, ok,
+	assert.False(t, ok,
 		"there should be no timestamp key because the server manages it")
 }
 
 // This creates a new certificate manager in the repo's base directory and
 // makes sure the repo has the right certificates
-func requireRepoHasExpectedCerts(t *testing.T, repo *NotaryRepository) {
+func assertRepoHasExpectedCerts(t *testing.T, repo *NotaryRepository) {
 	// The repo should have a certificate manager and have created certs using
 	// it, so create a new manager, and check that the certs do exist and
 	// are valid
 	certManager, err := certs.NewManager(repo.baseDir)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	certificates := certManager.TrustedCertificateStore().GetCertificates()
-	require.Len(t, certificates, 1, "unexpected number of trusted certificates")
+	assert.Len(t, certificates, 1, "unexpected number of trusted certificates")
 
 	certID, err := trustmanager.FingerprintCert(certificates[0])
-	require.NoError(t, err, "unable to fingerprint the trusted certificate")
-	require.NotEqual(t, certID, "")
+	assert.NoError(t, err, "unable to fingerprint the trusted certificate")
+	assert.NotEqual(t, certID, "")
 }
 
 // Sanity check the TUF metadata files. Verify that it exists for a particular
 // role, the JSON is well-formed, and the signatures exist.
 // For the root.json file, also check that the root, snapshot, and
 // targets key IDs are present.
-func requireRepoHasExpectedMetadata(t *testing.T, repo *NotaryRepository,
+func assertRepoHasExpectedMetadata(t *testing.T, repo *NotaryRepository,
 	role string, expected bool) {
 
 	filename := filepath.Join(tufDir, filepath.FromSlash(repo.gun),
@@ -353,28 +353,28 @@ func requireRepoHasExpectedMetadata(t *testing.T, repo *NotaryRepository,
 	_, err := os.Stat(fullPath)
 
 	if expected {
-		require.NoError(t, err, "missing TUF metadata file: %s", filename)
+		assert.NoError(t, err, "missing TUF metadata file: %s", filename)
 	} else {
-		require.Error(t, err,
+		assert.Error(t, err,
 			"%s metadata should not exist, but does: %s", role, filename)
 		return
 	}
 
 	jsonBytes, err := ioutil.ReadFile(fullPath)
-	require.NoError(t, err, "error reading TUF metadata file %s: %s", filename, err)
+	assert.NoError(t, err, "error reading TUF metadata file %s: %s", filename, err)
 
 	var decoded data.Signed
 	err = json.Unmarshal(jsonBytes, &decoded)
-	require.NoError(t, err, "error parsing TUF metadata file %s: %s", filename, err)
+	assert.NoError(t, err, "error parsing TUF metadata file %s: %s", filename, err)
 
-	require.Len(t, decoded.Signatures, 1,
+	assert.Len(t, decoded.Signatures, 1,
 		"incorrect number of signatures in TUF metadata file %s", filename)
 
-	require.NotEmpty(t, decoded.Signatures[0].KeyID,
+	assert.NotEmpty(t, decoded.Signatures[0].KeyID,
 		"empty key ID field in TUF metadata file %s", filename)
-	require.NotEmpty(t, decoded.Signatures[0].Method,
+	assert.NotEmpty(t, decoded.Signatures[0].Method,
 		"empty method field in TUF metadata file %s", filename)
-	require.NotEmpty(t, decoded.Signatures[0].Signature,
+	assert.NotEmpty(t, decoded.Signatures[0].Signature,
 		"empty signature in TUF metadata file %s", filename)
 
 	// Special case for root.json: also check that the signed
@@ -382,20 +382,20 @@ func requireRepoHasExpectedMetadata(t *testing.T, repo *NotaryRepository,
 	if role == data.CanonicalRootRole {
 		var decodedRoot data.Root
 		err := json.Unmarshal(decoded.Signed, &decodedRoot)
-		require.NoError(t, err, "error parsing root.json signed section: %s", err)
+		assert.NoError(t, err, "error parsing root.json signed section: %s", err)
 
-		require.Equal(t, "Root", decodedRoot.Type, "_type mismatch in root.json")
+		assert.Equal(t, "Root", decodedRoot.Type, "_type mismatch in root.json")
 
 		// Expect 1 key for each valid role in the Keys map - one for
 		// each of root, targets, snapshot, timestamp
-		require.Len(t, decodedRoot.Keys, len(data.BaseRoles),
+		assert.Len(t, decodedRoot.Keys, len(data.BaseRoles),
 			"wrong number of keys in root.json")
-		require.Len(t, decodedRoot.Roles, len(data.BaseRoles),
+		assert.Len(t, decodedRoot.Roles, len(data.BaseRoles),
 			"wrong number of roles in root.json")
 
 		for _, role := range data.BaseRoles {
 			_, ok := decodedRoot.Roles[role]
-			require.True(t, ok, "Missing role %s in root.json", role)
+			assert.True(t, ok, "Missing role %s in root.json", role)
 		}
 	}
 }
@@ -409,11 +409,11 @@ func testInitRepo(t *testing.T, rootType string, serverManagesSnapshot bool) {
 	repo, rootKeyID := initializeRepo(t, rootType, gun, ts.URL, serverManagesSnapshot)
 	defer os.RemoveAll(repo.baseDir)
 
-	requireRepoHasExpectedKeys(t, repo, rootKeyID, !serverManagesSnapshot)
-	requireRepoHasExpectedCerts(t, repo)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, true)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole,
+	assertRepoHasExpectedKeys(t, repo, rootKeyID, !serverManagesSnapshot)
+	assertRepoHasExpectedCerts(t, repo)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, true)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole,
 		!serverManagesSnapshot)
 }
 
@@ -430,7 +430,7 @@ func testInitRepoAttemptsExceeded(t *testing.T, rootType string) {
 	gun := "docker.com/notary"
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 
 	ts, _, _ := simpleTestServer(t)
@@ -438,17 +438,17 @@ func testInitRepoAttemptsExceeded(t *testing.T, rootType string) {
 
 	retriever := passphrase.ConstantRetriever("password")
 	repo, err := NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, retriever)
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 	rootPubKey, err := repo.CryptoService.Create("root", rootType)
-	require.NoError(t, err, "error generating root key: %s", err)
+	assert.NoError(t, err, "error generating root key: %s", err)
 
 	retriever = passphrase.ConstantRetriever("incorrect password")
 	// repo.CryptoService’s FileKeyStore caches the unlocked private key, so to test
 	// private key unlocking we need a new repo instance.
 	repo, err = NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, retriever)
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 	err = repo.Initialize(rootPubKey.ID())
-	require.EqualError(t, err, trustmanager.ErrAttemptsExceeded{}.Error())
+	assert.EqualError(t, err, trustmanager.ErrAttemptsExceeded{}.Error())
 }
 
 // TestInitRepoPasswordInvalid tests error handling when passphrase.Retriever
@@ -468,7 +468,7 @@ func testInitRepoPasswordInvalid(t *testing.T, rootType string) {
 	gun := "docker.com/notary"
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 
 	ts, _, _ := simpleTestServer(t)
@@ -476,31 +476,31 @@ func testInitRepoPasswordInvalid(t *testing.T, rootType string) {
 
 	retriever := passphrase.ConstantRetriever("password")
 	repo, err := NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, retriever)
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 	rootPubKey, err := repo.CryptoService.Create("root", rootType)
-	require.NoError(t, err, "error generating root key: %s", err)
+	assert.NoError(t, err, "error generating root key: %s", err)
 
 	// repo.CryptoService’s FileKeyStore caches the unlocked private key, so to test
 	// private key unlocking we need a new repo instance.
 	repo, err = NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, giveUpPassphraseRetriever)
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 	err = repo.Initialize(rootPubKey.ID())
-	require.EqualError(t, err, trustmanager.ErrPasswordInvalid{}.Error())
+	assert.EqualError(t, err, trustmanager.ErrPasswordInvalid{}.Error())
 }
 
 func addTarget(t *testing.T, repo *NotaryRepository, targetName, targetFile string,
 	roles ...string) *Target {
 	target, err := NewTarget(targetName, targetFile)
-	require.NoError(t, err, "error creating target")
+	assert.NoError(t, err, "error creating target")
 	err = repo.AddTarget(target, roles...)
-	require.NoError(t, err, "error adding target")
+	assert.NoError(t, err, "error adding target")
 	return target
 }
 
 // calls GetChangelist and gets the actual changes out
 func getChanges(t *testing.T, repo *NotaryRepository) []changelist.Change {
 	changeList, err := repo.GetChangelist()
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	return changeList.List()
 }
 
@@ -523,7 +523,7 @@ func TestAddTargetToTargetRoleByDefault(t *testing.T) {
 func testAddOrDeleteTarget(t *testing.T, repo *NotaryRepository, action string,
 	rolesToChange []string, expectedScopes []string) {
 
-	require.Len(t, getChanges(t, repo), 0, "should start with zero changes")
+	assert.Len(t, getChanges(t, repo), 0, "should start with zero changes")
 
 	if action == changelist.ActionCreate {
 		// Add fixtures/intermediate-ca.crt as a target. There's no particular
@@ -532,28 +532,28 @@ func testAddOrDeleteTarget(t *testing.T, repo *NotaryRepository, action string,
 		addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt", rolesToChange...)
 	} else {
 		err := repo.RemoveTarget("latest", rolesToChange...)
-		require.NoError(t, err, "error removing target")
+		assert.NoError(t, err, "error removing target")
 	}
 
 	changes := getChanges(t, repo)
-	require.Len(t, changes, len(expectedScopes), "wrong number of changes files found")
+	assert.Len(t, changes, len(expectedScopes), "wrong number of changes files found")
 
 	foundScopes := make(map[string]bool)
 	for _, c := range changes { // there is only one
-		require.EqualValues(t, action, c.Action())
+		assert.EqualValues(t, action, c.Action())
 		foundScopes[c.Scope()] = true
-		require.Equal(t, "target", c.Type())
-		require.Equal(t, "latest", c.Path())
+		assert.Equal(t, "target", c.Type())
+		assert.Equal(t, "latest", c.Path())
 		if action == changelist.ActionCreate {
-			require.NotEmpty(t, c.Content())
+			assert.NotEmpty(t, c.Content())
 		} else {
-			require.Empty(t, c.Content())
+			assert.Empty(t, c.Content())
 		}
 	}
-	require.Len(t, foundScopes, len(expectedScopes))
+	assert.Len(t, foundScopes, len(expectedScopes))
 	for _, expectedScope := range expectedScopes {
 		_, ok := foundScopes[expectedScope]
-		require.True(t, ok, "Target was not added/removed from %s", expectedScope)
+		assert.True(t, ok, "Target was not added/removed from %s", expectedScope)
 	}
 
 	// add/delete a second time
@@ -561,35 +561,35 @@ func testAddOrDeleteTarget(t *testing.T, repo *NotaryRepository, action string,
 		addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt", rolesToChange...)
 	} else {
 		err := repo.RemoveTarget("current", rolesToChange...)
-		require.NoError(t, err, "error removing target")
+		assert.NoError(t, err, "error removing target")
 	}
 
 	changes = getChanges(t, repo)
-	require.Len(t, changes, 2*len(expectedScopes),
+	assert.Len(t, changes, 2*len(expectedScopes),
 		"wrong number of changelist files found")
 
 	newFileFound := false
 	foundScopes = make(map[string]bool)
 	for _, c := range changes {
 		if c.Path() != "latest" {
-			require.EqualValues(t, action, c.Action())
+			assert.EqualValues(t, action, c.Action())
 			foundScopes[c.Scope()] = true
-			require.Equal(t, "target", c.Type())
-			require.Equal(t, "current", c.Path())
+			assert.Equal(t, "target", c.Type())
+			assert.Equal(t, "current", c.Path())
 			if action == changelist.ActionCreate {
-				require.NotEmpty(t, c.Content())
+				assert.NotEmpty(t, c.Content())
 			} else {
-				require.Empty(t, c.Content())
+				assert.Empty(t, c.Content())
 			}
 
 			newFileFound = true
 		}
 	}
-	require.True(t, newFileFound, "second changelist file not found")
-	require.Len(t, foundScopes, len(expectedScopes))
+	assert.True(t, newFileFound, "second changelist file not found")
+	assert.Len(t, foundScopes, len(expectedScopes))
 	for _, expectedScope := range expectedScopes {
 		_, ok := foundScopes[expectedScope]
-		require.True(t, ok, "Target was not added/removed from %s", expectedScope)
+		assert.True(t, ok, "Target was not added/removed from %s", expectedScope)
 	}
 }
 
@@ -632,18 +632,18 @@ func TestAddTargetToSpecifiedInvalidRoles(t *testing.T) {
 
 	for _, invalidRole := range invalidRoles {
 		target, err := NewTarget("latest", "../fixtures/intermediate-ca.crt")
-		require.NoError(t, err, "error creating target")
+		assert.NoError(t, err, "error creating target")
 
 		err = repo.AddTarget(target, data.CanonicalTargetsRole, invalidRole)
-		require.Error(t, err, "Expected an ErrInvalidRole error")
-		require.IsType(t, data.ErrInvalidRole{}, err)
+		assert.Error(t, err, "Expected an ErrInvalidRole error")
+		assert.IsType(t, data.ErrInvalidRole{}, err)
 
 		changes := getChanges(t, repo)
-		require.Len(t, changes, 0)
+		assert.Len(t, changes, 0)
 	}
 }
 
-// General way to require that errors writing a changefile are propagated up
+// General way to assert that errors writing a changefile are propagated up
 func testErrorWritingChangefiles(t *testing.T, writeChangeFile func(*NotaryRepository) error) {
 	ts, _, _ := simpleTestServer(t)
 	defer ts.Close()
@@ -655,26 +655,26 @@ func testErrorWritingChangefiles(t *testing.T, writeChangeFile func(*NotaryRepos
 	// directory unwritable
 	changelistPath := filepath.Join(repo.tufRepoPath, "changelist")
 	err := os.MkdirAll(changelistPath, 0744)
-	require.NoError(t, err, "could not create changelist dir")
+	assert.NoError(t, err, "could not create changelist dir")
 	err = os.Chmod(changelistPath, 0600)
-	require.NoError(t, err, "could not change permission of changelist dir")
+	assert.NoError(t, err, "could not change permission of changelist dir")
 
 	err = writeChangeFile(repo)
-	require.Error(t, err, "Expected an error writing the change")
-	require.IsType(t, &os.PathError{}, err)
+	assert.Error(t, err, "Expected an error writing the change")
+	assert.IsType(t, &os.PathError{}, err)
 
 	// then break prevent the changlist directory from being able to be created
 	err = os.Chmod(changelistPath, 0744)
-	require.NoError(t, err, "could not change permission of temp dir")
+	assert.NoError(t, err, "could not change permission of temp dir")
 	err = os.RemoveAll(changelistPath)
-	require.NoError(t, err, "could not remove changelist dir")
+	assert.NoError(t, err, "could not remove changelist dir")
 	// creating a changelist file so the directory can't be created
 	err = ioutil.WriteFile(changelistPath, []byte("hi"), 0644)
-	require.NoError(t, err, "could not write temporary file")
+	assert.NoError(t, err, "could not write temporary file")
 
 	err = writeChangeFile(repo)
-	require.Error(t, err, "Expected an error writing the change")
-	require.IsType(t, &os.PathError{}, err)
+	assert.Error(t, err, "Expected an error writing the change")
+	assert.IsType(t, &os.PathError{}, err)
 }
 
 // TestAddTargetErrorWritingChanges expects errors writing a change to file
@@ -682,7 +682,7 @@ func testErrorWritingChangefiles(t *testing.T, writeChangeFile func(*NotaryRepos
 func TestAddTargetErrorWritingChanges(t *testing.T) {
 	testErrorWritingChangefiles(t, func(repo *NotaryRepository) error {
 		target, err := NewTarget("latest", "../fixtures/intermediate-ca.crt")
-		require.NoError(t, err, "error creating target")
+		assert.NoError(t, err, "error creating target")
 		return repo.AddTarget(target, data.CanonicalTargetsRole)
 	})
 }
@@ -740,11 +740,11 @@ func TestRemoveTargetToSpecifiedInvalidRoles(t *testing.T) {
 
 	for _, invalidRole := range invalidRoles {
 		err := repo.RemoveTarget("latest", data.CanonicalTargetsRole, invalidRole)
-		require.Error(t, err, "Expected an ErrInvalidRole error")
-		require.IsType(t, data.ErrInvalidRole{}, err)
+		assert.Error(t, err, "Expected an ErrInvalidRole error")
+		assert.IsType(t, data.ErrInvalidRole{}, err)
 
 		changes := getChanges(t, repo)
-		require.Len(t, changes, 0)
+		assert.Len(t, changes, 0)
 	}
 }
 
@@ -779,7 +779,7 @@ func testListEmptyTargets(t *testing.T, rootType string) {
 	defer os.RemoveAll(repo.baseDir)
 
 	_, err := repo.ListTargets(data.CanonicalTargetsRole)
-	require.Error(t, err) // no trust data
+	assert.Error(t, err) // no trust data
 }
 
 // reads data from the repository in order to fake data being served via
@@ -788,11 +788,11 @@ func fakeServerData(t *testing.T, repo *NotaryRepository, mux *http.ServeMux,
 	keys map[string]data.PrivateKey) {
 
 	timestampKey, ok := keys[data.CanonicalTimestampRole]
-	require.True(t, ok)
+	assert.True(t, ok)
 	savedTUFRepo := repo.tufRepo // in case this is overwritten
 
 	fileStore, err := trustmanager.NewKeyFileStore(repo.baseDir, passphraseRetriever)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	fileStore.AddKey(
 		filepath.Join(filepath.FromSlash(repo.gun), timestampKey.ID()),
 		"nonroot", timestampKey)
@@ -803,14 +803,14 @@ func fakeServerData(t *testing.T, repo *NotaryRepository, mux *http.ServeMux,
 
 	signedTargets, err := savedTUFRepo.SignTargets(
 		"targets", data.DefaultExpires("targets"))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	signedLevel1, err := savedTUFRepo.SignTargets(
 		"targets/level1",
 		data.DefaultExpires(data.CanonicalTargetsRole),
 	)
 	if _, ok := savedTUFRepo.Targets["targets/level1"]; ok {
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}
 
 	signedLevel2, err := savedTUFRepo.SignTargets(
@@ -818,52 +818,52 @@ func fakeServerData(t *testing.T, repo *NotaryRepository, mux *http.ServeMux,
 		data.DefaultExpires(data.CanonicalTargetsRole),
 	)
 	if _, ok := savedTUFRepo.Targets["targets/level2"]; ok {
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}
 
 	signedSnapshot, err := savedTUFRepo.SignSnapshot(
 		data.DefaultExpires("snapshot"))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	signedTimestamp, err := savedTUFRepo.SignTimestamp(
 		data.DefaultExpires("timestamp"))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/root.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			fmt.Fprint(w, string(rootFileBytes))
 		})
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/timestamp.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			timestampJSON, _ := json.MarshalCanonical(signedTimestamp)
+			timestampJSON, _ := json.Marshal(signedTimestamp)
 			fmt.Fprint(w, string(timestampJSON))
 		})
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/snapshot.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			snapshotJSON, _ := json.MarshalCanonical(signedSnapshot)
+			snapshotJSON, _ := json.Marshal(signedSnapshot)
 			fmt.Fprint(w, string(snapshotJSON))
 		})
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/targets.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			targetsJSON, _ := json.MarshalCanonical(signedTargets)
+			targetsJSON, _ := json.Marshal(signedTargets)
 			fmt.Fprint(w, string(targetsJSON))
 		})
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/targets/level1.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			level1JSON, err := json.MarshalCanonical(signedLevel1)
-			require.NoError(t, err)
+			level1JSON, err := json.Marshal(signedLevel1)
+			assert.NoError(t, err)
 			fmt.Fprint(w, string(level1JSON))
 		})
 
 	mux.HandleFunc("/v2/docker.com/notary/_trust/tuf/targets/level2.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			level2JSON, err := json.MarshalCanonical(signedLevel2)
-			require.NoError(t, err)
+			level2JSON, err := json.Marshal(signedLevel2)
+			assert.NoError(t, err)
 			fmt.Fprint(w, string(level2JSON))
 		})
 }
@@ -884,7 +884,7 @@ func testListTarget(t *testing.T, rootType string) {
 
 	// tests need to manually boostrap timestamp as client doesn't generate it
 	err := repo.tufRepo.InitTimestamp()
-	require.NoError(t, err, "error creating repository: %s", err)
+	assert.NoError(t, err, "error creating repository: %s", err)
 
 	latestTarget := addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
 	currentTarget := addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt")
@@ -894,41 +894,41 @@ func testListTarget(t *testing.T, rootType string) {
 	// load the changelist for this repo
 	cl, err := changelist.NewFileChangelist(
 		filepath.Join(repo.baseDir, "tuf", filepath.FromSlash(repo.gun), "changelist"))
-	require.NoError(t, err, "could not open changelist")
+	assert.NoError(t, err, "could not open changelist")
 
 	// apply the changelist to the repo
 	err = applyChangelist(repo.tufRepo, cl)
-	require.NoError(t, err, "could not apply changelist")
+	assert.NoError(t, err, "could not apply changelist")
 
 	fakeServerData(t, repo, mux, keys)
 
 	targets, err := repo.ListTargets(data.CanonicalTargetsRole)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	// Should be two targets
-	require.Len(t, targets, 2, "unexpected number of targets returned by ListTargets")
+	assert.Len(t, targets, 2, "unexpected number of targets returned by ListTargets")
 
 	sort.Stable(targetSorter(targets))
 
 	// the targets should both be found in the targets role
 	for _, foundTarget := range targets {
-		require.Equal(t, data.CanonicalTargetsRole, foundTarget.Role)
+		assert.Equal(t, data.CanonicalTargetsRole, foundTarget.Role)
 	}
 
 	// current should be first
-	require.True(t, reflect.DeepEqual(*currentTarget, targets[0].Target), "current target does not match")
-	require.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
+	assert.True(t, reflect.DeepEqual(*currentTarget, targets[0].Target), "current target does not match")
+	assert.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
 
 	// Also test GetTargetByName
 	newLatestTarget, err := repo.GetTargetByName("latest")
-	require.NoError(t, err)
-	require.Equal(t, data.CanonicalTargetsRole, newLatestTarget.Role)
-	require.True(t, reflect.DeepEqual(*latestTarget, newLatestTarget.Target), "latest target does not match")
+	assert.NoError(t, err)
+	assert.Equal(t, data.CanonicalTargetsRole, newLatestTarget.Role)
+	assert.True(t, reflect.DeepEqual(*latestTarget, newLatestTarget.Target), "latest target does not match")
 
 	newCurrentTarget, err := repo.GetTargetByName("current")
-	require.NoError(t, err)
-	require.Equal(t, data.CanonicalTargetsRole, newCurrentTarget.Role)
-	require.True(t, reflect.DeepEqual(*currentTarget, newCurrentTarget.Target), "current target does not match")
+	assert.NoError(t, err)
+	assert.Equal(t, data.CanonicalTargetsRole, newCurrentTarget.Role)
+	assert.True(t, reflect.DeepEqual(*currentTarget, newCurrentTarget.Target), "current target does not match")
 }
 
 func testListTargetWithDelegates(t *testing.T, rootType string) {
@@ -940,25 +940,25 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 
 	// tests need to manually boostrap timestamp as client doesn't generate it
 	err := repo.tufRepo.InitTimestamp()
-	require.NoError(t, err, "error creating repository: %s", err)
+	assert.NoError(t, err, "error creating repository: %s", err)
 
 	latestTarget := addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
 	currentTarget := addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt")
 
 	// setup delegated targets/level1 role
 	k, err := repo.CryptoService.Create("targets/level1", rootType)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""}, nil)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	repo.tufRepo.UpdateDelegations(r, []data.PublicKey{k})
 	delegatedTarget := addTarget(t, repo, "current", "../fixtures/root-ca.crt", "targets/level1")
 	otherTarget := addTarget(t, repo, "other", "../fixtures/root-ca.crt", "targets/level1")
 
 	// setup delegated targets/level2 role
 	k, err = repo.CryptoService.Create("targets/level2", rootType)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	r, err = data.NewRole("targets/level2", 1, []string{k.ID()}, []string{""}, nil)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	repo.tufRepo.UpdateDelegations(r, []data.PublicKey{k})
 	// this target should not show up as the one in targets/level1 takes higher priority
 	_ = addTarget(t, repo, "current", "../fixtures/notary-server.crt", "targets/level2")
@@ -970,85 +970,85 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	// load the changelist for this repo
 	cl, err := changelist.NewFileChangelist(
 		filepath.Join(repo.baseDir, "tuf", filepath.FromSlash(repo.gun), "changelist"))
-	require.NoError(t, err, "could not open changelist")
+	assert.NoError(t, err, "could not open changelist")
 
 	// apply the changelist to the repo
 	err = applyChangelist(repo.tufRepo, cl)
-	require.NoError(t, err, "could not apply changelist")
+	assert.NoError(t, err, "could not apply changelist")
 
 	_, ok := repo.tufRepo.Targets["targets/level1"].Signed.Targets["current"]
-	require.True(t, ok)
+	assert.True(t, ok)
 	_, ok = repo.tufRepo.Targets["targets/level1"].Signed.Targets["other"]
-	require.True(t, ok)
+	assert.True(t, ok)
 	_, ok = repo.tufRepo.Targets["targets/level2"].Signed.Targets["level2"]
-	require.True(t, ok)
+	assert.True(t, ok)
 
 	fakeServerData(t, repo, mux, keys)
 
 	// test default listing
 	targets, err := repo.ListTargets()
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	// Should be four targets
-	require.Len(t, targets, 4, "unexpected number of targets returned by ListTargets")
+	assert.Len(t, targets, 4, "unexpected number of targets returned by ListTargets")
 
 	sort.Stable(targetSorter(targets))
 
 	// current should be first.
-	require.True(t, reflect.DeepEqual(*currentTarget, targets[0].Target), "current target does not match")
-	require.Equal(t, data.CanonicalTargetsRole, targets[0].Role)
+	assert.True(t, reflect.DeepEqual(*currentTarget, targets[0].Target), "current target does not match")
+	assert.Equal(t, data.CanonicalTargetsRole, targets[0].Role)
 
-	require.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
-	require.Equal(t, data.CanonicalTargetsRole, targets[1].Role)
+	assert.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
+	assert.Equal(t, data.CanonicalTargetsRole, targets[1].Role)
 
-	require.True(t, reflect.DeepEqual(*level2Target, targets[2].Target), "level2 target does not match")
-	require.Equal(t, "targets/level2", targets[2].Role)
+	assert.True(t, reflect.DeepEqual(*level2Target, targets[2].Target), "level2 target does not match")
+	assert.Equal(t, "targets/level2", targets[2].Role)
 
-	require.True(t, reflect.DeepEqual(*otherTarget, targets[3].Target), "other target does not match")
-	require.Equal(t, "targets/level1", targets[3].Role)
+	assert.True(t, reflect.DeepEqual(*otherTarget, targets[3].Target), "other target does not match")
+	assert.Equal(t, "targets/level1", targets[3].Role)
 
 	// test listing with priority specified
 	targets, err = repo.ListTargets("targets/level1", data.CanonicalTargetsRole)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	// Should be four targets
-	require.Len(t, targets, 4, "unexpected number of targets returned by ListTargets")
+	assert.Len(t, targets, 4, "unexpected number of targets returned by ListTargets")
 
 	sort.Stable(targetSorter(targets))
 
 	// current (in delegated role) should be first
-	require.True(t, reflect.DeepEqual(*delegatedTarget, targets[0].Target), "current target does not match")
-	require.Equal(t, "targets/level1", targets[0].Role)
+	assert.True(t, reflect.DeepEqual(*delegatedTarget, targets[0].Target), "current target does not match")
+	assert.Equal(t, "targets/level1", targets[0].Role)
 
-	require.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
-	require.Equal(t, data.CanonicalTargetsRole, targets[1].Role)
+	assert.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
+	assert.Equal(t, data.CanonicalTargetsRole, targets[1].Role)
 
-	require.True(t, reflect.DeepEqual(*level2Target, targets[2].Target), "level2 target does not match")
-	require.Equal(t, "targets/level2", targets[2].Role)
+	assert.True(t, reflect.DeepEqual(*level2Target, targets[2].Target), "level2 target does not match")
+	assert.Equal(t, "targets/level2", targets[2].Role)
 
-	require.True(t, reflect.DeepEqual(*otherTarget, targets[3].Target), "other target does not match")
-	require.Equal(t, "targets/level1", targets[3].Role)
+	assert.True(t, reflect.DeepEqual(*otherTarget, targets[3].Target), "other target does not match")
+	assert.Equal(t, "targets/level1", targets[3].Role)
 
 	// Also test GetTargetByName
 	newLatestTarget, err := repo.GetTargetByName("latest")
-	require.NoError(t, err)
-	require.True(t, reflect.DeepEqual(*latestTarget, newLatestTarget.Target), "latest target does not match")
-	require.Equal(t, data.CanonicalTargetsRole, newLatestTarget.Role)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(*latestTarget, newLatestTarget.Target), "latest target does not match")
+	assert.Equal(t, data.CanonicalTargetsRole, newLatestTarget.Role)
 
 	newCurrentTarget, err := repo.GetTargetByName("current", "targets/level1", "targets")
-	require.NoError(t, err)
-	require.True(t, reflect.DeepEqual(*delegatedTarget, newCurrentTarget.Target), "current target does not match")
-	require.Equal(t, "targets/level1", newCurrentTarget.Role)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(*delegatedTarget, newCurrentTarget.Target), "current target does not match")
+	assert.Equal(t, "targets/level1", newCurrentTarget.Role)
 
 	newOtherTarget, err := repo.GetTargetByName("other")
-	require.NoError(t, err)
-	require.True(t, reflect.DeepEqual(*otherTarget, newOtherTarget.Target), "other target does not match")
-	require.Equal(t, "targets/level1", newOtherTarget.Role)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(*otherTarget, newOtherTarget.Target), "other target does not match")
+	assert.Equal(t, "targets/level1", newOtherTarget.Role)
 
 	newLevel2Target, err := repo.GetTargetByName("level2")
-	require.NoError(t, err)
-	require.True(t, reflect.DeepEqual(*level2Target, newLevel2Target.Target), "level2 target does not match")
-	require.Equal(t, "targets/level2", newLevel2Target.Role)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(*level2Target, newLevel2Target.Target), "level2 target does not match")
+	assert.Equal(t, "targets/level2", newLevel2Target.Role)
 }
 
 // TestValidateRootKey verifies that the public data in root.json for the root
@@ -1071,15 +1071,15 @@ func testValidateRootKey(t *testing.T, rootType string) {
 		"metadata", "root.json")
 
 	jsonBytes, err := ioutil.ReadFile(rootJSONFile)
-	require.NoError(t, err, "error reading TUF metadata file %s: %s", rootJSONFile, err)
+	assert.NoError(t, err, "error reading TUF metadata file %s: %s", rootJSONFile, err)
 
 	var decoded data.Signed
 	err = json.Unmarshal(jsonBytes, &decoded)
-	require.NoError(t, err, "error parsing TUF metadata file %s: %s", rootJSONFile, err)
+	assert.NoError(t, err, "error parsing TUF metadata file %s: %s", rootJSONFile, err)
 
 	var decodedRoot data.Root
 	err = json.Unmarshal(decoded.Signed, &decodedRoot)
-	require.NoError(t, err, "error parsing root.json signed section: %s", err)
+	assert.NoError(t, err, "error parsing root.json signed section: %s", err)
 
 	keyids := []string{}
 	for role, roleData := range decodedRoot.Roles {
@@ -1087,13 +1087,13 @@ func testValidateRootKey(t *testing.T, rootType string) {
 			keyids = append(keyids, roleData.KeyIDs...)
 		}
 	}
-	require.NotEmpty(t, keyids)
+	assert.NotEmpty(t, keyids)
 
 	for _, keyid := range keyids {
 		key, ok := decodedRoot.Keys[keyid]
-		require.True(t, ok, "key id not found in keys")
+		assert.True(t, ok, "key id not found in keys")
 		_, err := trustmanager.LoadCertFromPEM(key.Public())
-		require.NoError(t, err, "key is not a valid cert")
+		assert.NoError(t, err, "key is not a valid cert")
 	}
 }
 
@@ -1113,7 +1113,7 @@ func testGetChangelist(t *testing.T, rootType string) {
 
 	repo, _ := initializeRepo(t, rootType, "docker.com/notary", ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
-	require.Len(t, getChanges(t, repo), 0, "No changes should be in changelist yet")
+	assert.Len(t, getChanges(t, repo), 0, "No changes should be in changelist yet")
 
 	// Create 2 targets
 	addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
@@ -1121,7 +1121,7 @@ func testGetChangelist(t *testing.T, rootType string) {
 
 	// Test loading changelist
 	chgs := getChanges(t, repo)
-	require.Len(t, chgs, 2, "Wrong number of changes returned from changelist")
+	assert.Len(t, chgs, 2, "Wrong number of changes returned from changelist")
 
 	changes := make(map[string]changelist.Change)
 	for _, ch := range chgs {
@@ -1129,18 +1129,18 @@ func testGetChangelist(t *testing.T, rootType string) {
 	}
 
 	currentChange := changes["current"]
-	require.NotNil(t, currentChange, "Expected changelist to contain a change for path 'current'")
-	require.EqualValues(t, changelist.ActionCreate, currentChange.Action())
-	require.Equal(t, "targets", currentChange.Scope())
-	require.Equal(t, "target", currentChange.Type())
-	require.Equal(t, "current", currentChange.Path())
+	assert.NotNil(t, currentChange, "Expected changelist to contain a change for path 'current'")
+	assert.EqualValues(t, changelist.ActionCreate, currentChange.Action())
+	assert.Equal(t, "targets", currentChange.Scope())
+	assert.Equal(t, "target", currentChange.Type())
+	assert.Equal(t, "current", currentChange.Path())
 
 	latestChange := changes["latest"]
-	require.NotNil(t, latestChange, "Expected changelist to contain a change for path 'latest'")
-	require.EqualValues(t, changelist.ActionCreate, latestChange.Action())
-	require.Equal(t, "targets", latestChange.Scope())
-	require.Equal(t, "target", latestChange.Type())
-	require.Equal(t, "latest", latestChange.Path())
+	assert.NotNil(t, latestChange, "Expected changelist to contain a change for path 'latest'")
+	assert.EqualValues(t, changelist.ActionCreate, latestChange.Action())
+	assert.Equal(t, "targets", latestChange.Scope())
+	assert.Equal(t, "target", latestChange.Type())
+	assert.Equal(t, "latest", latestChange.Path())
 }
 
 // Create a repo, instantiate a notary server, and publish the bare repo to the
@@ -1162,20 +1162,20 @@ func testPublishNoData(t *testing.T, rootType string, serverManagesSnapshot bool
 	repo1, _ := initializeRepo(t, rootType, "docker.com/notary", ts.URL,
 		serverManagesSnapshot)
 	defer os.RemoveAll(repo1.baseDir)
-	require.NoError(t, repo1.Publish())
+	assert.NoError(t, repo1.Publish())
 
 	// use another repo to check metadata
 	repo2 := newRepoToTestRepo(t, repo1)
 	defer os.RemoveAll(repo2.baseDir)
 
 	targets, err := repo2.ListTargets()
-	require.NoError(t, err)
-	require.Empty(t, targets)
+	assert.NoError(t, err)
+	assert.Empty(t, targets)
 
 	for _, role := range data.BaseRoles {
 		// we don't cache timstamp metadata
 		if role != data.CanonicalTimestampRole {
-			requireRepoHasExpectedMetadata(t, repo2, role, true)
+			assertRepoHasExpectedMetadata(t, repo2, role, true)
 		}
 	}
 }
@@ -1189,32 +1189,32 @@ func TestPublishUninitializedRepo(t *testing.T) {
 
 	// uninitialized repo should fail to publish
 	tempBaseDir, err := ioutil.TempDir("", "notary-tests")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	repo, err := NewNotaryRepository(tempBaseDir, gun, ts.URL,
 		http.DefaultTransport, passphraseRetriever)
-	require.NoError(t, err, "error creating repository: %s", err)
+	assert.NoError(t, err, "error creating repository: %s", err)
 	err = repo.Publish()
-	require.Error(t, err)
+	assert.Error(t, err)
 
 	// no metadata created
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, false)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, false)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, false)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, false)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, false)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, false)
 
 	// now, initialize and republish in the same directory
 	rootPubKey, err := repo.CryptoService.Create("root", data.ECDSAKey)
-	require.NoError(t, err, "error generating root key: %s", err)
+	assert.NoError(t, err, "error generating root key: %s", err)
 
-	require.NoError(t, repo.Initialize(rootPubKey.ID()))
+	assert.NoError(t, repo.Initialize(rootPubKey.ID()))
 
 	// now metadata is created
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, true)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, true)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, true)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, true)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
 
-	require.NoError(t, repo.Publish())
+	assert.NoError(t, repo.Publish())
 }
 
 // Create a repo, instantiate a notary server, and publish the repo with
@@ -1245,18 +1245,18 @@ func testPublishWithData(t *testing.T, rootType string, serverManagesSnapshot bo
 	repo, _ := initializeRepo(t, rootType, "docker.com/notary", ts.URL,
 		serverManagesSnapshot)
 	defer os.RemoveAll(repo.baseDir)
-	requirePublishSucceeds(t, repo)
+	assertPublishSucceeds(t, repo)
 }
 
-// requires that publish succeeds by adding to the default only and publishing;
+// asserts that publish succeeds by adding to the default only and publishing;
 // the targets should appear in targets
-func requirePublishSucceeds(t *testing.T, repo1 *NotaryRepository) {
-	requirePublishToRolesSucceeds(t, repo1, nil, []string{data.CanonicalTargetsRole})
+func assertPublishSucceeds(t *testing.T, repo1 *NotaryRepository) {
+	assertPublishToRolesSucceeds(t, repo1, nil, []string{data.CanonicalTargetsRole})
 }
 
-// requires that adding to the given roles results in the targets actually being
+// asserts that adding to the given roles results in the targets actually being
 // added only to the expected roles and no others
-func requirePublishToRolesSucceeds(t *testing.T, repo1 *NotaryRepository,
+func assertPublishToRolesSucceeds(t *testing.T, repo1 *NotaryRepository,
 	publishToRoles []string, expectedPublishedRoles []string) {
 
 	// were there unpublished changes before?
@@ -1272,13 +1272,13 @@ func requirePublishToRolesSucceeds(t *testing.T, repo1 *NotaryRepository,
 
 	// if no roles are provided, the default role is target
 	numRoles := int(math.Max(1, float64(len(publishToRoles))))
-	require.Len(t, getChanges(t, repo1), changesOffset+4*numRoles,
+	assert.Len(t, getChanges(t, repo1), changesOffset+4*numRoles,
 		"wrong number of changelist files found")
 
 	// Now test Publish
 	err := repo1.Publish()
-	require.NoError(t, err)
-	require.Len(t, getChanges(t, repo1), 0, "wrong number of changelist files found")
+	assert.NoError(t, err)
+	assert.Len(t, getChanges(t, repo1), 0, "wrong number of changelist files found")
 
 	// use another repo to check metadata
 	repo2 := newRepoToTestRepo(t, repo1)
@@ -1288,28 +1288,28 @@ func requirePublishToRolesSucceeds(t *testing.T, repo1 *NotaryRepository,
 	for _, role := range expectedPublishedRoles {
 		for _, repo := range []*NotaryRepository{repo1, repo2} {
 			targets, err := repo.ListTargets(role)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			require.Len(t, targets, 2,
+			assert.Len(t, targets, 2,
 				"unexpected number of targets returned by ListTargets(%s)", role)
 
 			sort.Stable(targetSorter(targets))
 
-			require.True(t, reflect.DeepEqual(*currentTarget, targets[0].Target), "current target does not match")
-			require.Equal(t, role, targets[0].Role)
-			require.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
-			require.Equal(t, role, targets[1].Role)
+			assert.True(t, reflect.DeepEqual(*currentTarget, targets[0].Target), "current target does not match")
+			assert.Equal(t, role, targets[0].Role)
+			assert.True(t, reflect.DeepEqual(*latestTarget, targets[1].Target), "latest target does not match")
+			assert.Equal(t, role, targets[1].Role)
 
 			// Also test GetTargetByName
 			newLatestTarget, err := repo.GetTargetByName("latest", role)
-			require.NoError(t, err)
-			require.True(t, reflect.DeepEqual(*latestTarget, newLatestTarget.Target), "latest target does not match")
-			require.Equal(t, role, newLatestTarget.Role)
+			assert.NoError(t, err)
+			assert.True(t, reflect.DeepEqual(*latestTarget, newLatestTarget.Target), "latest target does not match")
+			assert.Equal(t, role, newLatestTarget.Role)
 
 			newCurrentTarget, err := repo.GetTargetByName("current", role)
-			require.NoError(t, err)
-			require.True(t, reflect.DeepEqual(*currentTarget, newCurrentTarget.Target), "current target does not match")
-			require.Equal(t, role, newCurrentTarget.Role)
+			assert.NoError(t, err)
+			assert.True(t, reflect.DeepEqual(*currentTarget, newCurrentTarget.Target), "current target does not match")
+			assert.Equal(t, role, newCurrentTarget.Role)
 		}
 	}
 }
@@ -1332,30 +1332,30 @@ func testPublishAfterPullServerHasSnapshotKey(t *testing.T, rootType string) {
 	repo, _ := initializeRepo(t, rootType, "docker.com/notary", ts.URL, true)
 	defer os.RemoveAll(repo.baseDir)
 	// no timestamp metadata because that comes from the server
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTimestampRole, false)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalTimestampRole, false)
 	// no snapshot metadata because that comes from the server
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, false)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, false)
 
 	// Publish something
 	published := addTarget(t, repo, "v1", "../fixtures/intermediate-ca.crt")
-	require.NoError(t, repo.Publish())
+	assert.NoError(t, repo.Publish())
 
 	// still no timestamp or snapshot metadata info
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTimestampRole, false)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, false)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalTimestampRole, false)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, false)
 
 	// list, so that the snapshot metadata is pulled from server
 	targets, err := repo.ListTargets(data.CanonicalTargetsRole)
-	require.NoError(t, err)
-	require.Equal(t, []*TargetWithRole{{Target: *published, Role: data.CanonicalTargetsRole}}, targets)
+	assert.NoError(t, err)
+	assert.Equal(t, []*TargetWithRole{{Target: *published, Role: data.CanonicalTargetsRole}}, targets)
 	// listing downloaded the timestamp and snapshot metadata info
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTimestampRole, true)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, true)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalTimestampRole, true)
+	assertRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, true)
 
 	// Publish again should succeed
 	addTarget(t, repo, "v2", "../fixtures/intermediate-ca.crt")
 	err = repo.Publish()
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 // If neither the client nor the server has the snapshot key, signing will fail
@@ -1377,7 +1377,7 @@ func testPublishNoOneHasSnapshotKey(t *testing.T, rootType string) {
 	defer os.RemoveAll(repo.baseDir)
 
 	snapshotRole, ok := repo.tufRepo.Root.Signed.Roles[data.CanonicalSnapshotRole]
-	require.True(t, ok)
+	assert.True(t, ok)
 	for _, keyID := range snapshotRole.KeyIDs {
 		repo.CryptoService.RemoveKey(keyID)
 	}
@@ -1385,8 +1385,8 @@ func testPublishNoOneHasSnapshotKey(t *testing.T, rootType string) {
 	// Publish something
 	addTarget(t, repo, "v1", "../fixtures/intermediate-ca.crt")
 	err := repo.Publish()
-	require.Error(t, err)
-	require.IsType(t, validation.ErrBadHierarchy{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, validation.ErrBadHierarchy{}, err)
 }
 
 // If the snapshot metadata is corrupt or the snapshot metadata is unreadable,
@@ -1467,7 +1467,7 @@ func testPublishBadMetadata(t *testing.T, roleName string, repo *NotaryRepositor
 	publishFirst, succeeds bool) {
 
 	if publishFirst {
-		require.NoError(t, repo.Publish())
+		assert.NoError(t, repo.Publish())
 	}
 
 	addTarget(t, repo, "v1", "../fixtures/intermediate-ca.crt")
@@ -1476,10 +1476,10 @@ func testPublishBadMetadata(t *testing.T, roleName string, repo *NotaryRepositor
 	repo.fileStore.SetMeta(roleName, []byte("this isn't JSON"))
 	err := repo.Publish()
 	if succeeds {
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	} else {
-		require.Error(t, err)
-		require.IsType(t, &json.SyntaxError{}, err)
+		assert.Error(t, err)
+		assert.IsType(t, &regJson.SyntaxError{}, err)
 	}
 
 	// make an unreadable file by creating a directory instead of a file
@@ -1487,15 +1487,15 @@ func testPublishBadMetadata(t *testing.T, roleName string, repo *NotaryRepositor
 		filepath.Join(repo.baseDir, tufDir, filepath.FromSlash(repo.gun),
 			"metadata", roleName), "json")
 	os.RemoveAll(path)
-	require.NoError(t, os.Mkdir(path, 0755))
+	assert.NoError(t, os.Mkdir(path, 0755))
 	defer os.RemoveAll(path)
 
 	err = repo.Publish()
 	if succeeds {
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	} else {
-		require.Error(t, err)
-		require.IsType(t, &os.PathError{}, err)
+		assert.Error(t, err)
+		assert.IsType(t, &os.PathError{}, err)
 	}
 }
 
@@ -1504,7 +1504,7 @@ func TestNotInitializedOnPublish(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	gun := "docker.com/notary"
 	ts := fullTestServer(t)
@@ -1515,8 +1515,8 @@ func TestNotInitializedOnPublish(t *testing.T) {
 	addTarget(t, repo, "v1", "../fixtures/intermediate-ca.crt")
 
 	err = repo.Publish()
-	require.Error(t, err)
-	require.IsType(t, ErrRepoNotInitialized{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, ErrRepoNotInitialized{}, err)
 }
 
 type cannotCreateKeys struct {
@@ -1533,7 +1533,7 @@ func TestPublishSnapshotLocalKeysCreatedFirst(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 	gun := "docker.com/notary"
 
 	requestMade := false
@@ -1543,20 +1543,20 @@ func TestPublishSnapshotLocalKeysCreatedFirst(t *testing.T) {
 
 	repo, err := NewNotaryRepository(
 		tempBaseDir, gun, ts.URL, http.DefaultTransport, passphraseRetriever)
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 
 	cs := cryptoservice.NewCryptoService(gun,
 		trustmanager.NewKeyMemoryStore(passphraseRetriever))
 
 	rootPubKey, err := cs.Create(data.CanonicalRootRole, data.ECDSAKey)
-	require.NoError(t, err, "error generating root key: %s", err)
+	assert.NoError(t, err, "error generating root key: %s", err)
 
 	repo.CryptoService = cannotCreateKeys{CryptoService: cs}
 
 	err = repo.Initialize(rootPubKey.ID(), data.CanonicalSnapshotRole)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Oh no I cannot create keys")
-	require.False(t, requestMade)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Oh no I cannot create keys")
+	assert.False(t, requestMade)
 }
 
 // Publishing delegations works so long as the delegation parent exists by the
@@ -1572,26 +1572,26 @@ func TestPublishDelegations(t *testing.T) {
 	defer os.RemoveAll(repo1.baseDir)
 
 	delgKey, err := repo1.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	// This should publish fine, even though targets/a/b is dependent upon
 	// targets/a, because these should execute in order
 	for _, delgName := range []string{"targets/a", "targets/a/b", "targets/c"} {
-		require.NoError(t,
+		assert.NoError(t,
 			repo1.AddDelegation(delgName, 1, []data.PublicKey{delgKey}, []string{""}),
 			"error creating delegation")
 	}
-	require.Len(t, getChanges(t, repo1), 3, "wrong number of changelist files found")
-	require.NoError(t, repo1.Publish())
-	require.Len(t, getChanges(t, repo1), 0, "wrong number of changelist files found")
+	assert.Len(t, getChanges(t, repo1), 3, "wrong number of changelist files found")
+	assert.NoError(t, repo1.Publish())
+	assert.Len(t, getChanges(t, repo1), 0, "wrong number of changelist files found")
 
 	// this should not publish, because targets/z doesn't exist
-	require.NoError(t,
+	assert.NoError(t,
 		repo1.AddDelegation("targets/z/y", 1, []data.PublicKey{delgKey}, []string{""}),
 		"error creating delegation")
-	require.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
-	require.Error(t, repo1.Publish())
-	require.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
+	assert.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
+	assert.Error(t, repo1.Publish())
+	assert.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
 
 	// use another repo to check metadata
 	repo2 := newRepoToTestRepo(t, repo1)
@@ -1599,33 +1599,33 @@ func TestPublishDelegations(t *testing.T) {
 
 	// pull
 	_, err = repo2.ListTargets()
-	require.NoError(t, err, "unable to pull repo")
+	assert.NoError(t, err, "unable to pull repo")
 
 	for _, repo := range []*NotaryRepository{repo1, repo2} {
 		// targets should have delegations targets/a and targets/c
 		targets := repo.tufRepo.Targets[data.CanonicalTargetsRole]
-		require.Len(t, targets.Signed.Delegations.Roles, 2)
-		require.Len(t, targets.Signed.Delegations.Keys, 1)
+		assert.Len(t, targets.Signed.Delegations.Roles, 2)
+		assert.Len(t, targets.Signed.Delegations.Keys, 1)
 
 		_, ok := targets.Signed.Delegations.Keys[delgKey.ID()]
-		require.True(t, ok)
+		assert.True(t, ok)
 
 		foundRoleNames := make(map[string]bool)
 		for _, r := range targets.Signed.Delegations.Roles {
 			foundRoleNames[r.Name] = true
 		}
-		require.True(t, foundRoleNames["targets/a"])
-		require.True(t, foundRoleNames["targets/c"])
+		assert.True(t, foundRoleNames["targets/a"])
+		assert.True(t, foundRoleNames["targets/c"])
 
 		// targets/a should have delegation targets/a/b only
 		a := repo.tufRepo.Targets["targets/a"]
-		require.Len(t, a.Signed.Delegations.Roles, 1)
-		require.Len(t, a.Signed.Delegations.Keys, 1)
+		assert.Len(t, a.Signed.Delegations.Roles, 1)
+		assert.Len(t, a.Signed.Delegations.Keys, 1)
 
 		_, ok = a.Signed.Delegations.Keys[delgKey.ID()]
-		require.True(t, ok)
+		assert.True(t, ok)
 
-		require.Equal(t, "targets/a/b", a.Signed.Delegations.Roles[0].Name)
+		assert.Equal(t, "targets/a/b", a.Signed.Delegations.Roles[0].Name)
 	}
 }
 
@@ -1642,35 +1642,35 @@ func TestPublishDelegationsX509(t *testing.T) {
 	defer os.RemoveAll(repo1.baseDir)
 
 	delgKey, err := repo1.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	start := time.Now()
 	privKey, _, err := repo1.CryptoService.GetPrivateKey(delgKey.ID())
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	cert, err := cryptoservice.GenerateCertificate(
 		privKey, "targets/a", start, start.AddDate(1, 0, 0),
 	)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	delgCert := data.NewECDSAx509PublicKey(trustmanager.CertToPEM(cert))
 
 	// This should publish fine, even though targets/a/b is dependent upon
 	// targets/a, because these should execute in order
 	for _, delgName := range []string{"targets/a", "targets/a/b", "targets/c"} {
-		require.NoError(t,
+		assert.NoError(t,
 			repo1.AddDelegation(delgName, 1, []data.PublicKey{delgCert}, []string{""}),
 			"error creating delegation")
 	}
-	require.Len(t, getChanges(t, repo1), 3, "wrong number of changelist files found")
-	require.NoError(t, repo1.Publish())
-	require.Len(t, getChanges(t, repo1), 0, "wrong number of changelist files found")
+	assert.Len(t, getChanges(t, repo1), 3, "wrong number of changelist files found")
+	assert.NoError(t, repo1.Publish())
+	assert.Len(t, getChanges(t, repo1), 0, "wrong number of changelist files found")
 
 	// this should not publish, because targets/z doesn't exist
-	require.NoError(t,
+	assert.NoError(t,
 		repo1.AddDelegation("targets/z/y", 1, []data.PublicKey{delgCert}, []string{""}),
 		"error creating delegation")
-	require.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
-	require.Error(t, repo1.Publish())
-	require.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
+	assert.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
+	assert.Error(t, repo1.Publish())
+	assert.Len(t, getChanges(t, repo1), 1, "wrong number of changelist files found")
 
 	// Create a new repo and pull from the server
 	repo2 := newRepoToTestRepo(t, repo1)
@@ -1678,33 +1678,33 @@ func TestPublishDelegationsX509(t *testing.T) {
 
 	// pull
 	_, err = repo2.ListTargets()
-	require.NoError(t, err, "unable to pull repo")
+	assert.NoError(t, err, "unable to pull repo")
 
 	for _, repo := range []*NotaryRepository{repo1, repo2} {
 		// targets should have delegations targets/a and targets/c
 		targets := repo.tufRepo.Targets[data.CanonicalTargetsRole]
-		require.Len(t, targets.Signed.Delegations.Roles, 2)
-		require.Len(t, targets.Signed.Delegations.Keys, 1)
+		assert.Len(t, targets.Signed.Delegations.Roles, 2)
+		assert.Len(t, targets.Signed.Delegations.Keys, 1)
 
 		_, ok := targets.Signed.Delegations.Keys[delgCert.ID()]
-		require.True(t, ok)
+		assert.True(t, ok)
 
 		foundRoleNames := make(map[string]bool)
 		for _, r := range targets.Signed.Delegations.Roles {
 			foundRoleNames[r.Name] = true
 		}
-		require.True(t, foundRoleNames["targets/a"])
-		require.True(t, foundRoleNames["targets/c"])
+		assert.True(t, foundRoleNames["targets/a"])
+		assert.True(t, foundRoleNames["targets/c"])
 
 		// targets/a should have delegation targets/a/b only
 		a := repo.tufRepo.Targets["targets/a"]
-		require.Len(t, a.Signed.Delegations.Roles, 1)
-		require.Len(t, a.Signed.Delegations.Keys, 1)
+		assert.Len(t, a.Signed.Delegations.Roles, 1)
+		assert.Len(t, a.Signed.Delegations.Keys, 1)
 
 		_, ok = a.Signed.Delegations.Keys[delgCert.ID()]
-		require.True(t, ok)
+		assert.True(t, ok)
 
-		require.Equal(t, "targets/a/b", a.Signed.Delegations.Roles[0].Name)
+		assert.Equal(t, "targets/a/b", a.Signed.Delegations.Roles[0].Name)
 	}
 }
 
@@ -1719,7 +1719,7 @@ func TestPublishTargetsDelgationScopeFallback(t *testing.T) {
 
 	repo, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary", ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
-	requirePublishToRolesSucceeds(t, repo, []string{"targets/a/b", "targets/b/c"},
+	assertPublishToRolesSucceeds(t, repo, []string{"targets/a/b", "targets/b/c"},
 		[]string{data.CanonicalTargetsRole})
 }
 
@@ -1735,25 +1735,25 @@ func TestPublishTargetsDelgationScopeNoFallbackIfNoKeys(t *testing.T) {
 	// generate a key that isn't in the cryptoservice, so we can't sign this
 	// one
 	aPrivKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	require.NoError(t, err, "error generating key that is not in our cryptoservice")
+	assert.NoError(t, err, "error generating key that is not in our cryptoservice")
 	aPubKey := data.PublicKeyFromPrivate(aPrivKey)
 
 	// ensure that the role exists
-	require.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{aPubKey}, []string{""}))
-	require.NoError(t, repo.Publish())
+	assert.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{aPubKey}, []string{""}))
+	assert.NoError(t, repo.Publish())
 
 	// add a target to targets/a/b - no role b, so it falls back on a, which
 	// exists but there is no signing key for
 	addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt", "targets/a/b")
-	require.Len(t, getChanges(t, repo), 1, "wrong number of changelist files found")
+	assert.Len(t, getChanges(t, repo), 1, "wrong number of changelist files found")
 
 	// Now Publish should fail
-	require.Error(t, repo.Publish())
-	require.Len(t, getChanges(t, repo), 1, "wrong number of changelist files found")
+	assert.Error(t, repo.Publish())
+	assert.Len(t, getChanges(t, repo), 1, "wrong number of changelist files found")
 
 	targets, err := repo.ListTargets("targets", "targets/a", "targets/a/b")
-	require.NoError(t, err)
-	require.Empty(t, targets)
+	assert.NoError(t, err)
+	assert.Empty(t, targets)
 }
 
 // If a changelist specifies a particular role to push targets to, and such
@@ -1769,15 +1769,15 @@ func TestPublishTargetsDelgationSuccessLocallyHasRoles(t *testing.T) {
 	defer os.RemoveAll(repo.baseDir)
 
 	delgKey, err := repo.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	for _, delgName := range []string{"targets/a", "targets/a/b"} {
-		require.NoError(t,
+		assert.NoError(t,
 			repo.AddDelegation(delgName, 1, []data.PublicKey{delgKey}, []string{""}),
 			"error creating delegation")
 	}
 
-	requirePublishToRolesSucceeds(t, repo, []string{"targets/a/b"},
+	assertPublishToRolesSucceeds(t, repo, []string{"targets/a/b"},
 		[]string{"targets/a/b"})
 }
 
@@ -1792,21 +1792,21 @@ func TestPublishTargetsDelgationNoTargetsKeyNeeded(t *testing.T) {
 	defer os.RemoveAll(repo.baseDir)
 
 	delgKey, err := repo.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	for _, delgName := range []string{"targets/a", "targets/a/b"} {
-		require.NoError(t,
+		assert.NoError(t,
 			repo.AddDelegation(delgName, 1, []data.PublicKey{delgKey}, []string{""}),
 			"error creating delegation")
 	}
-	require.NoError(t, repo.Publish())
+	assert.NoError(t, repo.Publish())
 
 	// remove targets key - it is not even needed
 	targetsKeys := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
-	require.Len(t, targetsKeys, 1)
-	require.NoError(t, repo.CryptoService.RemoveKey(targetsKeys[0]))
+	assert.Len(t, targetsKeys, 1)
+	assert.NoError(t, repo.CryptoService.RemoveKey(targetsKeys[0]))
 
-	requirePublishToRolesSucceeds(t, repo, []string{"targets/a/b"},
+	assertPublishToRolesSucceeds(t, repo, []string{"targets/a/b"},
 		[]string{"targets/a/b"})
 }
 
@@ -1835,25 +1835,25 @@ func TestPublishTargetsDelgationSuccessNeedsToDownloadRoles(t *testing.T) {
 
 	// create a key on the owner repo
 	aKey, err := ownerRepo.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	// create a key on the delegated repo
 	bKey, err := delgRepo.CryptoService.Create("targets/a/b", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	// owner creates delegations, adds the delegated key to them, and publishes them
-	require.NoError(t,
+	assert.NoError(t,
 		ownerRepo.AddDelegation("targets/a", 1, []data.PublicKey{aKey}, []string{""}),
 		"error creating delegation")
-	require.NoError(t,
+	assert.NoError(t,
 		ownerRepo.AddDelegation("targets/a/b", 1, []data.PublicKey{bKey}, []string{""}),
 		"error creating delegation")
 
-	require.NoError(t, ownerRepo.Publish())
+	assert.NoError(t, ownerRepo.Publish())
 
 	// delegated repo now publishes to delegated roles, but it will need
 	// to download those roles first, since it doesn't know about them
-	requirePublishToRolesSucceeds(t, delgRepo, []string{"targets/a/b"},
+	assertPublishToRolesSucceeds(t, delgRepo, []string{"targets/a/b"},
 		[]string{"targets/a/b"})
 }
 
@@ -1874,34 +1874,34 @@ func TestPublishTargetsDelgationFromTwoRepos(t *testing.T) {
 
 	// create keys for each repo
 	key1, err := repo1.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	// create a key on the delegated repo
 	key2, err := repo2.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	// delegation includes both keys
-	require.NoError(t,
+	assert.NoError(t,
 		repo1.AddDelegation("targets/a", 1, []data.PublicKey{key1, key2}, []string{""}),
 		"error creating delegation")
 
-	require.NoError(t, repo1.Publish())
+	assert.NoError(t, repo1.Publish())
 
 	// both repos add targets and publish
 	addTarget(t, repo1, "first", "../fixtures/root-ca.crt", "targets/a")
-	require.NoError(t, repo1.Publish())
+	assert.NoError(t, repo1.Publish())
 	addTarget(t, repo2, "second", "../fixtures/root-ca.crt", "targets/a")
-	require.NoError(t, repo2.Publish())
+	assert.NoError(t, repo2.Publish())
 
 	// first repo can publish again
 	addTarget(t, repo1, "third", "../fixtures/root-ca.crt", "targets/a")
-	require.NoError(t, repo1.Publish())
+	assert.NoError(t, repo1.Publish())
 
 	// both repos should be able to see all targets
 	for _, repo := range []*NotaryRepository{repo1, repo2} {
 		targets, err := repo.ListTargets()
-		require.NoError(t, err)
-		require.Len(t, targets, 3)
+		assert.NoError(t, err)
+		assert.Len(t, targets, 3)
 
 		found := make(map[string]bool)
 		for _, t := range targets {
@@ -1910,7 +1910,7 @@ func TestPublishTargetsDelgationFromTwoRepos(t *testing.T) {
 
 		for _, targetName := range []string{"first", "second", "third"} {
 			_, ok := found[targetName]
-			require.True(t, ok)
+			assert.True(t, ok)
 		}
 	}
 }
@@ -1935,31 +1935,31 @@ func TestPublishRemoveDelgationKeyFromDelegationRole(t *testing.T) {
 
 	// create a key on the delegated repo
 	aKey, err := delgRepo.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	// owner creates delegation, adds the delegated key to it, and publishes it
-	require.NoError(t,
+	assert.NoError(t,
 		ownerRepo.AddDelegation("targets/a", 1, []data.PublicKey{aKey}, []string{""}),
 		"error creating delegation")
-	require.NoError(t, ownerRepo.Publish())
+	assert.NoError(t, ownerRepo.Publish())
 
 	// delegated repo can now publish to delegated role
 	addTarget(t, delgRepo, "v1", "../fixtures/root-ca.crt", "targets/a")
-	require.NoError(t, delgRepo.Publish())
+	assert.NoError(t, delgRepo.Publish())
 
 	// owner revokes delegation
 	// note there is no removekeyfromdelegation yet, so here's a hack to do so
 	newKey, err := ownerRepo.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	tdJSON, err := json.Marshal(&changelist.TufDelegation{
 		NewThreshold: 1,
 		AddKeys:      data.KeyList([]data.PublicKey{newKey}),
 		RemoveKeys:   []string{aKey.ID()},
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	cl, err := changelist.NewFileChangelist(filepath.Join(ownerRepo.tufRepoPath, "changelist"))
-	require.NoError(t, cl.Add(changelist.NewTufChange(
+	assert.NoError(t, cl.Add(changelist.NewTufChange(
 		changelist.ActionUpdate,
 		"targets/a",
 		changelist.TypeTargetsDelegation,
@@ -1967,11 +1967,11 @@ func TestPublishRemoveDelgationKeyFromDelegationRole(t *testing.T) {
 		tdJSON,
 	)))
 	cl.Close()
-	require.NoError(t, ownerRepo.Publish())
+	assert.NoError(t, ownerRepo.Publish())
 
 	// delegated repo can now no longer publish to delegated role
 	addTarget(t, delgRepo, "v2", "../fixtures/root-ca.crt", "targets/a")
-	require.Error(t, delgRepo.Publish())
+	assert.Error(t, delgRepo.Publish())
 }
 
 // A client who could publish before can no longer publish once the owner
@@ -1993,25 +1993,25 @@ func TestPublishRemoveDelgation(t *testing.T) {
 
 	// create a key on the delegated repo
 	aKey, err := delgRepo.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
 	// owner creates delegation, adds the delegated key to it, and publishes it
-	require.NoError(t,
+	assert.NoError(t,
 		ownerRepo.AddDelegation("targets/a", 1, []data.PublicKey{aKey}, []string{""}),
 		"error creating delegation")
-	require.NoError(t, ownerRepo.Publish())
+	assert.NoError(t, ownerRepo.Publish())
 
 	// delegated repo can now publish to delegated role
 	addTarget(t, delgRepo, "v1", "../fixtures/root-ca.crt", "targets/a")
-	require.NoError(t, delgRepo.Publish())
+	assert.NoError(t, delgRepo.Publish())
 
 	// owner removes delegation
-	require.NoError(t, ownerRepo.RemoveDelegation("targets/a"))
-	require.NoError(t, ownerRepo.Publish())
+	assert.NoError(t, ownerRepo.RemoveDelegation("targets/a"))
+	assert.NoError(t, ownerRepo.Publish())
 
 	// delegated repo can now no longer publish to delegated role
 	addTarget(t, delgRepo, "v2", "../fixtures/root-ca.crt", "targets/a")
-	require.Error(t, delgRepo.Publish())
+	assert.Error(t, delgRepo.Publish())
 }
 
 // If the delegation data is corrupt or unreadable, it doesn't matter because
@@ -2026,9 +2026,9 @@ func TestPublishSucceedsDespiteDelegationCorrupt(t *testing.T) {
 	defer os.RemoveAll(repo.baseDir)
 
 	delgKey, err := repo.CryptoService.Create("targets/a", data.ECDSAKey)
-	require.NoError(t, err, "error creating delegation key")
+	assert.NoError(t, err, "error creating delegation key")
 
-	require.NoError(t,
+	assert.NoError(t,
 		repo.AddDelegation("targets/a", 1, []data.PublicKey{delgKey}, []string{""}),
 		"error creating delegation")
 
@@ -2058,7 +2058,7 @@ func TestRotateKeyInvalidRole(t *testing.T) {
 				continue
 			}
 			err := repo.RotateKey(role, serverManagesKey)
-			require.Error(t, err,
+			assert.Error(t, err,
 				"Rotating a %s key with server-managing the key as %v should fail",
 				role, serverManagesKey)
 		}
@@ -2066,8 +2066,8 @@ func TestRotateKeyInvalidRole(t *testing.T) {
 }
 
 // Rotates the keys.  After the rotation, downloading the latest metadata
-// and require that the keys have changed
-func requireRotationSuccessful(t *testing.T, repo1 *NotaryRepository,
+// and assert that the keys have changed
+func assertRotationSuccessful(t *testing.T, repo1 *NotaryRepository,
 	keysToRotate map[string]bool, alreadyPublished bool) {
 	// Create 2 new repos:  1 will download repo data before the publish,
 	// and one only downloads after the publish. This reflects a client
@@ -2084,7 +2084,7 @@ func requireRotationSuccessful(t *testing.T, repo1 *NotaryRepository,
 
 		// force a pull on repo3
 		_, err := repo3.GetTargetByName("latest")
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		repos = append(repos, repo3)
 	}
@@ -2097,29 +2097,29 @@ func requireRotationSuccessful(t *testing.T, repo1 *NotaryRepository,
 
 	// Do rotation
 	for role, serverManaged := range keysToRotate {
-		require.NoError(t, repo1.RotateKey(role, serverManaged))
+		assert.NoError(t, repo1.RotateKey(role, serverManaged))
 	}
 
 	// Publish
 	err := repo1.Publish()
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	// Download data from remote and check that keys have changed
 	for _, repo := range repos {
 		_, err := repo.GetTargetByName("latest") // force a pull
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		for role, isRemoteKey := range keysToRotate {
 			keyIDs := repo.tufRepo.Root.Signed.Roles[role].KeyIDs
-			require.Len(t, keyIDs, 1)
+			assert.Len(t, keyIDs, 1)
 
 			// the new key is not the same as any of the old keys, and the
 			// old keys have been removed not just from the TUF file, but
 			// from the cryptoservice
 			for _, oldKeyID := range oldKeyIDs[role] {
-				require.NotEqual(t, oldKeyID, keyIDs[0])
+				assert.NotEqual(t, oldKeyID, keyIDs[0])
 				_, _, err := repo.CryptoService.GetPrivateKey(oldKeyID)
-				require.Error(t, err)
+				assert.Error(t, err)
 			}
 
 			// On the old repo, the new key is present in the cryptoservice, or
@@ -2127,11 +2127,11 @@ func requireRotationSuccessful(t *testing.T, repo1 *NotaryRepository,
 			// cryptoservice
 			key, _, err := repo.CryptoService.GetPrivateKey(keyIDs[0])
 			if repo != repo1 || isRemoteKey {
-				require.Error(t, err)
-				require.Nil(t, key)
+				assert.Error(t, err)
+				assert.Nil(t, key)
 			} else {
-				require.NoError(t, err)
-				require.NotNil(t, key)
+				assert.NoError(t, err)
+				assert.NotNil(t, key)
 			}
 		}
 
@@ -2139,14 +2139,14 @@ func requireRotationSuccessful(t *testing.T, repo1 *NotaryRepository,
 		// after publishing changes, on repo2, there should never have been
 		// any changelists)
 		changes := getChanges(t, repo)
-		require.Len(t, changes, 0, "wrong number of changelist files found")
+		assert.Len(t, changes, 0, "wrong number of changelist files found")
 	}
 }
 
 // Initialize repo to have the server sign snapshots (remote snapshot key)
 // Without downloading a server-signed snapshot file, rotate keys so that
 //    snapshots are locally signed (local snapshot key)
-// require that we can publish.
+// Assert that we can publish.
 func TestRotateBeforePublishFromRemoteKeyToLocalKey(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
@@ -2157,7 +2157,7 @@ func TestRotateBeforePublishFromRemoteKeyToLocalKey(t *testing.T) {
 	// Adding a target will allow us to confirm the repository is still valid
 	// after rotating the keys.
 	addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
-	requireRotationSuccessful(t, repo, map[string]bool{
+	assertRotationSuccessful(t, repo, map[string]bool{
 		data.CanonicalTargetsRole:  false,
 		data.CanonicalSnapshotRole: false}, false)
 }
@@ -2165,7 +2165,7 @@ func TestRotateBeforePublishFromRemoteKeyToLocalKey(t *testing.T) {
 // Initialize a repo, locally signed snapshots
 // Publish some content (so that the server has a root.json), and download root.json
 // Rotate keys
-// Download the latest metadata and require that the keys have changed.
+// Download the latest metadata and assert that the keys have changed.
 func TestRotateKeyAfterPublishNoServerManagementChange(t *testing.T) {
 	// rotate a single target key
 	testRotateKeySuccess(t, false, map[string]bool{data.CanonicalTargetsRole: false})
@@ -2208,17 +2208,17 @@ func testRotateKeySuccess(t *testing.T, serverManagesSnapshotInit bool,
 	addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
 
 	// Publish
-	require.NoError(t, repo.Publish())
+	assert.NoError(t, repo.Publish())
 
 	// Get root.json and capture targets + snapshot key IDs
 	repo.GetTargetByName("latest") // force a pull
-	requireRotationSuccessful(t, repo, keysToRotate, true)
+	assertRotationSuccessful(t, repo, keysToRotate, true)
 }
 
 // If there is no local cache, notary operations return the remote error code
 func TestRemoteServerUnavailableNoLocalCache(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 
 	ts := errorTestServer(t, 500)
@@ -2226,19 +2226,19 @@ func TestRemoteServerUnavailableNoLocalCache(t *testing.T) {
 
 	repo, err := NewNotaryRepository(tempBaseDir, "docker.com/notary",
 		ts.URL, http.DefaultTransport, passphraseRetriever)
-	require.NoError(t, err, "error creating repo: %s", err)
+	assert.NoError(t, err, "error creating repo: %s", err)
 
 	_, err = repo.ListTargets(data.CanonicalTargetsRole)
-	require.Error(t, err)
-	require.IsType(t, store.ErrServerUnavailable{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, store.ErrServerUnavailable{}, err)
 
 	_, err = repo.GetTargetByName("targetName")
-	require.Error(t, err)
-	require.IsType(t, store.ErrServerUnavailable{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, store.ErrServerUnavailable{}, err)
 
 	err = repo.Publish()
-	require.Error(t, err)
-	require.IsType(t, store.ErrServerUnavailable{}, err)
+	assert.Error(t, err)
+	assert.IsType(t, store.ErrServerUnavailable{}, err)
 }
 
 // AddDelegation creates a valid changefile (rejects invalid delegation names,
@@ -2253,27 +2253,27 @@ func TestAddDelegationChangefileValid(t *testing.T) {
 	defer os.RemoveAll(repo.baseDir)
 
 	targetKeyIds := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
-	require.NotEmpty(t, targetKeyIds)
+	assert.NotEmpty(t, targetKeyIds)
 	targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
-	require.NotNil(t, targetPubKey)
+	assert.NotNil(t, targetPubKey)
 
 	err := repo.AddDelegation("root", 1, []data.PublicKey{targetPubKey}, []string{""})
-	require.Error(t, err)
-	require.IsType(t, data.ErrInvalidRole{}, err)
-	require.Empty(t, getChanges(t, repo))
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
+	assert.Empty(t, getChanges(t, repo))
 
 	// to show that adding does not care about the hierarchy
 	err = repo.AddDelegation("targets/a/b/c", 1, []data.PublicKey{targetPubKey}, []string{""})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	// ensure that the changefiles is correct
 	changes := getChanges(t, repo)
-	require.Len(t, changes, 1)
-	require.Equal(t, changelist.ActionCreate, changes[0].Action())
-	require.Equal(t, "targets/a/b/c", changes[0].Scope())
-	require.Equal(t, changelist.TypeTargetsDelegation, changes[0].Type())
-	require.Equal(t, "", changes[0].Path())
-	require.NotEmpty(t, changes[0].Content())
+	assert.Len(t, changes, 1)
+	assert.Equal(t, changelist.ActionCreate, changes[0].Action())
+	assert.Equal(t, "targets/a/b/c", changes[0].Scope())
+	assert.Equal(t, changelist.TypeTargetsDelegation, changes[0].Type())
+	assert.Equal(t, "", changes[0].Path())
+	assert.NotEmpty(t, changes[0].Content())
 }
 
 // The changefile produced by AddDelegation, when applied, actually adds
@@ -2288,31 +2288,31 @@ func TestAddDelegationChangefileApplicable(t *testing.T) {
 	defer os.RemoveAll(repo.baseDir)
 
 	targetKeyIds := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
-	require.NotEmpty(t, targetKeyIds)
+	assert.NotEmpty(t, targetKeyIds)
 	targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
-	require.NotNil(t, targetPubKey)
+	assert.NotNil(t, targetPubKey)
 
 	// this hierarchy has to be right to be applied
 	err := repo.AddDelegation("targets/a", 1, []data.PublicKey{targetPubKey}, []string{""})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	changes := getChanges(t, repo)
-	require.Len(t, changes, 1)
+	assert.Len(t, changes, 1)
 
 	// ensure that it can be applied correctly
 	err = applyTargetsChange(repo.tufRepo, changes[0])
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	targetRole := repo.tufRepo.Targets[data.CanonicalTargetsRole]
-	require.Len(t, targetRole.Signed.Delegations.Roles, 1)
-	require.Len(t, targetRole.Signed.Delegations.Keys, 1)
+	assert.Len(t, targetRole.Signed.Delegations.Roles, 1)
+	assert.Len(t, targetRole.Signed.Delegations.Keys, 1)
 
 	_, ok := targetRole.Signed.Delegations.Keys[targetPubKey.ID()]
-	require.True(t, ok)
+	assert.True(t, ok)
 
 	newDelegationRole := targetRole.Signed.Delegations.Roles[0]
-	require.Len(t, newDelegationRole.KeyIDs, 1)
-	require.Equal(t, targetPubKey.ID(), newDelegationRole.KeyIDs[0])
-	require.Equal(t, "targets/a", newDelegationRole.Name)
+	assert.Len(t, newDelegationRole.KeyIDs, 1)
+	assert.Equal(t, targetPubKey.ID(), newDelegationRole.KeyIDs[0])
+	assert.Equal(t, "targets/a", newDelegationRole.Name)
 }
 
 // TestAddDelegationErrorWritingChanges expects errors writing a change to file
@@ -2320,9 +2320,9 @@ func TestAddDelegationChangefileApplicable(t *testing.T) {
 func TestAddDelegationErrorWritingChanges(t *testing.T) {
 	testErrorWritingChangefiles(t, func(repo *NotaryRepository) error {
 		targetKeyIds := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
-		require.NotEmpty(t, targetKeyIds)
+		assert.NotEmpty(t, targetKeyIds)
 		targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
-		require.NotNil(t, targetPubKey)
+		assert.NotNil(t, targetPubKey)
 
 		return repo.AddDelegation("targets/a", 1, []data.PublicKey{targetPubKey}, []string{""})
 	})
@@ -2339,25 +2339,25 @@ func TestRemoveDelegationChangefileValid(t *testing.T) {
 	repo, rootKeyID := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 	rootPubKey := repo.CryptoService.GetKey(rootKeyID)
-	require.NotNil(t, rootPubKey)
+	assert.NotNil(t, rootPubKey)
 
 	err := repo.RemoveDelegation("root")
-	require.Error(t, err)
-	require.IsType(t, data.ErrInvalidRole{}, err)
-	require.Empty(t, getChanges(t, repo))
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
+	assert.Empty(t, getChanges(t, repo))
 
 	// to demonstrate that so long as the delegation name is valid, the
 	// existence of the delegation doesn't matter
-	require.NoError(t, repo.RemoveDelegation("targets/a/b/c"))
+	assert.NoError(t, repo.RemoveDelegation("targets/a/b/c"))
 
 	// ensure that the changefile is correct
 	changes := getChanges(t, repo)
-	require.Len(t, changes, 1)
-	require.Equal(t, changelist.ActionDelete, changes[0].Action())
-	require.Equal(t, "targets/a/b/c", changes[0].Scope())
-	require.Equal(t, changelist.TypeTargetsDelegation, changes[0].Type())
-	require.Equal(t, "", changes[0].Path())
-	require.Empty(t, changes[0].Content())
+	assert.Len(t, changes, 1)
+	assert.Equal(t, changelist.ActionDelete, changes[0].Action())
+	assert.Equal(t, "targets/a/b/c", changes[0].Scope())
+	assert.Equal(t, changelist.TypeTargetsDelegation, changes[0].Type())
+	assert.Equal(t, "", changes[0].Path())
+	assert.Empty(t, changes[0].Content())
 }
 
 // The changefile produced by RemoveDelegation, when applied, actually removes
@@ -2371,27 +2371,27 @@ func TestRemoveDelegationChangefileApplicable(t *testing.T) {
 	repo, rootKeyID := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 	rootPubKey := repo.CryptoService.GetKey(rootKeyID)
-	require.NotNil(t, rootPubKey)
+	assert.NotNil(t, rootPubKey)
 
 	// add a delegation first so it can be removed
-	require.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{rootPubKey}, []string{""}))
+	assert.NoError(t, repo.AddDelegation("targets/a", 1, []data.PublicKey{rootPubKey}, []string{""}))
 	changes := getChanges(t, repo)
-	require.Len(t, changes, 1)
-	require.NoError(t, applyTargetsChange(repo.tufRepo, changes[0]))
+	assert.Len(t, changes, 1)
+	assert.NoError(t, applyTargetsChange(repo.tufRepo, changes[0]))
 
 	targetRole := repo.tufRepo.Targets[data.CanonicalTargetsRole]
-	require.Len(t, targetRole.Signed.Delegations.Roles, 1)
-	require.Len(t, targetRole.Signed.Delegations.Keys, 1)
+	assert.Len(t, targetRole.Signed.Delegations.Roles, 1)
+	assert.Len(t, targetRole.Signed.Delegations.Keys, 1)
 
 	// now remove it
-	require.NoError(t, repo.RemoveDelegation("targets/a"))
+	assert.NoError(t, repo.RemoveDelegation("targets/a"))
 	changes = getChanges(t, repo)
-	require.Len(t, changes, 2)
-	require.NoError(t, applyTargetsChange(repo.tufRepo, changes[1]))
+	assert.Len(t, changes, 2)
+	assert.NoError(t, applyTargetsChange(repo.tufRepo, changes[1]))
 
 	targetRole = repo.tufRepo.Targets[data.CanonicalTargetsRole]
-	require.Empty(t, targetRole.Signed.Delegations.Roles)
-	require.Empty(t, targetRole.Signed.Delegations.Keys)
+	assert.Empty(t, targetRole.Signed.Delegations.Roles)
+	assert.Empty(t, targetRole.Signed.Delegations.Keys)
 }
 
 // TestRemoveDelegationErrorWritingChanges expects errors writing a change to

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -1,14 +1,13 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/go/canonical/json"
-
 	"github.com/docker/notary/client/changelist"
 	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
@@ -262,5 +261,5 @@ func serializeCanonicalRole(tufRepo *tuf.Repo, role string) (out []byte, err err
 		return
 	}
 
-	return json.MarshalCanonical(s)
+	return json.Marshal(s)
 }

--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -2,26 +2,27 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	ctxu "github.com/docker/distribution/context"
-	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/jfrazelle/go/canonical/json"
-	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 
+	ctxu "github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/notary/server/errors"
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
-	"github.com/docker/notary/tuf/testutils"
 	"github.com/docker/notary/tuf/validation"
+
+	"github.com/docker/notary/tuf/testutils"
 	"github.com/docker/notary/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 type handlerState struct {
@@ -178,7 +179,7 @@ func TestGetHandlerRoot(t *testing.T) {
 	ctx = context.WithValue(ctx, "metaStore", metaStore)
 
 	root, err := repo.SignRoot(data.DefaultExpires("root"))
-	rootJSON, err := json.MarshalCanonical(root)
+	rootJSON, err := json.Marshal(root)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 1, Data: rootJSON})
 
@@ -204,13 +205,13 @@ func TestGetHandlerTimestamp(t *testing.T) {
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
 
 	sn, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
-	snJSON, err := json.MarshalCanonical(sn)
+	snJSON, err := json.Marshal(sn)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent(
 		"gun", storage.MetaUpdate{Role: "snapshot", Version: 1, Data: snJSON})
 
 	ts, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
-	tsJSON, err := json.MarshalCanonical(ts)
+	tsJSON, err := json.Marshal(ts)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent(
 		"gun", storage.MetaUpdate{Role: "timestamp", Version: 1, Data: tsJSON})
@@ -237,7 +238,7 @@ func TestGetHandlerSnapshot(t *testing.T) {
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
 
 	sn, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
-	snJSON, err := json.MarshalCanonical(sn)
+	snJSON, err := json.Marshal(sn)
 	assert.NoError(t, err)
 	metaStore.UpdateCurrent(
 		"gun", storage.MetaUpdate{Role: "snapshot", Version: 1, Data: snJSON})

--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	cjson "github.com/jfrazelle/go/canonical/json"
 
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf"
@@ -247,7 +246,7 @@ func generateSnapshot(gun string, kdb *keys.KeyDB, repo *tuf.Repo, store storage
 	if err != nil {
 		return nil, validation.ErrBadSnapshot{Msg: err.Error()}
 	}
-	sgndJSON, err := cjson.MarshalCanonical(sgnd)
+	sgndJSON, err := json.Marshal(sgnd)
 	if err != nil {
 		return nil, validation.ErrBadSnapshot{Msg: err.Error()}
 	}

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -2,14 +2,11 @@ package handlers
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/jfrazelle/go/canonical/json"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
@@ -17,6 +14,9 @@ import (
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/testutils"
 	"github.com/docker/notary/tuf/validation"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/notary/server/storage"
 )
 
 func copyTimestampKey(t *testing.T, fromKeyDB *keys.KeyDB,
@@ -797,7 +797,7 @@ func TestLoadTargetsFromStore(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	tgs, err := json.MarshalCanonical(st)
+	tgs, err := json.Marshal(st)
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -844,7 +844,7 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 
 	// we're not going to validate things loaded from storage, so no need
 	// to sign the base targets, just Marshal it and set it into storage
-	tgtsJSON, err := json.MarshalCanonical(baseRepo.Targets["targets"])
+	tgtsJSON, err := json.Marshal(baseRepo.Targets["targets"])
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -856,7 +856,7 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 	// generate the update object we're doing to use to call loadAndValidateTargets
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.MarshalCanonical(del)
+	delJSON, err := json.Marshal(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{
@@ -894,7 +894,7 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 
 	targets, err := baseRepo.SignTargets("targets", data.DefaultExpires(data.CanonicalTargetsRole))
 
-	tgtsJSON, err := json.MarshalCanonical(targets)
+	tgtsJSON, err := json.Marshal(targets)
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -905,7 +905,7 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.MarshalCanonical(del)
+	delJSON, err := json.Marshal(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{
@@ -952,7 +952,7 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 	// generate the update object we're doing to use to call loadAndValidateTargets
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.MarshalCanonical(del)
+	delJSON, err := json.Marshal(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{
@@ -989,7 +989,7 @@ func TestValidateTargetsRoleNotInParent(t *testing.T) {
 
 	targets, err := baseRepo.SignTargets("targets", data.DefaultExpires(data.CanonicalTargetsRole))
 
-	tgtsJSON, err := json.MarshalCanonical(targets)
+	tgtsJSON, err := json.Marshal(targets)
 	assert.NoError(t, err)
 	update := storage.MetaUpdate{
 		Role:    data.CanonicalTargetsRole,
@@ -1000,7 +1000,7 @@ func TestValidateTargetsRoleNotInParent(t *testing.T) {
 
 	del, err := baseRepo.SignTargets("targets/level1", data.DefaultExpires(data.CanonicalTargetsRole))
 	assert.NoError(t, err)
-	delJSON, err := json.MarshalCanonical(del)
+	delJSON, err := json.Marshal(del)
 	assert.NoError(t, err)
 
 	delUpdate := storage.MetaUpdate{

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -1,8 +1,9 @@
 package snapshot
 
 import (
+	"encoding/json"
+
 	"github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/go/canonical/json"
 
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf/data"
@@ -69,7 +70,7 @@ func GetOrCreateSnapshot(gun string, store storage.MetaStore, cryptoService sign
 		logrus.Error("Failed to create a new snapshot")
 		return nil, err
 	}
-	out, err := json.MarshalCanonical(sgnd)
+	out, err := json.Marshal(sgnd)
 	if err != nil {
 		logrus.Error("Failed to marshal new snapshot")
 		return nil, err

--- a/server/snapshot/snapshot_test.go
+++ b/server/snapshot/snapshot_test.go
@@ -2,10 +2,10 @@ package snapshot
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/jfrazelle/go/canonical/json"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/notary/server/storage"
@@ -140,7 +140,7 @@ func TestGetSnapshotCurrValid(t *testing.T) {
 			},
 		},
 	}
-	snapJSON, _ := json.MarshalCanonical(snapshot)
+	snapJSON, _ := json.Marshal(snapshot)
 
 	// test when db is missing the role data
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
@@ -165,7 +165,7 @@ func TestGetSnapshotCurrExpired(t *testing.T) {
 	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
 
 	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.MarshalCanonical(snapshot)
+	snapJSON, _ := json.Marshal(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	_, err = GetOrCreateSnapshot("gun", store, crypto)
@@ -179,7 +179,7 @@ func TestGetSnapshotCurrCorrupt(t *testing.T) {
 	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
 
 	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.MarshalCanonical(snapshot)
+	snapJSON, _ := json.Marshal(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON[1:]})
 	_, err = GetOrCreateSnapshot("gun", store, crypto)

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -77,7 +77,7 @@ func GetOrCreateTimestamp(gun string, store storage.MetaStore, cryptoService sig
 		logrus.Error("Failed to create a new timestamp")
 		return nil, err
 	}
-	out, err := json.MarshalCanonical(sgnd)
+	out, err := json.Marshal(sgnd)
 	if err != nil {
 		logrus.Error("Failed to marshal new timestamp")
 		return nil, err

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -1,15 +1,15 @@
 package timestamp
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/jfrazelle/go/canonical/json"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/notary/server/storage"
-	"github.com/docker/notary/tuf/data"
-	"github.com/docker/notary/tuf/signed"
 )
 
 func TestTimestampExpired(t *testing.T) {
@@ -53,7 +53,7 @@ func TestGetTimestamp(t *testing.T) {
 	crypto := signed.NewEd25519()
 
 	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.MarshalCanonical(snapshot)
+	snapJSON, _ := json.Marshal(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
@@ -70,7 +70,7 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 
 	snapshot := data.SignedSnapshot{}
 	snapshot.Signed.Version = 0
-	snapJSON, _ := json.MarshalCanonical(snapshot)
+	snapJSON, _ := json.Marshal(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
@@ -82,7 +82,7 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 
 	snapshot = data.SignedSnapshot{}
 	snapshot.Signed.Version = 1
-	snapJSON, _ = json.MarshalCanonical(snapshot)
+	snapJSON, _ = json.Marshal(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 1, Data: snapJSON})
 

--- a/tuf/data/snapshot.go
+++ b/tuf/data/snapshot.go
@@ -27,12 +27,12 @@ type Snapshot struct {
 // and targets objects
 func NewSnapshot(root *Signed, targets *Signed) (*SignedSnapshot, error) {
 	logrus.Debug("generating new snapshot...")
-	targetsJSON, err := json.MarshalCanonical(targets)
+	targetsJSON, err := json.Marshal(targets)
 	if err != nil {
 		logrus.Debug("Error Marshalling Targets")
 		return nil, err
 	}
-	rootJSON, err := json.MarshalCanonical(root)
+	rootJSON, err := json.Marshal(root)
 	if err != nil {
 		logrus.Debug("Error Marshalling Root")
 		return nil, err

--- a/tuf/data/timestamp.go
+++ b/tuf/data/timestamp.go
@@ -24,7 +24,7 @@ type Timestamp struct {
 
 // NewTimestamp initializes a timestamp with an existing snapshot
 func NewTimestamp(snapshot *Signed) (*SignedTimestamp, error) {
-	snapshotJSON, err := json.MarshalCanonical(snapshot)
+	snapshotJSON, err := json.Marshal(snapshot)
 	if err != nil {
 		return nil, err
 	}

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -1,17 +1,17 @@
 package testutils
 
 import (
+	"encoding/json"
 	"math/rand"
 	"time"
 
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/utils"
 	fuzz "github.com/google/gofuzz"
-	"github.com/jfrazelle/go/canonical/json"
 
 	tuf "github.com/docker/notary/tuf"
-	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
-	"github.com/docker/notary/tuf/utils"
 )
 
 // EmptyRepo creates an in memory key database, crypto service
@@ -83,19 +83,19 @@ func Sign(repo *tuf.Repo) (root, targets, snapshot, timestamp *data.Signed, err 
 
 // Serialize takes the Signed objects for the 4 top level roles and serializes them all to JSON
 func Serialize(sRoot, sTargets, sSnapshot, sTimestamp *data.Signed) (root, targets, snapshot, timestamp []byte, err error) {
-	root, err = json.MarshalCanonical(sRoot)
+	root, err = json.Marshal(sRoot)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	targets, err = json.MarshalCanonical(sTargets)
+	targets, err = json.Marshal(sTargets)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	snapshot, err = json.MarshalCanonical(sSnapshot)
+	snapshot, err = json.Marshal(sSnapshot)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	timestamp, err = json.MarshalCanonical(sTimestamp)
+	timestamp, err = json.Marshal(sTimestamp)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -5,14 +5,13 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/go/canonical/json"
-
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
@@ -607,7 +606,7 @@ func (tr *Repo) RemoveTargets(role string, targets ...string) error {
 
 // UpdateSnapshot updates the FileMeta for the given role based on the Signed object
 func (tr *Repo) UpdateSnapshot(role string, s *data.Signed) error {
-	jsonData, err := json.MarshalCanonical(s)
+	jsonData, err := json.Marshal(s)
 	if err != nil {
 		return err
 	}
@@ -622,7 +621,7 @@ func (tr *Repo) UpdateSnapshot(role string, s *data.Signed) error {
 
 // UpdateTimestamp updates the snapshot meta in the timestamp based on the Signed object
 func (tr *Repo) UpdateTimestamp(s *data.Signed) error {
-	jsonData, err := json.MarshalCanonical(s)
+	jsonData, err := json.Marshal(s)
 	if err != nil {
 		return err
 	}

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -2,18 +2,17 @@ package tuf
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 
-	"github.com/jfrazelle/go/canonical/json"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
+	"github.com/stretchr/testify/assert"
 )
 
 func initRepo(t *testing.T, cryptoService signed.CryptoService, keyDB *keys.KeyDB) *Repo {
@@ -113,13 +112,13 @@ func writeRepo(t *testing.T, dir string, repo *Repo) {
 	assert.NoError(t, err)
 	signedRoot, err := repo.SignRoot(data.DefaultExpires("root"))
 	assert.NoError(t, err)
-	rootJSON, _ := json.MarshalCanonical(signedRoot)
+	rootJSON, _ := json.Marshal(signedRoot)
 	ioutil.WriteFile(dir+"/root.json", rootJSON, 0755)
 
 	for r := range repo.Targets {
 		signedTargets, err := repo.SignTargets(r, data.DefaultExpires("targets"))
 		assert.NoError(t, err)
-		targetsJSON, _ := json.MarshalCanonical(signedTargets)
+		targetsJSON, _ := json.Marshal(signedTargets)
 		p := path.Join(dir, r+".json")
 		parentDir := filepath.Dir(p)
 		os.MkdirAll(parentDir, 0755)
@@ -128,12 +127,12 @@ func writeRepo(t *testing.T, dir string, repo *Repo) {
 
 	signedSnapshot, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
 	assert.NoError(t, err)
-	snapshotJSON, _ := json.MarshalCanonical(signedSnapshot)
+	snapshotJSON, _ := json.Marshal(signedSnapshot)
 	ioutil.WriteFile(dir+"/snapshot.json", snapshotJSON, 0755)
 
 	signedTimestamp, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
 	assert.NoError(t, err)
-	timestampJSON, _ := json.MarshalCanonical(signedTimestamp)
+	timestampJSON, _ := json.Marshal(signedTimestamp)
 	ioutil.WriteFile(dir+"/timestamp.json", timestampJSON, 0755)
 }
 


### PR DESCRIPTION
This reverts commit f417c834c49d32e6aa9bdbbc1ba5c544c0f760b2.

Signed-off-by: Ying Li <ying.li@docker.com>