### PR TITLE
Log: improve error logging

### DIFF
--- a/cryptoservice/crypto_service.go
+++ b/cryptoservice/crypto_service.go
@@ -73,9 +73,9 @@ func (cs *CryptoService) Create(role, algorithm string) (data.PublicKey, error) 
 
 }
 
-// GetPrivateKey returns a private key by ID. It tries to get the key first
-// without a GUN (in which case it's a root key).  If that fails, try to get
-// the key with the GUN (non-root key).
+// GetPrivateKey returns a private key and role if present by ID.
+// It tries to get the key first without a GUN (in which case it's a root key).
+// If that fails, try to get the key with the GUN (non-root key).
 // If that fails, then we don't have the key.
 func (cs *CryptoService) GetPrivateKey(keyID string) (k data.PrivateKey, role string, err error) {
 	keyPaths := []string{keyID, filepath.Join(cs.gun, keyID)}

--- a/server/handlers/default.go
+++ b/server/handlers/default.go
@@ -129,7 +129,7 @@ func getHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, var
 	out, err := store.GetCurrent(gun, tufRole)
 	if err != nil {
 		if _, ok := err.(storage.ErrNotFound); ok {
-			logrus.Error("404 GET " + gun + ":" + tufRole)
+			logrus.Errorf("404 GET %s:%s, error: %v", gun, tufRole, err)
 			return errors.ErrMetadataNotFound.WithDetail(nil)
 		}
 		logger.Error("500 GET")

--- a/tuf/signed/ed25519.go
+++ b/tuf/signed/ed25519.go
@@ -95,7 +95,7 @@ func (e *Ed25519) GetKey(keyID string) data.PublicKey {
 	return data.PublicKeyFromPrivate(e.keys[keyID].privKey)
 }
 
-// GetPrivateKey returns a single private key based on the ID
+// GetPrivateKey returns a single private key and role if present, based on the ID
 func (e *Ed25519) GetPrivateKey(keyID string) (data.PrivateKey, string, error) {
 	if k, ok := e.keys[keyID]; ok {
 		return k.privKey, k.role, nil


### PR DESCRIPTION
When pushing an image to Distribution server with Notary enabled at the
first time, client will try to get the root.json and it will fail since
there is nothing in Notary yet.

This patch enhances the error message by adding the error detail.
- "404 GET notary-distribution:5678/busybox:root"


And also update some comments

Signed-off-by: Hu Keping <hukeping@huawei.com>