### PR TITLE
Add a user_keys subdirectory to the KeyFileStore ...

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
+	"github.com/docker/notary/tuf/utils"
 	"github.com/docker/notary/tuf/validation"
 	"github.com/jfrazelle/go/canonical/json"
 	"github.com/stretchr/testify/assert"
@@ -2765,4 +2766,67 @@ func TestBootstrapClientInvalidURL(t *testing.T) {
 	// and are requesting remote root regardless of checkInitialized
 	// value
 	assert.EqualError(t, err, err2.Error())
+}
+
+func TestPublishTargetsDelgationCanUseUserKeyWithArbitaryRole(t *testing.T) {
+	testPublishTargetsDelgationCanUseUserKeyWithArbitaryRole(t, false)
+	testPublishTargetsDelgationCanUseUserKeyWithArbitaryRole(t, true)
+}
+
+func testPublishTargetsDelgationCanUseUserKeyWithArbitaryRole(t *testing.T, x509 bool) {
+	gun := "docker.com/notary"
+	ts := fullTestServer(t)
+	defer ts.Close()
+
+	// this is the original repo - it owns the root/targets keys and creates
+	// the delegation to which it doesn't have the key (so server snapshot
+	// signing would be required)
+	ownerRepo, _ := initializeRepo(t, data.ECDSAKey, gun, ts.URL, true)
+	fmt.Println(ownerRepo.baseDir)
+
+	// this is a user, or otherwise a repo that only has access to the delegation
+	// key so it can publish targets to the delegated role
+	delgRepo, _ := newRepoToTestRepo(t, ownerRepo, true)
+	fmt.Println(delgRepo.baseDir)
+
+	// create a key on the owner repo
+	aKey := createKey(t, ownerRepo, "user", x509)
+	aKeyID, err := utils.CanonicalKeyID(aKey)
+	assert.NoError(t, err)
+	// move this to the user key directory, and ensure that we can sign with it
+	assert.NoError(t, os.Rename(
+		filepath.Join(ownerRepo.baseDir, "private/user_keys", gun, aKeyID+".key"),
+		filepath.Join(ownerRepo.baseDir, "private/user_keys", aKeyID+".key")))
+
+	// create a key on the delegated repo
+	bKey := createKey(t, delgRepo, "notARealRoleName", x509)
+	bKeyID, err := utils.CanonicalKeyID(bKey)
+	assert.NoError(t, err)
+	assert.NoError(t, os.Rename(
+		filepath.Join(delgRepo.baseDir, "private/user_keys", gun, bKeyID+".key"),
+		filepath.Join(delgRepo.baseDir, "private/user_keys", bKeyID+".key")))
+
+	// clear metadata and unencrypted private key cache
+	var ownerRec, delgRec *passRoleRecorder
+	ownerRepo, ownerRec = newRepoToTestRepo(t, ownerRepo, false)
+	delgRepo, delgRec = newRepoToTestRepo(t, delgRepo, false)
+
+	// owner creates delegations, adds the delegated key to them, and publishes them
+	assert.NoError(t,
+		ownerRepo.AddDelegation("targets/a", 1, []data.PublicKey{aKey}, []string{""}),
+		"error creating delegation")
+	assert.NoError(t,
+		ownerRepo.AddDelegation("targets/a/b", 1, []data.PublicKey{bKey}, []string{""}),
+		"error creating delegation")
+
+	assert.NoError(t, ownerRepo.Publish())
+	// delegation parents all get signed
+	ownerRec.assertAsked(t, []string{data.CanonicalTargetsRole, "targets/a"})
+
+	// delegated repo now publishes to delegated roles, but it will need
+	// to download those roles first, since it doesn't know about them
+	assertPublishToRolesSucceeds(t, delgRepo, []string{"targets/a/b"},
+		[]string{"targets/a/b"})
+
+	delgRec.assertAsked(t, []string{"targets/a/b"})
 }

