### PR TITLE
client library and cli deletion functionality

### DIFF
--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -236,7 +236,7 @@ func filestoreWithTwoCerts(t *testing.T, gun, keyAlg string) (
 
 	cryptoService := cryptoservice.NewCryptoService(gun, fileKeyStore)
 
-	// Create a Manager
+	// Create a store
 	trustPath := filepath.Join(tempBaseDir, notary.TrustedCertsDir)
 	certStore, err := trustmanager.NewX509FilteredFileStore(
 		trustPath,

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 
+	"github.com/docker/notary"
 	"github.com/docker/notary/tuf/data"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -253,7 +254,7 @@ func (k *keyCommander) keysExportRoot(cmd *cobra.Command, args []string) error {
 	keyID := args[0]
 	exportFilename := args[1]
 
-	if len(keyID) != idSize {
+	if len(keyID) != notary.Sha256HexSize {
 		return fmt.Errorf("Please specify a valid root key ID")
 	}
 
@@ -473,7 +474,7 @@ func (k *keyCommander) keyRemove(cmd *cobra.Command, args []string) error {
 	keyID := args[0]
 
 	// This is an invalid ID
-	if len(keyID) != idSize {
+	if len(keyID) != notary.Sha256HexSize {
 		return fmt.Errorf("invalid key ID provided: %s", keyID)
 	}
 	cmd.Println("")

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -17,7 +17,6 @@ import (
 const (
 	configDir        = ".notary/"
 	defaultServerURL = "https://notary-server:4443"
-	idSize           = 64
 )
 
 var (

--- a/const.go
+++ b/const.go
@@ -4,5 +4,6 @@ package notary
 const (
 	PrivKeyPerms    = 0700
 	PubCertPerms    = 0755
+	Sha256HexSize   = 64
 	TrustedCertsDir = "trusted_certificates"
 )

--- a/tuf/store/filestore.go
+++ b/tuf/store/filestore.go
@@ -84,3 +84,8 @@ func (f *FilesystemStore) SetMeta(name string, meta []byte) error {
 	}
 	return nil
 }
+
+// RemoveAll clears the existing filestore by removing its base directory
+func (f *FilesystemStore) RemoveAll() error {
+	return os.RemoveAll(f.baseDir)
+}

--- a/tuf/store/filestore_test.go
+++ b/tuf/store/filestore_test.go
@@ -109,3 +109,30 @@ func TestGetMetaNoSuchMetadata(t *testing.T) {
 	assert.Error(t, err)
 	assert.IsType(t, ErrMetaNotFound{}, err)
 }
+
+func TestRemoveAll(t *testing.T) {
+	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
+	defer os.RemoveAll(testDir)
+
+	testContent := []byte("test data")
+
+	// Write some files in metadata and targets dirs
+	metaPath := path.Join(testDir, "metadata", "testMeta.json")
+	ioutil.WriteFile(metaPath, testContent, 0600)
+	targetsPath := path.Join(testDir, "targets", "testTargets.json")
+	ioutil.WriteFile(targetsPath, testContent, 0600)
+
+	// Remove all
+	err = s.RemoveAll()
+	assert.Nil(t, err, "Removing all from FilesystemStore returned unexpected error: %v", err)
+
+	// Test that files no longer exist
+	_, err = ioutil.ReadFile(metaPath)
+	assert.True(t, os.IsNotExist(err))
+	_, err = ioutil.ReadFile(targetsPath)
+	assert.True(t, os.IsNotExist(err))
+
+	// Removing the empty filestore returns nil
+	assert.Nil(t, s.RemoveAll())
+}

--- a/tuf/store/httpstore.go
+++ b/tuf/store/httpstore.go
@@ -227,6 +227,11 @@ func (s HTTPStore) SetMultiMeta(metas map[string][]byte) error {
 	return translateStatusToError(resp, "POST metadata endpoint")
 }
 
+// RemoveAll in the interface is not supported, admins should use the DeleteHandler endpoint directly to delete remote data for a GUN
+func (s HTTPStore) RemoveAll() error {
+	return errors.New("remove all functionality not supported for HTTPStore")
+}
+
 func (s HTTPStore) buildMetaURL(name string) (*url.URL, error) {
 	var filename string
 	if name != "" {

--- a/tuf/store/httpstore_test.go
+++ b/tuf/store/httpstore_test.go
@@ -244,3 +244,19 @@ func TestTranslateErrorsWhenCannotParse400(t *testing.T) {
 		assert.IsType(t, ErrInvalidOperation{}, err)
 	}
 }
+
+func TestHTTPStoreRemoveAll(t *testing.T) {
+	// Set up a simple handler and server for our store
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testRoot))
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+	store, err := NewHTTPStore(server.URL, "metadata", "json", "targets", "key", http.DefaultTransport)
+	assert.NoError(t, err)
+
+	// currently unsupported since there is no use case
+	// check for the error
+	err = store.RemoveAll()
+	assert.Error(t, err)
+}

--- a/tuf/store/interfaces.go
+++ b/tuf/store/interfaces.go
@@ -14,6 +14,7 @@ type MetadataStore interface {
 	GetMeta(name string, size int64) ([]byte, error)
 	SetMeta(name string, blob []byte) error
 	SetMultiMeta(map[string][]byte) error
+	RemoveAll() error
 }
 
 // PublicKeyStore must be implemented by a key service

--- a/tuf/store/memorystore.go
+++ b/tuf/store/memorystore.go
@@ -95,3 +95,11 @@ func (m *memoryStore) Commit(map[string][]byte, bool, map[string]data.Hashes) er
 func (m *memoryStore) GetKey(role string) ([]byte, error) {
 	return nil, fmt.Errorf("GetKey is not implemented for the memoryStore")
 }
+
+// Clear this existing memory store by setting this store as new empty one
+func (m *memoryStore) RemoveAll() error {
+	m.meta = make(map[string][]byte)
+	m.files = make(map[string][]byte)
+	m.keys = make(map[string][]data.PrivateKey)
+	return nil
+}

--- a/tuf/store/memorystore_test.go
+++ b/tuf/store/memorystore_test.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryStore(t *testing.T) {
+	s := NewMemoryStore(nil, nil)
+	_, err := s.GetMeta("nonexistent", 0)
+	require.Error(t, err)
+	require.IsType(t, ErrMetaNotFound{}, err)
+
+	metaContent := []byte("content")
+	metaSize := int64(7)
+	err = s.SetMeta("exists", metaContent)
+	require.NoError(t, err)
+
+	meta, err := s.GetMeta("exists", metaSize)
+	require.NoError(t, err)
+	require.Equal(t, metaContent, meta)
+
+	err = s.RemoveAll()
+	require.NoError(t, err)
+
+	_, err = s.GetMeta("exists", 0)
+	require.Error(t, err)
+	require.IsType(t, ErrMetaNotFound{}, err)
+}

--- a/tuf/store/offlinestore.go
+++ b/tuf/store/offlinestore.go
@@ -41,3 +41,8 @@ func (es OfflineStore) GetKey(role string) ([]byte, error) {
 func (es OfflineStore) GetTarget(path string) (io.ReadCloser, error) {
 	return nil, err
 }
+
+// RemoveAll return ErrOffline
+func (es OfflineStore) RemoveAll() error {
+	return err
+}

--- a/tuf/store/offlinestore_test.go
+++ b/tuf/store/offlinestore_test.go
@@ -27,6 +27,10 @@ func TestOfflineStore(t *testing.T) {
 	_, err = s.GetTarget("")
 	require.Error(t, err)
 	require.IsType(t, ErrOffline{}, err)
+
+	err = s.RemoveAll()
+	require.Error(t, err)
+	require.IsType(t, ErrOffline{}, err)
 }
 
 func TestErrOffline(t *testing.T) {


### PR DESCRIPTION
Delete local client repo TUF cache, certs, and keys via the client library.  Closes #449

Also updates `notary cert remove gun` to remove TUF data for that gun.  Closes #462 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>