### PR TITLE
Add FileMeta for previous timestamp to current timestamp

### DIFF
--- a/client/client_root_validation_test.go
+++ b/client/client_root_validation_test.go
@@ -31,8 +31,7 @@ func validateRootSuccessfully(t *testing.T, rootType string) {
 	defer os.RemoveAll(repo.baseDir)
 
 	// tests need to manually boostrap timestamp as client doesn't generate it
-	err := repo.tufRepo.InitTimestamp()
-	assert.NoError(t, err, "error creating repository: %s", err)
+	repo.tufRepo.InitTimestamp()
 
 	// Initialize is supposed to have created new certificate for this repository
 	// Lets check for it and store it for later use
@@ -44,7 +43,7 @@ func validateRootSuccessfully(t *testing.T, rootType string) {
 	//
 	// Test TOFUS logic. We remove all certs and expect a new one to be added after ListTargets
 	//
-	err = repo.CertStore.RemoveAll()
+	err := repo.CertStore.RemoveAll()
 	assert.NoError(t, err)
 	assert.Len(t, repo.CertStore.GetCertificates(), 0)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1116,8 +1116,7 @@ func testListTarget(t *testing.T, rootType string) {
 	defer os.RemoveAll(repo.baseDir)
 
 	// tests need to manually bootstrap timestamp as client doesn't generate it
-	err := repo.tufRepo.InitTimestamp()
-	assert.NoError(t, err, "error creating repository: %s", err)
+	repo.tufRepo.InitTimestamp()
 
 	latestTarget := addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
 	currentTarget := addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt")
@@ -1172,8 +1171,7 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	defer os.RemoveAll(repo.baseDir)
 
 	// tests need to manually bootstrap timestamp as client doesn't generate it
-	err := repo.tufRepo.InitTimestamp()
-	assert.NoError(t, err, "error creating repository: %s", err)
+	repo.tufRepo.InitTimestamp()
 
 	latestTarget := addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
 	currentTarget := addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt")

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/tuf/testutils"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/notary/server/storage"
@@ -51,14 +52,18 @@ func TestGetTimestampKey(t *testing.T) {
 
 func TestGetTimestamp(t *testing.T) {
 	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
+	_, repo, crypto, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
 
-	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.Marshal(snapshot)
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
+	snapJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
 
+	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 0, Data: rootJSON})
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
-	_, err := GetOrCreateTimestampKey("gun", store, crypto, data.ED25519Key)
+	_, err = GetOrCreateTimestampKey("gun", store, crypto, data.ED25519Key)
 	assert.Nil(t, err, "GetKey errored")
 
 	_, err = GetOrCreateTimestamp("gun", store, crypto)
@@ -67,21 +72,24 @@ func TestGetTimestamp(t *testing.T) {
 
 func TestGetTimestampNewSnapshot(t *testing.T) {
 	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
+	_, repo, crypto, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
 
-	snapshot := data.SignedSnapshot{}
-	snapshot.Signed.Version = 0
-	snapJSON, _ := json.Marshal(snapshot)
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
+	snapJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
 
+	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 0, Data: rootJSON})
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
 	// create a key to be used by GetTimestamp
-	_, err := GetOrCreateTimestampKey("gun", store, crypto, data.ED25519Key)
+	_, err = GetOrCreateTimestampKey("gun", store, crypto, data.ED25519Key)
 	assert.Nil(t, err, "GetKey errored")
 
 	ts1, err := GetOrCreateTimestamp("gun", store, crypto)
 	assert.Nil(t, err, "GetTimestamp errored")
 
-	snapshot = data.SignedSnapshot{}
+	snapshot := data.SignedSnapshot{}
 	snapshot.Signed.Version = 1
 	snapJSON, _ = json.Marshal(snapshot)
 

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -1,6 +1,7 @@
 package timestamp
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
@@ -90,4 +91,9 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 	assert.NoError(t, err, "GetTimestamp errored")
 
 	assert.NotEqual(t, ts1, ts2, "Timestamp was not regenerated when snapshot changed")
+
+	ts := &data.SignedTimestamp{}
+	err = json.Unmarshal(ts2, &ts)
+	meta, err := data.NewFileMeta(bytes.NewReader(ts1), "sha256")
+	assert.EqualValues(t, meta, ts.Signed.Meta[data.PreviousTSName])
 }

--- a/tuf/data/timestamp.go
+++ b/tuf/data/timestamp.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"bytes"
 	"time"
 
 	"github.com/jfrazelle/go/canonical/json"
@@ -27,26 +26,16 @@ type Timestamp struct {
 }
 
 // NewTimestamp initializes a timestamp with an existing snapshot
-func NewTimestamp(snapshot *Signed) (*SignedTimestamp, error) {
-	snapshotJSON, err := json.Marshal(snapshot)
-	if err != nil {
-		return nil, err
-	}
-	snapshotMeta, err := NewFileMeta(bytes.NewReader(snapshotJSON), "sha256")
-	if err != nil {
-		return nil, err
-	}
+func NewTimestamp() *SignedTimestamp {
 	return &SignedTimestamp{
 		Signatures: make([]Signature, 0),
 		Signed: Timestamp{
 			Type:    TUFTypes["timestamp"],
 			Version: 0,
 			Expires: DefaultExpires("timestamp"),
-			Meta: Files{
-				CanonicalSnapshotRole: snapshotMeta,
-			},
+			Meta:    make(Files),
 		},
-	}, nil
+	}
 }
 
 // ToSigned partially serializes a SignedTimestamp such that it can

--- a/tuf/data/timestamp.go
+++ b/tuf/data/timestamp.go
@@ -7,6 +7,10 @@ import (
 	"github.com/jfrazelle/go/canonical/json"
 )
 
+// PreviousTSName is the map key under which the meta for the previous
+// timestamp will be included in the current timestamp.
+const PreviousTSName = "previous_timestamp"
+
 // SignedTimestamp is a fully unpacked timestamp.json
 type SignedTimestamp struct {
 	Signatures []Signature

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -325,7 +325,8 @@ func (tr *Repo) InitRepo(consistent bool) error {
 	if err := tr.InitSnapshot(); err != nil {
 		return err
 	}
-	return tr.InitTimestamp()
+	tr.InitTimestamp()
+	return nil
 }
 
 // InitRoot initializes an empty root file with the 4 core roles based
@@ -394,18 +395,8 @@ func (tr *Repo) InitSnapshot() error {
 }
 
 // InitTimestamp initializes a timestamp based on the current snapshot
-func (tr *Repo) InitTimestamp() error {
-	snap, err := tr.Snapshot.ToSigned()
-	if err != nil {
-		return err
-	}
-	timestamp, err := data.NewTimestamp(snap)
-	if err != nil {
-		return err
-	}
-
-	tr.Timestamp = timestamp
-	return nil
+func (tr *Repo) InitTimestamp() {
+	tr.Timestamp = data.NewTimestamp()
 }
 
 // SetRoot parses the Signed object into a SignedRoot object, sets


### PR DESCRIPTION
Marked as PoC to prevent preemptive merging. This is complete working and tested code.

This creates a verifiable history chain. Still waiting for feedback on this idea from various advisors.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)