### PR TITLE
Offline operation when server not reachable

### DIFF
--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -426,7 +426,9 @@ func tokenAuth(config *viper.Viper, baseTransport *http.Transport, gun string,
 	}
 	resp, err := pingClient.Do(req)
 	if err != nil {
-		fatalf(err.Error())
+		logrus.Errorf("could not reach %s: %s", trustServerURL, err.Error())
+		logrus.Info("continuing in offline mode")
+		return nil
 	}
 	defer resp.Body.Close()
 

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -395,10 +395,11 @@ func getTransport(config *viper.Viper, gun string, readOnly bool) http.RoundTrip
 		TLSClientConfig:     tlsConfig,
 		DisableKeepAlives:   true,
 	}
-	return tokenAuth(config, base, gun, readOnly)
+	trustServerURL := getRemoteTrustServer(config)
+	return tokenAuth(trustServerURL, base, gun, readOnly)
 }
 
-func tokenAuth(config *viper.Viper, baseTransport *http.Transport, gun string,
+func tokenAuth(trustServerURL string, baseTransport *http.Transport, gun string,
 	readOnly bool) http.RoundTripper {
 
 	// TODO(dmcgowan): add notary specific headers
@@ -407,7 +408,6 @@ func tokenAuth(config *viper.Viper, baseTransport *http.Transport, gun string,
 		Transport: authTransport,
 		Timeout:   5 * time.Second,
 	}
-	trustServerURL := getRemoteTrustServer(config)
 	endpoint, err := url.Parse(trustServerURL)
 	if err != nil {
 		fatalf("Could not parse remote trust server url (%s): %s", trustServerURL, err.Error())
@@ -430,7 +430,16 @@ func tokenAuth(config *viper.Viper, baseTransport *http.Transport, gun string,
 		logrus.Info("continuing in offline mode")
 		return nil
 	}
+	// non-nil err means we must close body
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// If we didn't get a 2XX range status code, we're not talking to a notary server.
+		// The http client should be configured to handle redirects so at this point, 3XX is
+		// not a valid status code.
+		logrus.Errorf("could not reach %s: %d", trustServerURL, resp.StatusCode)
+		logrus.Info("continuing in offline mode")
+		return nil
+	}
 
 	challengeManager := auth.NewSimpleChallengeManager()
 	if err := challengeManager.AddResponse(resp); err != nil {

--- a/cmd/notary/tuf_test.go
+++ b/cmd/notary/tuf_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenAuth(t *testing.T) {
+	var (
+		readOnly      bool
+		baseTransport = &http.Transport{}
+		gun           = "test"
+	)
+	require.Nil(t, tokenAuth("https://localhost:9999", baseTransport, gun, readOnly))
+}
+
+func NotFoundTestHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(404)
+}
+
+func TestTokenAuthNon200Status(t *testing.T) {
+	var (
+		readOnly      bool
+		baseTransport = &http.Transport{}
+		gun           = "test"
+	)
+	s := httptest.NewServer(http.HandlerFunc(NotFoundTestHandler))
+	defer s.Close()
+
+	require.Nil(t, tokenAuth(s.URL, baseTransport, gun, readOnly))
+}

--- a/tuf/store/httpstore.go
+++ b/tuf/store/httpstore.go
@@ -85,6 +85,9 @@ func NewHTTPStore(baseURL, metaPrefix, metaExtension, targetsPrefix, keyExtensio
 	if !base.IsAbs() {
 		return nil, errors.New("HTTPStore requires an absolute baseURL")
 	}
+	if roundTrip == nil {
+		return &OfflineStore{}, nil
+	}
 	return &HTTPStore{
 		baseURL:       *base,
 		metaPrefix:    metaPrefix,

--- a/tuf/store/httpstore_test.go
+++ b/tuf/store/httpstore_test.go
@@ -260,3 +260,9 @@ func TestHTTPStoreRemoveAll(t *testing.T) {
 	err = store.RemoveAll()
 	assert.Error(t, err)
 }
+
+func TestHTTPOffline(t *testing.T) {
+	s, err := NewHTTPStore("https://localhost/", "", "", "", "", nil)
+	assert.NoError(t, err)
+	assert.IsType(t, &OfflineStore{}, s)
+}


### PR DESCRIPTION
This only solves for the second error in #468.

~~TODO: need to dig up what specific errors I should be matching when checking the http response error. It probably shouldn't be generic.~~

According to net/http docs, non-2XX responses don't result in an err, which is exclusively reserved for protocol problems or client configuration directives. Added a check for non-2XX StatusCodes and also setting to offline on those.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)