### PR TITLE
delegation command for notary-cli

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -353,7 +353,7 @@ func (r *NotaryRepository) AddDelegation(name string, threshold int,
 // the repository when the changelist gets applied at publish time.
 // This does not validate that the delegation exists, since one might exist
 // after applying all changes.
-func (r *NotaryRepository) RemoveDelegation(name string) error {
+func (r *NotaryRepository) RemoveDelegation(name string, keyIDs, paths []string, removeAll bool) error {
 
 	if !data.IsDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -366,14 +366,35 @@ func (r *NotaryRepository) RemoveDelegation(name string) error {
 	defer cl.Close()
 
 	logrus.Debugf(`Removing delegation "%s"\n`, name)
+	var template *changelist.TufChange
 
-	template := changelist.NewTufChange(
-		changelist.ActionDelete,
-		name,
-		changelist.TypeTargetsDelegation,
-		"", // no path
-		nil,
-	)
+	// We use the Delete action only for force removal, Update is used for removing individual keys and paths
+	if removeAll {
+		template = changelist.NewTufChange(
+			changelist.ActionDelete,
+			name,
+			changelist.TypeTargetsDelegation,
+			"",  // no path
+			nil, // deleting role, no data needed
+		)
+
+	} else {
+		tdJSON, err := json.Marshal(&changelist.TufDelegation{
+			RemoveKeys:  keyIDs,
+			RemovePaths: paths,
+		})
+		if err != nil {
+			return err
+		}
+
+		template = changelist.NewTufChange(
+			changelist.ActionUpdate,
+			name,
+			changelist.TypeTargetsDelegation,
+			"", // no path
+			tdJSON,
+		)
+	}
 
 	return addChange(cl, template, name)
 }
@@ -513,6 +534,45 @@ func (r *NotaryRepository) GetChangelist() (changelist.Changelist, error) {
 		return nil, err
 	}
 	return cl, nil
+}
+
+// GetDelegationRoles returns the keys and roles of the repository's delegations
+func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
+	// Update state of the repo to latest
+	if _, err := r.Update(false); err != nil {
+		return nil, err
+	}
+
+	// All top level delegations (ex: targets/level1) are stored exclusively in targets.json
+	targets, ok := r.tufRepo.Targets[data.CanonicalTargetsRole]
+	if !ok {
+		return nil, store.ErrMetaNotFound{data.CanonicalTargetsRole}
+	}
+
+	allDelegations := targets.Signed.Delegations.Roles
+
+	// make a copy for traversing nested delegations
+	delegationsList := make([]*data.Role, len(allDelegations))
+	copy(delegationsList, allDelegations)
+
+	// Now traverse to lower level delegations (ex: targets/level1/level2)
+	for len(delegationsList) > 0 {
+		// Pop off first delegation to traverse
+		delegation := delegationsList[0]
+		delegationsList = delegationsList[1:]
+
+		// Get metadata
+		delegationMeta, ok := r.tufRepo.Targets[delegation.Name]
+		// If we get an error, don't try to traverse further into this subtree because it doesn't exist or is malformed
+		if !ok {
+			continue
+		}
+
+		// Add nested delegations to return list and exploration list
+		allDelegations = append(allDelegations, delegationMeta.Signed.Delegations.Roles...)
+		delegationsList = append(delegationsList, delegationMeta.Signed.Delegations.Roles...)
+	}
+	return allDelegations, nil
 }
 
 // Publish pushes the local changes in signed material to the remote notary-server

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -85,13 +86,13 @@ func changeTargetsDelegation(repo *tuf.Repo, c changelist.Change) error {
 			return err
 		}
 		if err == nil {
-			// role existed
-			return data.ErrInvalidRole{
-				Role:   c.Scope(),
-				Reason: "cannot create a role that already exists",
+			// role existed, attempt to merge paths and keys
+			if err := r.AddPaths(td.AddPaths); err != nil {
+				return err
 			}
+			return repo.UpdateDelegations(r, td.AddKeys)
 		}
-		// role doesn't exist, create brand new
+		// create brand new role
 		r, err = td.ToNewRole(c.Scope())
 		if err != nil {
 			return err
@@ -107,7 +108,12 @@ func changeTargetsDelegation(repo *tuf.Repo, c changelist.Change) error {
 		if err != nil {
 			return err
 		}
-		// role exists, merge
+		// If we specify the only keys left delete the role, else just delete specified keys
+		if strings.Join(r.KeyIDs, ";") == strings.Join(td.RemoveKeys, ";") && len(td.AddKeys) == 0 {
+			r := data.Role{Name: c.Scope()}
+			return repo.DeleteDelegation(r)
+		}
+		// if we aren't deleting and the role exists, merge
 		if err := r.AddPaths(td.AddPaths); err != nil {
 			return err
 		}

--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/docker/notary"
+	notaryclient "github.com/docker/notary/client"
+	"github.com/docker/notary/passphrase"
+	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/tuf/data"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cmdDelegationTemplate = usageTemplate{
+	Use:   "delegation",
+	Short: "Operates on delegations.",
+	Long:  `Operations on TUF delegations.`,
+}
+
+var cmdDelegationListTemplate = usageTemplate{
+	Use:   "list [ GUN ]",
+	Short: "Lists delegations for the Global Unique Name.",
+	Long:  "Lists all delegations known to notary for a specific Global Unique Name.",
+}
+
+var cmdDelegationRemoveTemplate = usageTemplate{
+	Use:   "remove [ GUN ] [ Role ] <KeyID 1> ...",
+	Short: "Remove KeyID(s) from the specified Role delegation.",
+	Long:  "Remove KeyID(s) from the specified Role delegation in a specific Global Unique Name.",
+}
+
+var cmdDelegationAddTemplate = usageTemplate{
+	Use:   "add [ GUN ] [ Role ] <PEM file path 1> ...",
+	Short: "Add a keys to delegation using the provided public key certificate PEMs.",
+	Long:  "Add a keys to delegation using the provided public key certificate PEMs in a specific Global Unique Name.",
+}
+
+var paths []string
+var removeAll, removeYes bool
+
+type delegationCommander struct {
+	// these need to be set
+	configGetter func() *viper.Viper
+	retriever    passphrase.Retriever
+}
+
+func (d *delegationCommander) GetCommand() *cobra.Command {
+	cmd := cmdDelegationTemplate.ToCommand(nil)
+	cmd.AddCommand(cmdDelegationListTemplate.ToCommand(d.delegationsList))
+
+	cmdRemDelg := cmdDelegationRemoveTemplate.ToCommand(d.delegationRemove)
+	cmdRemDelg.Flags().StringSliceVar(&paths, "paths", nil, "List of paths to remove")
+	cmdRemDelg.Flags().BoolVarP(&removeYes, "yes", "y", false, "Answer yes to the removal question (no confirmation)")
+	cmd.AddCommand(cmdRemDelg)
+
+	cmdAddDelg := cmdDelegationAddTemplate.ToCommand(d.delegationAdd)
+	cmdAddDelg.Flags().StringSliceVar(&paths, "paths", nil, "List of paths to add")
+	cmd.AddCommand(cmdAddDelg)
+	return cmd
+}
+
+// delegationsList lists all the delegations for a particular GUN
+func (d *delegationCommander) delegationsList(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf(
+			"Please provide a Global Unique Name as an argument to list")
+	}
+
+	config := d.configGetter()
+
+	gun := args[0]
+
+	// initialize repo with transport to get latest state of the world before listing delegations
+	nRepo, err := notaryclient.NewNotaryRepository(config.GetString("trust_dir"), gun, getRemoteTrustServer(config), getTransport(config, gun, true), retriever)
+	if err != nil {
+		return err
+	}
+
+	delegationRoles, err := nRepo.GetDelegationRoles()
+	if err != nil {
+		return fmt.Errorf("Error retrieving delegation roles for repository %s: %v", gun, err)
+	}
+
+	cmd.Println("")
+	prettyPrintRoles(delegationRoles, cmd.Out())
+	cmd.Println("")
+	return nil
+}
+
+// delegationRemove removes a public key from a specific role in a GUN
+func (d *delegationCommander) delegationRemove(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("must specify the Global Unique Name and the role of the delegation along with optional keyIDs and/or a list of paths to remove")
+	}
+
+	config := d.configGetter()
+
+	gun := args[0]
+	role := args[1]
+
+	// If we're only given the gun and the role, attempt to remove all data for this delegation
+	if len(args) == 2 && paths == nil {
+		removeAll = true
+	}
+
+	keyIDs := []string{}
+	// Change nil paths to empty slice for TUF
+	if paths == nil {
+		paths = []string{}
+	}
+
+	if len(args) > 2 {
+		keyIDs = args[2:]
+	}
+
+	// no online operations are performed by add so the transport argument
+	// should be nil
+	nRepo, err := notaryclient.NewNotaryRepository(config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, retriever)
+	if err != nil {
+		return err
+	}
+
+	if removeAll {
+		cmd.Println("\nAre you sure you want to remove all data for this delegation? (yes/no)")
+		// Ask for confirmation before force removing delegation
+		if !removeYes {
+			confirmed := askConfirm()
+			if !confirmed {
+				fatalf("Aborting action.")
+			}
+		} else {
+			cmd.Println("Confirmed `yes` from flag")
+		}
+	}
+
+	// Remove the delegation from the repository
+	err = nRepo.RemoveDelegation(role, keyIDs, paths, removeAll)
+	if err != nil {
+		return fmt.Errorf("failed to remove delegation: %v", err)
+	}
+	cmd.Println("")
+	if removeAll {
+		cmd.Printf("Forced removal (including all keys and paths) of delegation role %s to repository \"%s\" staged for next publish.\n", role, gun)
+	}
+	cmd.Printf(
+		"Removal of delegation role %s with keys %s and paths %s, to repository \"%s\" staged for next publish.\n",
+		role, keyIDs, paths, gun)
+	cmd.Println("")
+
+	return nil
+}
+
+// delegationAdd creates a new delegation by adding a public key from a certificate to a specific role in a GUN
+func (d *delegationCommander) delegationAdd(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 || len(args) < 3 && paths == nil {
+		return fmt.Errorf("must specify the Global Unique Name and the role of the delegation along with the public key certificate paths and/or a list of paths to add")
+	}
+
+	config := d.configGetter()
+
+	gun := args[0]
+	role := args[1]
+
+	pubKeys := []data.PublicKey{}
+	if len(args) > 2 {
+		pubKeyPaths := args[2:]
+		for _, pubKeyPath := range pubKeyPaths {
+			// Read public key bytes from PEM file
+			pubKeyBytes, err := ioutil.ReadFile(pubKeyPath)
+			if err != nil {
+				return fmt.Errorf("unable to read public key from file: %s", pubKeyPath)
+			}
+
+			// Parse PEM bytes into type PublicKey
+			pubKey, err := trustmanager.ParsePEMPublicKey(pubKeyBytes)
+			if err != nil {
+				return fmt.Errorf("unable to parse valid public key certificate from PEM file %s: %v", pubKeyPath, err)
+			}
+			pubKeys = append(pubKeys, pubKey)
+		}
+	}
+
+	// no online operations are performed by add so the transport argument
+	// should be nil
+	nRepo, err := notaryclient.NewNotaryRepository(config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, retriever)
+	if err != nil {
+		return err
+	}
+
+	// Add the delegation to the repository
+	// Sets threshold to 1 since we only added one key - thresholds are not currently fully supported, though
+	// one can use additional client-side validation to check for signatures from a quorum of varying delegation roles
+	err = nRepo.AddDelegation(role, notary.MinThreshold, pubKeys, paths)
+	if err != nil {
+		return fmt.Errorf("failed to create delegation: %v", err)
+	}
+
+	// Make keyID slice for better CLI print
+	pubKeyIDs := []string{}
+	for _, pubKey := range pubKeys {
+		pubKeyIDs = append(pubKeyIDs, pubKey.ID())
+	}
+
+	cmd.Println("")
+	cmd.Printf(
+		"Addition of delegation role %s with keys %s and paths %s, to repository \"%s\" staged for next publish.\n",
+		role, pubKeyIDs, paths, gun)
+	cmd.Println("")
+	return nil
+}

--- a/cmd/notary/delegations_test.go
+++ b/cmd/notary/delegations_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/trustmanager"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+var testTrustDir = "trust_dir"
+
+func setup() *delegationCommander {
+	return &delegationCommander{
+		configGetter: func() *viper.Viper {
+			mainViper := viper.New()
+			mainViper.Set("trust_dir", testTrustDir)
+			return mainViper
+		},
+		retriever: nil,
+	}
+}
+
+func TestAddInvalidDelegationName(t *testing.T) {
+	// Cleanup after test
+	defer os.RemoveAll(testTrustDir)
+
+	// Setup certificate
+	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
+	assert.NoError(t, err)
+	cert, _, err := generateValidTestCert()
+	_, err = tempFile.Write(trustmanager.CertToPEM(cert))
+	assert.NoError(t, err)
+	tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	// Setup commander
+	commander := setup()
+
+	// Should error due to invalid delegation name (should be prefixed by "targets/")
+	err = commander.delegationAdd(commander.GetCommand(), []string{"gun", "INVALID_NAME", tempFile.Name()})
+	assert.Error(t, err)
+}
+
+func TestAddInvalidDelegationCert(t *testing.T) {
+	// Cleanup after test
+	defer os.RemoveAll(testTrustDir)
+
+	// Setup certificate
+	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
+	assert.NoError(t, err)
+	cert, _, err := generateExpiredTestCert()
+	_, err = tempFile.Write(trustmanager.CertToPEM(cert))
+	assert.NoError(t, err)
+	tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	// Setup commander
+	commander := setup()
+
+	// Should error due to expired cert
+	err = commander.delegationAdd(commander.GetCommand(), []string{"gun", "targets/delegation", tempFile.Name(), "--paths", "path"})
+	assert.Error(t, err)
+}
+
+func TestRemoveInvalidDelegationName(t *testing.T) {
+	// Cleanup after test
+	defer os.RemoveAll(testTrustDir)
+
+	// Setup commander
+	commander := setup()
+
+	// Should error due to invalid delegation name (should be prefixed by "targets/")
+	err := commander.delegationRemove(commander.GetCommand(), []string{"gun", "INVALID_NAME", "fake_key_id1", "fake_key_id2"})
+	assert.Error(t, err)
+}
+
+func TestAddInvalidNumArgs(t *testing.T) {
+	// Setup commander
+	commander := setup()
+
+	// Should error due to invalid number of args (2 instead of 3)
+	err := commander.delegationAdd(commander.GetCommand(), []string{"not", "enough"})
+	assert.Error(t, err)
+}
+
+func TestListInvalidNumArgs(t *testing.T) {
+	// Setup commander
+	commander := setup()
+
+	// Should error due to invalid number of args (0 instead of 1)
+	err := commander.delegationsList(commander.GetCommand(), []string{})
+	assert.Error(t, err)
+}
+
+func TestRemoveInvalidNumArgs(t *testing.T) {
+	// Setup commander
+	commander := setup()
+
+	// Should error due to invalid number of args (1 instead of 2)
+	err := commander.delegationRemove(commander.GetCommand(), []string{"notenough"})
+	assert.Error(t, err)
+}
+
+func generateValidTestCert() (*x509.Certificate, string, error) {
+	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
+	if err != nil {
+		return nil, "", err
+	}
+	keyID := privKey.ID()
+	startTime := time.Now()
+	endTime := startTime.AddDate(10, 0, 0)
+	cert, err := cryptoservice.GenerateCertificate(privKey, "gun", startTime, endTime)
+	if err != nil {
+		return nil, "", err
+	}
+	return cert, keyID, nil
+}
+
+func generateExpiredTestCert() (*x509.Certificate, string, error) {
+	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
+	if err != nil {
+		return nil, "", err
+	}
+	keyID := privKey.ID()
+	// Set to Unix time 0 start time, valid for one more day
+	startTime := time.Unix(0, 0)
+	endTime := startTime.AddDate(0, 0, 1)
+	cert, err := cryptoservice.GenerateCertificate(privKey, "gun", startTime, endTime)
+	if err != nil {
+		return nil, "", err
+	}
+	return cert, keyID, nil
+}

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -120,7 +120,13 @@ func setupCommand(notaryCmd *cobra.Command) {
 		retriever:    retriever,
 	}
 
+	cmdDelegationGenerator := &delegationCommander{
+		configGetter: parseConfig,
+		retriever:    retriever,
+	}
+
 	notaryCmd.AddCommand(cmdKeyGenerator.GetCommand())
+	notaryCmd.AddCommand(cmdDelegationGenerator.GetCommand())
 	notaryCmd.AddCommand(cmdCert)
 	notaryCmd.AddCommand(cmdTufInit)
 	notaryCmd.AddCommand(cmdTufList)

--- a/const.go
+++ b/const.go
@@ -2,6 +2,8 @@ package notary
 
 // application wide constants
 const (
+	// Require a minimum of one threshold for roles, currently we do not support a higher threshold
+	MinThreshold    = 1
 	PrivKeyPerms    = 0700
 	PubCertPerms    = 0755
 	TrustedCertsDir = "trusted_certificates"

--- a/cryptoservice/crypto_service.go
+++ b/cryptoservice/crypto_service.go
@@ -69,8 +69,8 @@ func (cs *CryptoService) Create(role, algorithm string) (data.PublicKey, error) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to add key to filestore: %v", err)
 	}
-	return nil, fmt.Errorf("keystores would not accept new private keys for unknown reasons")
 
+	return nil, fmt.Errorf("keystores would not accept new private keys for unknown reasons")
 }
 
 // GetPrivateKey returns a private key and role if present by ID.

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"github.com/Sirupsen/logrus"
 	"path"
 	"regexp"
 	"strings"
