### PR TITLE
Pass original invalid version storage error details into standardized err

### DIFF
--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -44,6 +44,12 @@ var (
 		Description:    "An error occurred when attempting to apply an update at the storage layer.",
 		HTTPStatusCode: http.StatusInternalServerError,
 	})
+	ErrOldVersion = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "VERSION",
+		Message:        "A newer version of metadata is already available.",
+		Description:    "A newer version of the repository's metadata is already available in storage.",
+		HTTPStatusCode: http.StatusBadRequest,
+	})
 	ErrMetadataNotFound = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "METADATA_NOT_FOUND",
 		Message:        "You have requested metadata that does not exist.",

--- a/server/handlers/default.go
+++ b/server/handlers/default.go
@@ -96,6 +96,11 @@ func atomicUpdateHandler(ctx context.Context, w http.ResponseWriter, r *http.Req
 	}
 	err = store.UpdateMany(gun, updates)
 	if err != nil {
+		// If we have an old version error, surface to user with error code
+		if _, ok := err.(storage.ErrOldVersion); ok {
+			return errors.ErrOldVersion.WithDetail(err)
+		}
+		// More generic storage update error, possibly due to attempted rollback
 		return errors.ErrUpdating.WithDetail(nil)
 	}
 	return nil


### PR DESCRIPTION
Introduces `ErrOldVersion` to distinguish between errors for invalid versions of metadata and errors for during a DB rollback (`ErrUpdating` was propagated both for errors previously from the `atomicUpdateHandler`).  Closes https://github.com/docker/notary/issues/423

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>