### PR TITLE
when doing getTransport readOnly needs to be false 

### DIFF
--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -371,7 +371,7 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 	if k.rotateKeyServerManaged {
 		// this does not actually push the changes, just creates the keys, but
 		// it creates a key remotely so it needs a transport
-		rt = getTransport(config, gun, true)
+		rt = getTransport(config, gun, false)
 	}
 	nRepo, err := notaryclient.NewNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config),

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -354,6 +354,13 @@ func (ps passwordStore) Basic(u *url.URL) (string, string) {
 	return username, password
 }
 
+// getTransport returns an http.RoundTripper to be used for all http requests.
+// It correctly handles the auth challenge/credentials required to interact
+// with a notary server over both HTTP Basic Auth and the JWT auth implemented
+// in the notary-server
+// The readOnly flag indicates if the operation should be performed as an
+// anonymous read only operation. If the command entered requires write
+// permissions on the server, readOnly must be false
 func getTransport(config *viper.Viper, gun string, readOnly bool) http.RoundTripper {
 	// Attempt to get a root CA from the config file. Nil is the host defaults.
 	rootCAFile := config.GetString("remote_server.root_ca")


### PR DESCRIPTION
Write permissions are required to access the *.key endpoints as they may transparently result in key creation.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)