@@ -109,10 +110,7 @@ func NewRole(name string, threshold int, keyIDs, paths, pathHashPrefixes []strin
 	}
 	if IsDelegation(name) {
 		if len(paths) == 0 && len(pathHashPrefixes) == 0 {
-			return nil, ErrInvalidRole{
-				Role:   name,
-				Reason: "roles with no Paths and no PathHashPrefixes will never be able to publish content",
-			}
+			logrus.Debugf("role %s with no Paths and no PathHashPrefixes will never be able to publish content until one or more are added", name)
 		}
 	}
 	if threshold < 1 {

--- a/tuf/data/roles_test.go
+++ b/tuf/data/roles_test.go
@@ -63,16 +63,6 @@ func TestSubtractStrSlicesEqual(t *testing.T) {
 	assert.Len(t, res, 0)
 }
 
-func TestNewRolePathsAndHashPrefixRejection(t *testing.T) {
-	_, err := NewRole("targets/level1", 1, []string{"abc"}, nil, nil)
-	assert.Error(t, err)
-	assert.IsType(t, ErrInvalidRole{}, err)
-
-	_, err = NewRole("targets/level1", 1, []string{"abc"}, []string{""}, []string{""})
-	assert.Error(t, err)
-	assert.IsType(t, ErrInvalidRole{}, err)
-}
-
 func TestAddRemoveKeys(t *testing.T) {
 	role, err := NewRole("targets", 1, []string{"abc"}, []string{""}, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
Adds a `notary delegation` command to the cli.  There are three commands:
- `add`: adds a delegation using a given gun, X509 cert(s) with public key, role (ex: "targets/delegation"), and optional comma-separated `--paths`. Currently we only validate the expiry date on the certificate since there are no restrictions on the signature, but it could be backed by the TUF root key or existing PKI in the future. This command creates a TUF change offline, which will need to be published to take effect.
- `remove`: removes delegation info using a gun and role with either key IDs (standard arguments) or comma-separated `--paths`.  The command can also just remove all information for the specified role using a `--force` flag (this requires confirmation).  Creates a TUF change offline (update or delete, depending on `--force`) that will require a publish for effect.
- `list`: updates the notary repository online before listing all published delegations in a table format.

Closes #434.