### PR TITLE
Change testutils.EmptyRepo() to use a cert as the root.json root key.

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -153,7 +153,8 @@ func validRootLeafCerts(root *data.SignedRoot, gun string) ([]*x509.Certificate,
 	for _, cert := range allLeafCerts {
 		// Validate that this leaf certificate has a CN that matches the exact gun
 		if cert.Subject.CommonName != gun {
-			logrus.Debugf("error leaf certificate CN: %s doesn't match the given GUN: %s", cert.Subject.CommonName)
+			logrus.Debugf("error leaf certificate CN: %s doesn't match the given GUN: %s",
+				cert.Subject.CommonName, gun)
 			continue
 		}
 		// Make sure the certificate is not expired

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 func TestApplyTargetsChange(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
-	_, err := repo.InitTargets(data.CanonicalTargetsRole)
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
+	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -51,8 +52,9 @@ func TestApplyTargetsChange(t *testing.T) {
 
 // Adding the same target twice doesn't actually add it.
 func TestApplyAddTargetTwice(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
-	_, err := repo.InitTargets(data.CanonicalTargetsRole)
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
+	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -96,8 +98,9 @@ func TestApplyAddTargetTwice(t *testing.T) {
 }
 
 func TestApplyChangelist(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
-	_, err := repo.InitTargets(data.CanonicalTargetsRole)
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
+	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -139,8 +142,9 @@ func TestApplyChangelist(t *testing.T) {
 }
 
 func TestApplyChangelistMulti(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
-	_, err := repo.InitTargets(data.CanonicalTargetsRole)
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
+	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -179,7 +183,8 @@ func TestApplyChangelistMulti(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateDelete(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -236,7 +241,8 @@ func TestApplyTargetsDelegationCreateDelete(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreate2SharedKey(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -333,7 +339,8 @@ func TestApplyTargetsDelegationCreate2SharedKey(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateEdit(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -400,7 +407,8 @@ func TestApplyTargetsDelegationCreateEdit(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationEditNonExisting(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -430,7 +438,8 @@ func TestApplyTargetsDelegationEditNonExisting(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateAlreadyExisting(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -467,7 +476,8 @@ func TestApplyTargetsDelegationCreateAlreadyExisting(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationInvalidRole(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -496,7 +506,8 @@ func TestApplyTargetsDelegationInvalidRole(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationInvalidJSONContent(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -525,7 +536,8 @@ func TestApplyTargetsDelegationInvalidJSONContent(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationInvalidAction(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	ch := changelist.NewTufChange(
 		"bad action",
@@ -535,12 +547,13 @@ func TestApplyTargetsDelegationInvalidAction(t *testing.T) {
 		nil,
 	)
 
-	err := applyTargetsChange(repo, ch)
+	err = applyTargetsChange(repo, ch)
 	assert.Error(t, err)
 }
 
 func TestApplyTargetsChangeInvalidType(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	ch := changelist.NewTufChange(
 		changelist.ActionCreate,
@@ -550,7 +563,7 @@ func TestApplyTargetsChangeInvalidType(t *testing.T) {
 		nil,
 	)
 
-	err := applyTargetsChange(repo, ch)
+	err = applyTargetsChange(repo, ch)
 	assert.Error(t, err)
 }
 
@@ -558,7 +571,8 @@ func TestApplyTargetsChangeInvalidType(t *testing.T) {
 // These next 2 tests check that attempting to edit an existing role to
 // create an invalid role errors in both possible combinations.
 func TestApplyTargetsDelegationConflictPathsPrefixes(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -604,7 +618,8 @@ func TestApplyTargetsDelegationConflictPathsPrefixes(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationConflictPrefixesPaths(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -650,7 +665,8 @@ func TestApplyTargetsDelegationConflictPrefixesPaths(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateInvalid(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -680,7 +696,8 @@ func TestApplyTargetsDelegationCreateInvalid(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreate2Deep(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -760,11 +777,12 @@ func TestApplyTargetsDelegationCreate2Deep(t *testing.T) {
 
 // Applying a delegation whose parent doesn't exist fails.
 func TestApplyTargetsDelegationParentDoesntExist(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	// make sure a key exists for the previous level, so it's not a missing
 	// key error, but we don't care about this key
-	_, err := cs.Create("targets/level1", data.ED25519Key)
+	_, err = cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1/level2", data.ED25519Key)
@@ -795,7 +813,8 @@ func TestApplyTargetsDelegationParentDoesntExist(t *testing.T) {
 
 // If there is no delegation target, ApplyTargets creates it
 func TestApplyChangelistCreatesDelegation(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -833,7 +852,8 @@ func TestApplyChangelistCreatesDelegation(t *testing.T) {
 
 // Each change applies only to the role specified
 func TestApplyChangelistTargetsToMultipleRoles(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
@@ -881,7 +901,8 @@ func TestApplyChangelistTargetsToMultipleRoles(t *testing.T) {
 
 // ApplyTargets falls back to role that exists when adding or deleting a change
 func TestApplyChangelistTargetsFallbackRoles(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -922,7 +943,8 @@ func TestApplyChangelistTargetsFallbackRoles(t *testing.T) {
 
 // changeTargetMeta fallback fails with ErrInvalidRole if role is invalid
 func TestChangeTargetMetaFallbackFailsInvalidRole(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	hash := sha256.Sum256([]byte{})
 	f := &data.FileMeta{
@@ -948,7 +970,8 @@ func TestChangeTargetMetaFallbackFailsInvalidRole(t *testing.T) {
 // If applying a change fails due to a prefix error, it does not fall back
 // on the parent.
 func TestChangeTargetMetaDoesntFallbackIfPrefixError(t *testing.T) {
-	_, repo, cs := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestApplyTargetsChange(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
@@ -52,7 +52,7 @@ func TestApplyTargetsChange(t *testing.T) {
 
 // Adding the same target twice doesn't actually add it.
 func TestApplyAddTargetTwice(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
@@ -98,7 +98,7 @@ func TestApplyAddTargetTwice(t *testing.T) {
 }
 
 func TestApplyChangelist(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
@@ -142,7 +142,7 @@ func TestApplyChangelist(t *testing.T) {
 }
 
 func TestApplyChangelistMulti(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	_, err = repo.InitTargets(data.CanonicalTargetsRole)
 	assert.NoError(t, err)
@@ -183,7 +183,7 @@ func TestApplyChangelistMulti(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateDelete(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -241,7 +241,7 @@ func TestApplyTargetsDelegationCreateDelete(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreate2SharedKey(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -339,7 +339,7 @@ func TestApplyTargetsDelegationCreate2SharedKey(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateEdit(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -407,7 +407,7 @@ func TestApplyTargetsDelegationCreateEdit(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationEditNonExisting(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -438,7 +438,7 @@ func TestApplyTargetsDelegationEditNonExisting(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateAlreadyExisting(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -476,7 +476,7 @@ func TestApplyTargetsDelegationCreateAlreadyExisting(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationInvalidRole(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -506,7 +506,7 @@ func TestApplyTargetsDelegationInvalidRole(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationInvalidJSONContent(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -536,7 +536,7 @@ func TestApplyTargetsDelegationInvalidJSONContent(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationInvalidAction(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	ch := changelist.NewTufChange(
@@ -552,7 +552,7 @@ func TestApplyTargetsDelegationInvalidAction(t *testing.T) {
 }
 
 func TestApplyTargetsChangeInvalidType(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	ch := changelist.NewTufChange(
@@ -571,7 +571,7 @@ func TestApplyTargetsChangeInvalidType(t *testing.T) {
 // These next 2 tests check that attempting to edit an existing role to
 // create an invalid role errors in both possible combinations.
 func TestApplyTargetsDelegationConflictPathsPrefixes(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -618,7 +618,7 @@ func TestApplyTargetsDelegationConflictPathsPrefixes(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationConflictPrefixesPaths(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -665,7 +665,7 @@ func TestApplyTargetsDelegationConflictPrefixesPaths(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreateInvalid(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -696,7 +696,7 @@ func TestApplyTargetsDelegationCreateInvalid(t *testing.T) {
 }
 
 func TestApplyTargetsDelegationCreate2Deep(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -777,7 +777,7 @@ func TestApplyTargetsDelegationCreate2Deep(t *testing.T) {
 
 // Applying a delegation whose parent doesn't exist fails.
 func TestApplyTargetsDelegationParentDoesntExist(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	// make sure a key exists for the previous level, so it's not a missing
@@ -813,7 +813,7 @@ func TestApplyTargetsDelegationParentDoesntExist(t *testing.T) {
 
 // If there is no delegation target, ApplyTargets creates it
 func TestApplyChangelistCreatesDelegation(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -852,7 +852,7 @@ func TestApplyChangelistCreatesDelegation(t *testing.T) {
 
 // Each change applies only to the role specified
 func TestApplyChangelistTargetsToMultipleRoles(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
@@ -901,7 +901,7 @@ func TestApplyChangelistTargetsToMultipleRoles(t *testing.T) {
 
 // ApplyTargets falls back to role that exists when adding or deleting a change
 func TestApplyChangelistTargetsFallbackRoles(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	hash := sha256.Sum256([]byte{})
@@ -943,7 +943,7 @@ func TestApplyChangelistTargetsFallbackRoles(t *testing.T) {
 
 // changeTargetMeta fallback fails with ErrInvalidRole if role is invalid
 func TestChangeTargetMetaFallbackFailsInvalidRole(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	hash := sha256.Sum256([]byte{})
@@ -970,7 +970,7 @@ func TestChangeTargetMetaFallbackFailsInvalidRole(t *testing.T) {
 // If applying a change fails due to a prefix error, it does not fall back
 // on the parent.
 func TestChangeTargetMetaDoesntFallbackIfPrefixError(t *testing.T) {
-	_, repo, cs, err := testutils.EmptyRepo()
+	_, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)

--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -173,7 +173,7 @@ func TestGetKeyHandlerCreatesOnce(t *testing.T) {
 
 func TestGetHandlerRoot(t *testing.T) {
 	metaStore := storage.NewMemStorage()
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("gun")
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -201,7 +201,7 @@ func TestGetHandlerRoot(t *testing.T) {
 
 func TestGetHandlerTimestamp(t *testing.T) {
 	metaStore := storage.NewMemStorage()
-	_, repo, crypto, err := testutils.EmptyRepo()
+	_, repo, crypto, err := testutils.EmptyRepo("gun")
 	assert.NoError(t, err)
 
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
@@ -235,7 +235,7 @@ func TestGetHandlerTimestamp(t *testing.T) {
 
 func TestGetHandlerSnapshot(t *testing.T) {
 	metaStore := storage.NewMemStorage()
-	_, repo, crypto, err := testutils.EmptyRepo()
+	_, repo, crypto, err := testutils.EmptyRepo("gun")
 	assert.NoError(t, err)
 
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
@@ -323,7 +323,7 @@ func TestAtomicUpdateValidationFailurePropagated(t *testing.T) {
 	gun := "testGUN"
 	vars := map[string]string{"imageName": gun}
 
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo(gun)
 	assert.NoError(t, err)
 	copyTimestampKey(t, kdb, metaStore, gun)
 	state := handlerState{store: metaStore, crypto: cs}
@@ -365,7 +365,7 @@ func TestAtomicUpdateNonValidationFailureNotPropagated(t *testing.T) {
 	gun := "testGUN"
 	vars := map[string]string{"imageName": gun}
 
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo(gun)
 	assert.NoError(t, err)
 	copyTimestampKey(t, kdb, metaStore, gun)
 	state := handlerState{store: &failStore{*metaStore}, crypto: cs}
@@ -406,7 +406,7 @@ func TestAtomicUpdateVersionErrorPropagated(t *testing.T) {
 	gun := "testGUN"
 	vars := map[string]string{"imageName": gun}
 
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo(gun)
 	assert.NoError(t, err)
 	copyTimestampKey(t, kdb, metaStore, gun)
 	state := handlerState{store: &invalidVersionStore{*metaStore}, crypto: cs}

--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -173,7 +173,8 @@ func TestGetKeyHandlerCreatesOnce(t *testing.T) {
 
 func TestGetHandlerRoot(t *testing.T) {
 	metaStore := storage.NewMemStorage()
-	_, repo, _ := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, "metaStore", metaStore)
@@ -200,7 +201,8 @@ func TestGetHandlerRoot(t *testing.T) {
 
 func TestGetHandlerTimestamp(t *testing.T) {
 	metaStore := storage.NewMemStorage()
-	_, repo, crypto := testutils.EmptyRepo()
+	_, repo, crypto, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
 
@@ -233,7 +235,8 @@ func TestGetHandlerTimestamp(t *testing.T) {
 
 func TestGetHandlerSnapshot(t *testing.T) {
 	metaStore := storage.NewMemStorage()
-	_, repo, crypto := testutils.EmptyRepo()
+	_, repo, crypto, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	ctx := getContext(handlerState{store: metaStore, crypto: crypto})
 
@@ -320,7 +323,8 @@ func TestAtomicUpdateValidationFailurePropagated(t *testing.T) {
 	gun := "testGUN"
 	vars := map[string]string{"imageName": gun}
 
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	copyTimestampKey(t, kdb, metaStore, gun)
 	state := handlerState{store: metaStore, crypto: cs}
 
@@ -361,7 +365,8 @@ func TestAtomicUpdateNonValidationFailureNotPropagated(t *testing.T) {
 	gun := "testGUN"
 	vars := map[string]string{"imageName": gun}
 
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	copyTimestampKey(t, kdb, metaStore, gun)
 	state := handlerState{store: &failStore{*metaStore}, crypto: cs}
 
@@ -401,7 +406,8 @@ func TestAtomicUpdateVersionErrorPropagated(t *testing.T) {
 	gun := "testGUN"
 	vars := map[string]string{"imageName": gun}
 
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	copyTimestampKey(t, kdb, metaStore, gun)
 	state := handlerState{store: &invalidVersionStore{*metaStore}, crypto: cs}
 

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -69,7 +69,8 @@ func getUpdates(r, tg, sn, ts *data.Signed) (
 }
 
 func TestValidateEmptyNew(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -85,7 +86,8 @@ func TestValidateEmptyNew(t *testing.T) {
 }
 
 func TestValidateNoNewRoot(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -102,7 +104,8 @@ func TestValidateNoNewRoot(t *testing.T) {
 }
 
 func TestValidateNoNewTargets(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -119,7 +122,8 @@ func TestValidateNoNewTargets(t *testing.T) {
 }
 
 func TestValidateOnlySnapshot(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -138,7 +142,8 @@ func TestValidateOnlySnapshot(t *testing.T) {
 }
 
 func TestValidateOldRoot(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -155,7 +160,8 @@ func TestValidateOldRoot(t *testing.T) {
 }
 
 func TestValidateRootRotation(t *testing.T) {
-	kdb, repo, crypto := testutils.EmptyRepo()
+	kdb, repo, crypto, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -200,7 +206,8 @@ func TestValidateRootRotation(t *testing.T) {
 }
 
 func TestValidateNoRoot(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -217,7 +224,8 @@ func TestValidateNoRoot(t *testing.T) {
 }
 
 func TestValidateSnapshotMissing(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -234,7 +242,8 @@ func TestValidateSnapshotMissing(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerateNoPrev(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
 
@@ -258,7 +267,8 @@ func TestValidateSnapshotGenerateNoPrev(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerateWithPrev(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
 
@@ -298,7 +308,8 @@ func TestValidateSnapshotGenerateWithPrev(t *testing.T) {
 }
 
 func TestValidateSnapshotGeneratePrevCorrupt(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
 
@@ -328,7 +339,8 @@ func TestValidateSnapshotGeneratePrevCorrupt(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerateNoTargets(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
 
@@ -352,7 +364,8 @@ func TestValidateSnapshotGenerateNoTargets(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerate(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
 
@@ -381,7 +394,8 @@ func TestValidateSnapshotGenerate(t *testing.T) {
 // happen if pushing an existing repository from one server to another that
 // does not have the repo.
 func TestValidateRootNoTimestampKey(t *testing.T) {
-	_, oldRepo, cs := testutils.EmptyRepo()
+	_, oldRepo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	r, tg, sn, ts, err := testutils.Sign(oldRepo)
 	assert.NoError(t, err)
@@ -412,7 +426,8 @@ func TestValidateRootNoTimestampKey(t *testing.T) {
 // repository from one server to another that had already initialized the same
 // repo.
 func TestValidateRootInvalidTimestampKey(t *testing.T) {
-	_, oldRepo, cs := testutils.EmptyRepo()
+	_, oldRepo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 
 	r, tg, sn, ts, err := testutils.Sign(oldRepo)
 	assert.NoError(t, err)
@@ -434,7 +449,8 @@ func TestValidateRootInvalidTimestampKey(t *testing.T) {
 
 // If the timestamp role has a threshold > 1, validation fails.
 func TestValidateRootInvalidTimestampThreshold(t *testing.T) {
-	kdb, oldRepo, cs := testutils.EmptyRepo()
+	kdb, oldRepo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	tsRole, ok := oldRepo.Root.Signed.Roles[data.CanonicalTimestampRole]
 	assert.True(t, ok)
 	tsRole.Threshold = 2
@@ -456,7 +472,8 @@ func TestValidateRootInvalidTimestampThreshold(t *testing.T) {
 // If any role has a threshold < 1, validation fails
 func TestValidateRootInvalidZeroThreshold(t *testing.T) {
 	for _, role := range data.BaseRoles {
-		kdb, oldRepo, cs := testutils.EmptyRepo()
+		kdb, oldRepo, cs, err := testutils.EmptyRepo()
+		assert.NoError(t, err)
 		tsRole, ok := oldRepo.Root.Signed.Roles[role]
 		assert.True(t, ok)
 		tsRole.Threshold = 0
@@ -480,7 +497,8 @@ func TestValidateRootInvalidZeroThreshold(t *testing.T) {
 // These tests remove a role from the Root file and
 // check for a validation.ErrBadRoot
 func TestValidateRootRoleMissing(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	delete(repo.Root.Signed.Roles, "root")
@@ -499,7 +517,8 @@ func TestValidateRootRoleMissing(t *testing.T) {
 }
 
 func TestValidateTargetsRoleMissing(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	delete(repo.Root.Signed.Roles, "targets")
@@ -518,7 +537,8 @@ func TestValidateTargetsRoleMissing(t *testing.T) {
 }
 
 func TestValidateSnapshotRoleMissing(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	delete(repo.Root.Signed.Roles, "snapshot")
@@ -540,7 +560,8 @@ func TestValidateSnapshotRoleMissing(t *testing.T) {
 
 // ### Signature missing negative tests ###
 func TestValidateRootSigMissing(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	delete(repo.Root.Signed.Roles, "snapshot")
@@ -562,7 +583,8 @@ func TestValidateRootSigMissing(t *testing.T) {
 }
 
 func TestValidateTargetsSigMissing(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -582,7 +604,8 @@ func TestValidateTargetsSigMissing(t *testing.T) {
 }
 
 func TestValidateSnapshotSigMissing(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -605,7 +628,8 @@ func TestValidateSnapshotSigMissing(t *testing.T) {
 
 // ### Corrupted metadata negative tests ###
 func TestValidateRootCorrupt(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -625,7 +649,8 @@ func TestValidateRootCorrupt(t *testing.T) {
 }
 
 func TestValidateTargetsCorrupt(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -645,7 +670,8 @@ func TestValidateTargetsCorrupt(t *testing.T) {
 }
 
 func TestValidateSnapshotCorrupt(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -668,7 +694,8 @@ func TestValidateSnapshotCorrupt(t *testing.T) {
 
 // ### Snapshot size mismatch negative tests ###
 func TestValidateRootModifiedSize(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -692,7 +719,8 @@ func TestValidateRootModifiedSize(t *testing.T) {
 }
 
 func TestValidateTargetsModifiedSize(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -716,7 +744,8 @@ func TestValidateTargetsModifiedSize(t *testing.T) {
 
 // ### Snapshot hash mismatch negative tests ###
 func TestValidateRootModifiedHash(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -741,7 +770,8 @@ func TestValidateRootModifiedHash(t *testing.T) {
 }
 
 func TestValidateTargetsModifiedHash(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
@@ -776,10 +806,11 @@ func TestGenerateSnapshotNoRole(t *testing.T) {
 }
 
 func TestGenerateSnapshotNoKey(t *testing.T) {
-	kdb, _, _ := testutils.EmptyRepo()
+	kdb, _, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
-	_, err := generateSnapshot("gun", kdb, nil, store)
+	_, err = generateSnapshot("gun", kdb, nil, store)
 	assert.Error(t, err)
 	assert.IsType(t, validation.ErrBadHierarchy{}, err)
 }
@@ -788,7 +819,8 @@ func TestGenerateSnapshotNoKey(t *testing.T) {
 
 // ### Target validation with delegations tests
 func TestLoadTargetsFromStore(t *testing.T) {
-	_, repo, _ := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	st, err := repo.SignTargets(
@@ -828,7 +860,8 @@ func TestLoadTargetsFromStore(t *testing.T) {
 }
 
 func TestValidateTargetsLoadParent(t *testing.T) {
-	_, baseRepo, cs := testutils.EmptyRepo()
+	_, baseRepo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
@@ -879,7 +912,8 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 }
 
 func TestValidateTargetsParentInUpdate(t *testing.T) {
-	_, baseRepo, cs := testutils.EmptyRepo()
+	_, baseRepo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
@@ -936,7 +970,8 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 }
 
 func TestValidateTargetsParentNotFound(t *testing.T) {
-	_, baseRepo, cs := testutils.EmptyRepo()
+	_, baseRepo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
@@ -973,7 +1008,8 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 }
 
 func TestValidateTargetsRoleNotInParent(t *testing.T) {
-	kdb, baseRepo, cs := testutils.EmptyRepo()
+	kdb, baseRepo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -69,7 +69,7 @@ func getUpdates(r, tg, sn, ts *data.Signed) (
 }
 
 func TestValidateEmptyNew(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -86,7 +86,7 @@ func TestValidateEmptyNew(t *testing.T) {
 }
 
 func TestValidateNoNewRoot(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -104,7 +104,7 @@ func TestValidateNoNewRoot(t *testing.T) {
 }
 
 func TestValidateNoNewTargets(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -122,7 +122,7 @@ func TestValidateNoNewTargets(t *testing.T) {
 }
 
 func TestValidateOnlySnapshot(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -142,7 +142,7 @@ func TestValidateOnlySnapshot(t *testing.T) {
 }
 
 func TestValidateOldRoot(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -160,7 +160,7 @@ func TestValidateOldRoot(t *testing.T) {
 }
 
 func TestValidateRootRotation(t *testing.T) {
-	kdb, repo, crypto, err := testutils.EmptyRepo()
+	kdb, repo, crypto, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -206,7 +206,7 @@ func TestValidateRootRotation(t *testing.T) {
 }
 
 func TestValidateNoRoot(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -224,7 +224,7 @@ func TestValidateNoRoot(t *testing.T) {
 }
 
 func TestValidateSnapshotMissing(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -242,7 +242,7 @@ func TestValidateSnapshotMissing(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerateNoPrev(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
@@ -267,7 +267,7 @@ func TestValidateSnapshotGenerateNoPrev(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerateWithPrev(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
@@ -308,7 +308,7 @@ func TestValidateSnapshotGenerateWithPrev(t *testing.T) {
 }
 
 func TestValidateSnapshotGeneratePrevCorrupt(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
@@ -339,7 +339,7 @@ func TestValidateSnapshotGeneratePrevCorrupt(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerateNoTargets(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
@@ -364,7 +364,7 @@ func TestValidateSnapshotGenerateNoTargets(t *testing.T) {
 }
 
 func TestValidateSnapshotGenerate(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 	snapRole := kdb.GetRole(data.CanonicalSnapshotRole)
@@ -394,7 +394,7 @@ func TestValidateSnapshotGenerate(t *testing.T) {
 // happen if pushing an existing repository from one server to another that
 // does not have the repo.
 func TestValidateRootNoTimestampKey(t *testing.T) {
-	_, oldRepo, cs, err := testutils.EmptyRepo()
+	_, oldRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	r, tg, sn, ts, err := testutils.Sign(oldRepo)
@@ -426,7 +426,7 @@ func TestValidateRootNoTimestampKey(t *testing.T) {
 // repository from one server to another that had already initialized the same
 // repo.
 func TestValidateRootInvalidTimestampKey(t *testing.T) {
-	_, oldRepo, cs, err := testutils.EmptyRepo()
+	_, oldRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 
 	r, tg, sn, ts, err := testutils.Sign(oldRepo)
@@ -449,7 +449,7 @@ func TestValidateRootInvalidTimestampKey(t *testing.T) {
 
 // If the timestamp role has a threshold > 1, validation fails.
 func TestValidateRootInvalidTimestampThreshold(t *testing.T) {
-	kdb, oldRepo, cs, err := testutils.EmptyRepo()
+	kdb, oldRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	tsRole, ok := oldRepo.Root.Signed.Roles[data.CanonicalTimestampRole]
 	assert.True(t, ok)
@@ -472,7 +472,7 @@ func TestValidateRootInvalidTimestampThreshold(t *testing.T) {
 // If any role has a threshold < 1, validation fails
 func TestValidateRootInvalidZeroThreshold(t *testing.T) {
 	for _, role := range data.BaseRoles {
-		kdb, oldRepo, cs, err := testutils.EmptyRepo()
+		kdb, oldRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 		assert.NoError(t, err)
 		tsRole, ok := oldRepo.Root.Signed.Roles[role]
 		assert.True(t, ok)
@@ -497,7 +497,7 @@ func TestValidateRootInvalidZeroThreshold(t *testing.T) {
 // These tests remove a role from the Root file and
 // check for a validation.ErrBadRoot
 func TestValidateRootRoleMissing(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -517,7 +517,7 @@ func TestValidateRootRoleMissing(t *testing.T) {
 }
 
 func TestValidateTargetsRoleMissing(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -537,7 +537,7 @@ func TestValidateTargetsRoleMissing(t *testing.T) {
 }
 
 func TestValidateSnapshotRoleMissing(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -560,7 +560,7 @@ func TestValidateSnapshotRoleMissing(t *testing.T) {
 
 // ### Signature missing negative tests ###
 func TestValidateRootSigMissing(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -583,7 +583,7 @@ func TestValidateRootSigMissing(t *testing.T) {
 }
 
 func TestValidateTargetsSigMissing(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -604,7 +604,7 @@ func TestValidateTargetsSigMissing(t *testing.T) {
 }
 
 func TestValidateSnapshotSigMissing(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -628,7 +628,7 @@ func TestValidateSnapshotSigMissing(t *testing.T) {
 
 // ### Corrupted metadata negative tests ###
 func TestValidateRootCorrupt(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -649,7 +649,7 @@ func TestValidateRootCorrupt(t *testing.T) {
 }
 
 func TestValidateTargetsCorrupt(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -670,7 +670,7 @@ func TestValidateTargetsCorrupt(t *testing.T) {
 }
 
 func TestValidateSnapshotCorrupt(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -694,7 +694,7 @@ func TestValidateSnapshotCorrupt(t *testing.T) {
 
 // ### Snapshot size mismatch negative tests ###
 func TestValidateRootModifiedSize(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -719,7 +719,7 @@ func TestValidateRootModifiedSize(t *testing.T) {
 }
 
 func TestValidateTargetsModifiedSize(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -744,7 +744,7 @@ func TestValidateTargetsModifiedSize(t *testing.T) {
 
 // ### Snapshot hash mismatch negative tests ###
 func TestValidateRootModifiedHash(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -770,7 +770,7 @@ func TestValidateRootModifiedHash(t *testing.T) {
 }
 
 func TestValidateTargetsModifiedHash(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -806,7 +806,7 @@ func TestGenerateSnapshotNoRole(t *testing.T) {
 }
 
 func TestGenerateSnapshotNoKey(t *testing.T) {
-	kdb, _, _, err := testutils.EmptyRepo()
+	kdb, _, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -819,7 +819,7 @@ func TestGenerateSnapshotNoKey(t *testing.T) {
 
 // ### Target validation with delegations tests
 func TestLoadTargetsFromStore(t *testing.T) {
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -860,7 +860,7 @@ func TestLoadTargetsFromStore(t *testing.T) {
 }
 
 func TestValidateTargetsLoadParent(t *testing.T) {
-	_, baseRepo, cs, err := testutils.EmptyRepo()
+	_, baseRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -912,7 +912,7 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 }
 
 func TestValidateTargetsParentInUpdate(t *testing.T) {
-	_, baseRepo, cs, err := testutils.EmptyRepo()
+	_, baseRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -970,7 +970,7 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 }
 
 func TestValidateTargetsParentNotFound(t *testing.T) {
-	_, baseRepo, cs, err := testutils.EmptyRepo()
+	_, baseRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 
@@ -1008,7 +1008,7 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 }
 
 func TestValidateTargetsRoleNotInParent(t *testing.T) {
-	kdb, baseRepo, cs, err := testutils.EmptyRepo()
+	kdb, baseRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
 

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -37,7 +37,7 @@ func TestValidationErrorFormat(t *testing.T) {
 		http.DefaultTransport,
 	)
 
-	_, repo, _, err := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	assert.NoError(t, err)

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -37,7 +37,8 @@ func TestValidationErrorFormat(t *testing.T) {
 		http.DefaultTransport,
 	)
 
-	_, repo, _ := testutils.EmptyRepo()
+	_, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	assert.NoError(t, err)
 	rs, _, _, _, err := testutils.Serialize(r, tg, sn, ts)

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -312,7 +312,7 @@ func TestSizeMismatchShort(t *testing.T) {
 }
 
 func TestDownloadTargetsHappy(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -333,7 +333,7 @@ func TestDownloadTargetsHappy(t *testing.T) {
 }
 
 func TestDownloadTargetsDeepHappy(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -408,7 +408,7 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 }
 
 func TestDownloadTargetChecksumMismatch(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -449,7 +449,7 @@ func TestDownloadTargetChecksumMismatch(t *testing.T) {
 // TestDownloadTargetsNoChecksum: it's never valid to download any targets
 // role (incl. delegations) when a checksum is not available.
 func TestDownloadTargetsNoChecksum(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -472,7 +472,7 @@ func TestDownloadTargetsNoChecksum(t *testing.T) {
 // TestDownloadTargetsNoSnapshot: it's never valid to download any targets
 // role (incl. delegations) when a checksum is not available.
 func TestDownloadTargetsNoSnapshot(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -493,7 +493,7 @@ func TestDownloadTargetsNoSnapshot(t *testing.T) {
 }
 
 func TestBootstrapDownloadRootHappy(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -515,7 +515,7 @@ func TestBootstrapDownloadRootHappy(t *testing.T) {
 }
 
 func TestUpdateDownloadRootHappy(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -537,7 +537,7 @@ func TestUpdateDownloadRootHappy(t *testing.T) {
 }
 
 func TestUpdateDownloadRootBadChecksum(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -562,7 +562,7 @@ func TestUpdateDownloadRootBadChecksum(t *testing.T) {
 }
 
 func TestDownloadTimestampHappy(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -581,7 +581,7 @@ func TestDownloadTimestampHappy(t *testing.T) {
 }
 
 func TestDownloadSnapshotHappy(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -609,7 +609,7 @@ func TestDownloadSnapshotHappy(t *testing.T) {
 // TestDownloadSnapshotNoChecksum: It should never be valid to download a
 // snapshot if we don't have a checksum
 func TestDownloadSnapshotNoTimestamp(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -630,7 +630,7 @@ func TestDownloadSnapshotNoTimestamp(t *testing.T) {
 }
 
 func TestDownloadSnapshotNoChecksum(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -651,7 +651,7 @@ func TestDownloadSnapshotNoChecksum(t *testing.T) {
 }
 
 func TestDownloadSnapshotBadChecksum(t *testing.T) {
-	kdb, repo, _, err := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
@@ -680,7 +680,7 @@ func TestDownloadSnapshotBadChecksum(t *testing.T) {
 // was found. If the path doesn't exist in that role subtree, returns
 // nil and an empty string.
 func TestTargetMeta(t *testing.T) {
-	kdb, repo, cs, err := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, nil, kdb, localStorage)

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -312,7 +312,8 @@ func TestSizeMismatchShort(t *testing.T) {
 }
 
 func TestDownloadTargetsHappy(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -332,7 +333,8 @@ func TestDownloadTargetsHappy(t *testing.T) {
 }
 
 func TestDownloadTargetsDeepHappy(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -406,7 +408,8 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 }
 
 func TestDownloadTargetChecksumMismatch(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -446,7 +449,8 @@ func TestDownloadTargetChecksumMismatch(t *testing.T) {
 // TestDownloadTargetsNoChecksum: it's never valid to download any targets
 // role (incl. delegations) when a checksum is not available.
 func TestDownloadTargetsNoChecksum(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -468,7 +472,8 @@ func TestDownloadTargetsNoChecksum(t *testing.T) {
 // TestDownloadTargetsNoSnapshot: it's never valid to download any targets
 // role (incl. delegations) when a checksum is not available.
 func TestDownloadTargetsNoSnapshot(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -488,7 +493,8 @@ func TestDownloadTargetsNoSnapshot(t *testing.T) {
 }
 
 func TestBootstrapDownloadRootHappy(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -509,7 +515,8 @@ func TestBootstrapDownloadRootHappy(t *testing.T) {
 }
 
 func TestUpdateDownloadRootHappy(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -530,13 +537,14 @@ func TestUpdateDownloadRootHappy(t *testing.T) {
 }
 
 func TestUpdateDownloadRootBadChecksum(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// sign snapshot to make sure we have a checksum for root
-	_, err := repo.SignSnapshot(data.DefaultExpires("snapshot"))
+	_, err = repo.SignSnapshot(data.DefaultExpires("snapshot"))
 	assert.NoError(t, err)
 
 	// create and "upload" sample root, snapshot, and timestamp
@@ -554,7 +562,8 @@ func TestUpdateDownloadRootBadChecksum(t *testing.T) {
 }
 
 func TestDownloadTimestampHappy(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -572,7 +581,8 @@ func TestDownloadTimestampHappy(t *testing.T) {
 }
 
 func TestDownloadSnapshotHappy(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -599,7 +609,8 @@ func TestDownloadSnapshotHappy(t *testing.T) {
 // TestDownloadSnapshotNoChecksum: It should never be valid to download a
 // snapshot if we don't have a checksum
 func TestDownloadSnapshotNoTimestamp(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -619,7 +630,8 @@ func TestDownloadSnapshotNoTimestamp(t *testing.T) {
 }
 
 func TestDownloadSnapshotNoChecksum(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
@@ -639,13 +651,14 @@ func TestDownloadSnapshotNoChecksum(t *testing.T) {
 }
 
 func TestDownloadSnapshotBadChecksum(t *testing.T) {
-	kdb, repo, _ := testutils.EmptyRepo()
+	kdb, repo, _, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	remoteStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// sign timestamp to ensure it has a checksum for snapshot
-	_, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
+	_, err = repo.SignTimestamp(data.DefaultExpires("timestamp"))
 	assert.NoError(t, err)
 
 	// create and "upload" sample snapshot and timestamp
@@ -667,7 +680,8 @@ func TestDownloadSnapshotBadChecksum(t *testing.T) {
 // was found. If the path doesn't exist in that role subtree, returns
 // nil and an empty string.
 func TestTargetMeta(t *testing.T) {
-	kdb, repo, cs := testutils.EmptyRepo()
+	kdb, repo, cs, err := testutils.EmptyRepo()
+	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
 	client := NewClient(repo, nil, kdb, localStorage)
 

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -19,22 +19,22 @@ import (
 
 // EmptyRepo creates an in memory key database, crypto service
 // and initializes a repo with no targets or delegations.
-func EmptyRepo() (*keys.KeyDB, *tuf.Repo, signed.CryptoService, error) {
+func EmptyRepo(gun string) (*keys.KeyDB, *tuf.Repo, signed.CryptoService, error) {
 	c := cryptoservice.NewCryptoService(
-		"", trustmanager.NewKeyMemoryStore(passphrase.ConstantRetriever("")))
+		gun, trustmanager.NewKeyMemoryStore(passphrase.ConstantRetriever("")))
 	kdb := keys.NewDB()
 	r := tuf.NewRepo(kdb, c)
 
-	for _, role := range []string{"root", "targets", "snapshot", "timestamp"} {
+	for _, role := range data.BaseRoles {
 		key, _ := c.Create(role, data.ECDSAKey)
-		if role == "root" {
+		if role == data.CanonicalRootRole {
 			start := time.Now().AddDate(0, 0, -1)
 			privKey, _, err := c.GetPrivateKey(key.ID())
 			if err != nil {
 				return nil, nil, nil, err
 			}
 			cert, err := cryptoservice.GenerateCertificate(
-				privKey, role, start, start.AddDate(1, 0, 0),
+				privKey, gun, start, start.AddDate(1, 0, 0),
 			)
 			if err != nil {
 				return nil, nil, nil, err


### PR DESCRIPTION
This involves making it use ECDSA keys since we can't generate ED25519 certs.

Signed-off-by: Ying Li <ying.li@docker.com>

This is useful when using `EmptyRepo()` to generate metadata to be served when testing.