--- a/cmd/notary/prettyprint.go
+++ b/cmd/notary/prettyprint.go
@@ -98,7 +98,10 @@ func prettyPrintKeys(keyStores []trustmanager.KeyStore, writer io.Writer) {
 		for keyPath, role := range store.ListKeys() {
 			gun := ""
 			if role != data.CanonicalRootRole {
-				gun = filepath.Dir(keyPath)
+				dirPath := filepath.Dir(keyPath)
+				if dirPath != "." { // no gun
+					gun = dirPath
+				}
 			}
 			info = append(info, keyInfo{
 				role:     role,
@@ -108,6 +111,7 @@ func prettyPrintKeys(keyStores []trustmanager.KeyStore, writer io.Writer) {
 			})
 		}
 	}
+
 	if len(info) == 0 {
 		writer.Write([]byte("No signing keys found.\n"))
 		return

--- a/cmd/notary/prettyprint_test.go
+++ b/cmd/notary/prettyprint_test.go
@@ -93,30 +93,33 @@ func TestPrettyPrintRootAndSigningKeys(t *testing.T) {
 
 	longNameShortened := "..." + strings.Repeat("z", 37)
 
-	// just use the same key for testing
-	key, err := trustmanager.GenerateED25519Key(rand.Reader)
-	assert.NoError(t, err)
+	keys := make([]data.PrivateKey, 3)
+	for i := 0; i < 3; i++ {
+		key, err := trustmanager.GenerateED25519Key(rand.Reader)
+		assert.NoError(t, err)
+		keys[i] = key
+	}
 
 	root := data.CanonicalRootRole
 
 	// add keys to the key stores
-	err = keyStores[0].AddKey(key.ID(), root, key)
-	assert.NoError(t, err)
-
-	err = keyStores[1].AddKey(key.ID(), root, key)
-	assert.NoError(t, err)
-
-	err = keyStores[0].AddKey(strings.Repeat("a/", 30)+key.ID(), "targets", key)
-	assert.NoError(t, err)
-
-	err = keyStores[1].AddKey("short/gun/"+key.ID(), "snapshot", key)
-	assert.NoError(t, err)
+	assert.NoError(t, keyStores[0].AddKey(keys[0].ID(), root, keys[0]))
+	assert.NoError(t, keyStores[1].AddKey(keys[0].ID(), root, keys[0]))
+	assert.NoError(t, keyStores[0].AddKey(strings.Repeat("a/", 30)+keys[0].ID(), "targets", keys[0]))
+	assert.NoError(t, keyStores[1].AddKey("short/gun/"+keys[0].ID(), "snapshot", keys[0]))
+	assert.NoError(t, keyStores[0].AddKey(keys[1].ID(), "targets/a", keys[1]))
+	assert.NoError(t, keyStores[0].AddKey(keys[2].ID(), "invalidRole", keys[2]))
 
 	expected := [][]string{
-		{root, key.ID(), keyStores[0].Name()},
-		{root, key.ID(), longNameShortened},
-		{"targets", "..." + strings.Repeat("/a", 11), key.ID(), keyStores[0].Name()},
-		{"snapshot", "short/gun", key.ID(), longNameShortened},
+		// root always comes first
+		{root, keys[0].ID(), keyStores[0].Name()},
+		{root, keys[0].ID(), longNameShortened},
+		// these have no gun, so they come first
+		{"invalidRole", keys[2].ID(), keyStores[0].Name()},
+		{"targets/a", keys[1].ID(), keyStores[0].Name()},
+		// these have guns, and are sorted then by guns
+		{"targets", "..." + strings.Repeat("/a", 11), keys[0].ID(), keyStores[0].Name()},
+		{"snapshot", "short/gun", keys[0].ID(), longNameShortened},
 	}
 
 	var b bytes.Buffer

--- a/trustmanager/keyfilestore.go
+++ b/trustmanager/keyfilestore.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	rootKeysSubdir    = "root_keys"
+	userKeysSubdir    = "user_keys"
 	nonRootKeysSubdir = "tuf_keys"
 	privDir           = "private"
 )
@@ -244,8 +245,10 @@ func listKeys(s LimitedFileStore) map[string]string {
 		var keyIDFull string
 		if strings.HasPrefix(f, rootKeysSubdir+"/") {
 			keyIDFull = strings.TrimPrefix(f, rootKeysSubdir+"/")
-		} else {
+		} else if strings.HasPrefix(f, nonRootKeysSubdir+"/") {
 			keyIDFull = strings.TrimPrefix(f, nonRootKeysSubdir+"/")
+		} else {
+			keyIDFull = strings.TrimPrefix(f, userKeysSubdir+"/")
 		}
 
 		keyIDFull = strings.TrimSpace(keyIDFull)
@@ -301,10 +304,16 @@ func removeKey(s LimitedFileStore, cachedKeys map[string]*cachedKey, name string
 
 // Assumes 2 subdirectories, 1 containing root keys and 1 containing tuf keys
 func getSubdir(alias string) string {
-	if alias == "root" {
+	if alias == data.CanonicalRootRole {
 		return rootKeysSubdir
 	}
-	return nonRootKeysSubdir
+
+	for _, role := range data.BaseRoles {
+		if role == alias {
+			return nonRootKeysSubdir
+		}
+	}
+	return userKeysSubdir
 }
 
 // Given a key ID, gets the bytes and alias belonging to that key if the key


### PR DESCRIPTION
where users can keep user keys.

This makes it so that we can sign with any key in the user_keys subdir.  Currently,
created keys are created in the user_keys subdirectory under the gun subdirectory,
but this can be a future change.

Note that user keys can be ANY role that is not a valid role, so we don't write
ourselves into a corner yet.

Signed-off-by: Ying Li <ying.li@docker.com>

We've also tested this manually by building a binary, by creating a key and moving to `../private/user_keys/SHA.key`, and were able to add a delegation and add a target to a delegation using a hacked up version of #440.