### PR TITLE
Ensure that we do not unnecessarily re-sign/serialize a root.json file on publish

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -565,11 +565,7 @@ func (r *NotaryRepository) Publish() error {
 		}
 		updatedFiles[data.CanonicalRootRole] = rootJSON
 	} else if initialPublish {
-		root, err := r.tufRepo.Root.ToSigned()
-		if err != nil {
-			return err
-		}
-		rootJSON, err := json.Marshal(root)
+		rootJSON, err := r.tufRepo.Root.MarshalJSON()
 		if err != nil {
 			return err
 		}

--- a/client/client_root_validation_test.go
+++ b/client/client_root_validation_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var passphraseRetriever = func(string, string, bool, int) (string, bool, error) { return "passphrase", false, nil }
-
 // TestValidateRoot through the process of initializing a repository and makes
 // sure the repository looks correct on disk.
 // We test this with both an RSA and ECDSA root key

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1827,7 +1827,7 @@ func createKey(t *testing.T, repo *NotaryRepository, role string, x509 bool) dat
 	assert.NoError(t, err, "error creating key")
 
 	if x509 {
-		start := time.Now()
+		start := time.Now().AddDate(0, 0, -1)
 		privKey, _, err := repo.CryptoService.GetPrivateKey(key.ID())
 		assert.NoError(t, err)
 		cert, err := cryptoservice.GenerateCertificate(

--- a/tuf/data/root.go
+++ b/tuf/data/root.go
@@ -43,7 +43,7 @@ func NewRoot(keys map[string]PublicKey, roles map[string]*RootRole, consistent b
 
 // ToSigned partially serializes a SignedRoot for further signing
 func (r SignedRoot) ToSigned() (*Signed, error) {
-	s, err := json.MarshalCanonical(r.Signed)
+	s, err := defaultSerializer.MarshalCanonical(r.Signed)
 	if err != nil {
 		return nil, err
 	}
@@ -58,6 +58,15 @@ func (r SignedRoot) ToSigned() (*Signed, error) {
 		Signatures: sigs,
 		Signed:     signed,
 	}, nil
+}
+
+// MarshalJSON returns the serialized form of SignedRoot as bytes
+func (r SignedRoot) MarshalJSON() ([]byte, error) {
+	signed, err := r.ToSigned()
+	if err != nil {
+		return nil, err
+	}
+	return defaultSerializer.Marshal(signed)
 }
 
 // RootFromSigned fully unpacks a Signed object into a SignedRoot

--- a/tuf/data/root.go
+++ b/tuf/data/root.go
@@ -47,6 +47,7 @@ func (r SignedRoot) ToSigned() (*Signed, error) {
 	if err != nil {
 		return nil, err
 	}
+	// cast into a json.RawMessage
 	signed := json.RawMessage{}
 	err = signed.UnmarshalJSON(s)
 	if err != nil {

--- a/tuf/data/root_test.go
+++ b/tuf/data/root_test.go
@@ -1,0 +1,98 @@
+package data
+
+import (
+	"bytes"
+	rjson "encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	cjson "github.com/jfrazelle/go/canonical/json"
+	"github.com/stretchr/testify/require"
+)
+
+type errorSerializer struct {
+	canonicalJSON
+}
+
+func (e errorSerializer) MarshalCanonical(from interface{}) ([]byte, error) {
+	return nil, fmt.Errorf("bad")
+}
+
+func TestToSignedMarshalsSignedPortionWithCanonicalJSON(t *testing.T) {
+	r := SignedRoot{Signed: Root{Type: "root", Version: 2, Expires: time.Now()}}
+	signedCanonical, err := r.ToSigned()
+	require.NoError(t, err)
+
+	canonicalSignedPortion, err := cjson.MarshalCanonical(r.Signed)
+	require.NoError(t, err)
+
+	castedCanonical := rjson.RawMessage(canonicalSignedPortion)
+
+	// don't bother testing regular JSON because it might not be different
+
+	require.True(t, bytes.Equal(signedCanonical.Signed, castedCanonical),
+		"expected %v == %v", signedCanonical.Signed, castedCanonical)
+}
+
+func TestToSignCopiesSignatures(t *testing.T) {
+	r := SignedRoot{
+		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+		Signatures: []Signature{
+			{KeyID: "key1", Method: "method1", Signature: []byte("hello")},
+		},
+	}
+	signed, err := r.ToSigned()
+	require.NoError(t, err)
+
+	require.True(t, reflect.DeepEqual(r.Signatures, signed.Signatures),
+		"expected %v == %v", r.Signatures, signed.Signatures)
+
+	r.Signatures[0].KeyID = "changed"
+	require.False(t, reflect.DeepEqual(r.Signatures, signed.Signatures),
+		"expected %v != %v", r.Signatures, signed.Signatures)
+}
+
+func TestToSignedMarshallingErrorsPropagated(t *testing.T) {
+	setDefaultSerializer(errorSerializer{})
+	defer setDefaultSerializer(canonicalJSON{})
+	r := SignedRoot{
+		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+	}
+	_, err := r.ToSigned()
+	require.EqualError(t, err, "bad")
+}
+
+func TestMarshalJSONMarshalsSignedWithRegularJSON(t *testing.T) {
+	r := SignedRoot{
+		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+		Signatures: []Signature{
+			{KeyID: "key1", Method: "method1", Signature: []byte("hello")},
+			{KeyID: "key2", Method: "method2", Signature: []byte("there")},
+		},
+	}
+	serialized, err := r.MarshalJSON()
+	require.NoError(t, err)
+
+	signed, err := r.ToSigned()
+	require.NoError(t, err)
+
+	// don't bother testing canonical JSON because it might not be different
+
+	regular, err := rjson.Marshal(signed)
+	require.NoError(t, err)
+
+	require.True(t, bytes.Equal(serialized, regular),
+		"expected %v != %v", serialized, regular)
+}
+
+func TestMarshalJSONMarshallingErrorsPropagated(t *testing.T) {
+	setDefaultSerializer(errorSerializer{})
+	defer setDefaultSerializer(canonicalJSON{})
+	r := SignedRoot{
+		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+	}
+	_, err := r.MarshalJSON()
+	require.EqualError(t, err, "bad")
+}

--- a/tuf/data/serializer.go
+++ b/tuf/data/serializer.go
@@ -1,0 +1,36 @@
+package data
+
+import "github.com/jfrazelle/go/canonical/json"
+
+// Serializer is an interface that can marshal and unmarshal TUF data.  This
+// is expected to be a canonical JSON marshaller
+type serializer interface {
+	MarshalCanonical(from interface{}) ([]byte, error)
+	Marshal(from interface{}) ([]byte, error)
+	Unmarshal(from []byte, to interface{}) error
+}
+
+// CanonicalJSON marshals to and from canonical JSON
+type canonicalJSON struct{}
+
+// MarshalCanonical returns the canonical JSON form of a thing
+func (c canonicalJSON) MarshalCanonical(from interface{}) ([]byte, error) {
+	return json.MarshalCanonical(from)
+}
+
+// Marshal returns the regular non-canonical JSON form of a thing
+func (c canonicalJSON) Marshal(from interface{}) ([]byte, error) {
+	return json.Marshal(from)
+}
+
+// Unmarshal unmarshals some JSON bytes
+func (c canonicalJSON) Unmarshal(from []byte, to interface{}) error {
+	return json.Unmarshal(from, to)
+}
+
+// defaultSerializer is a canonical JSON serializer
+var defaultSerializer = serializer(canonicalJSON{})
+
+func setDefaultSerializer(s serializer) {
+	defaultSerializer = s
+}

--- a/tuf/data/serializer.go
+++ b/tuf/data/serializer.go
@@ -29,7 +29,7 @@ func (c canonicalJSON) Unmarshal(from []byte, to interface{}) error {
 }
 
 // defaultSerializer is a canonical JSON serializer
-var defaultSerializer = serializer(canonicalJSON{})
+var defaultSerializer serializer = canonicalJSON{}
 
 func setDefaultSerializer(s serializer) {
 	defaultSerializer = s


### PR DESCRIPTION
Adds additional tests to ensure that keys aren't unnecessarily created on error,
and that only the required keys to sign are used.

Signed-off-by: Ying Li <ying.li@docker.com>

Probably the better way to do this would be to refactor the code some to inject a remoteStore into NotaryRepository, and compare the metadata (which we should probably do anyway).

Then again, this does ensure that we aren't re-signing or pulling out private keys unnecessarily.