### PR TITLE
get all current role information for a repo

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -577,20 +577,17 @@ type RoleWithSignatures struct {
 	data.Role
 }
 
-// GetRepoRoleMetaInfo returns a list of RoleWithSignatures objects for this repo
+// ListRoles returns a list of RoleWithSignatures objects for this repo
 // This represents the latest metadata for each role in this repo
-func (r *NotaryRepository) GetRepoRoleMetaInfo() ([]RoleWithSignatures, error) {
+func (r *NotaryRepository) ListRoles() ([]RoleWithSignatures, error) {
 	// Update to latest repo state
 	_, err := r.Update(false)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get all role info from our updated keysDB
-	roles, err := r.tufRepo.GetAllRoles()
-	if err != nil {
-		return nil, err
-	}
+	// Get all role info from our updated keysDB, can be empty
+	roles := r.tufRepo.GetAllLoadedRoles()
 
 	var roleWithSigs []RoleWithSignatures
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2950,8 +2950,8 @@ func TestDeleteRepoNoCerts(t *testing.T) {
 	assertRepoHasExpectedKeys(t, repo, rootKeyID, true)
 }
 
-// Test that we get a correct map of key IDs
-func TestGetRepoRoleMetaInfo(t *testing.T) {
+// Test that we get a correct list of roles with keys and signatures
+func TestListRoles(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
@@ -2960,7 +2960,7 @@ func TestGetRepoRoleMetaInfo(t *testing.T) {
 
 	assert.NoError(t, repo.Publish())
 
-	rolesWithSigs, err := repo.GetRepoRoleMetaInfo()
+	rolesWithSigs, err := repo.ListRoles()
 	assert.NoError(t, err)
 
 	// Should only have base roles at this point
@@ -2980,7 +2980,7 @@ func TestGetRepoRoleMetaInfo(t *testing.T) {
 
 	assert.NoError(t, repo.Publish())
 
-	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	rolesWithSigs, err = repo.ListRoles()
 	assert.NoError(t, err)
 
 	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+1)
@@ -2998,7 +2998,7 @@ func TestGetRepoRoleMetaInfo(t *testing.T) {
 	addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt", "targets/a")
 	assert.NoError(t, repo.Publish())
 
-	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	rolesWithSigs, err = repo.ListRoles()
 	assert.NoError(t, err)
 
 	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+1)
@@ -3017,7 +3017,7 @@ func TestGetRepoRoleMetaInfo(t *testing.T) {
 
 	assert.NoError(t, repo.Publish())
 
-	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	rolesWithSigs, err = repo.ListRoles()
 	assert.NoError(t, err)
 
 	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+2)
@@ -3039,12 +3039,12 @@ func TestGetRepoRoleMetaInfo(t *testing.T) {
 	assert.NoError(t, repo2.Publish())
 
 	// repo2 only has the base roles
-	rolesWithSigs2, err := repo2.GetRepoRoleMetaInfo()
+	rolesWithSigs2, err := repo2.ListRoles()
 	assert.NoError(t, err)
 	assert.Len(t, rolesWithSigs2, len(data.BaseRoles))
 
 	// original repo stays in same state (base roles + 2 delegations)
-	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	rolesWithSigs, err = repo.ListRoles()
 	assert.NoError(t, err)
 	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+2)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1115,7 +1115,7 @@ func testListTarget(t *testing.T, rootType string) {
 	repo, _ := initializeRepo(t, rootType, "docker.com/notary", ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 
-	// tests need to manually boostrap timestamp as client doesn't generate it
+	// tests need to manually bootstrap timestamp as client doesn't generate it
 	err := repo.tufRepo.InitTimestamp()
 	assert.NoError(t, err, "error creating repository: %s", err)
 
@@ -1171,7 +1171,7 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	repo, _ := initializeRepo(t, rootType, "docker.com/notary", ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 
-	// tests need to manually boostrap timestamp as client doesn't generate it
+	// tests need to manually bootstrap timestamp as client doesn't generate it
 	err := repo.tufRepo.InitTimestamp()
 	assert.NoError(t, err, "error creating repository: %s", err)
 
@@ -2948,4 +2948,103 @@ func TestDeleteRepoNoCerts(t *testing.T) {
 
 	// Assert keys for this repo exist locally
 	assertRepoHasExpectedKeys(t, repo, rootKeyID, true)
+}
+
+// Test that we get a correct map of key IDs
+func TestGetRepoRoleMetaInfo(t *testing.T) {
+	ts := fullTestServer(t)
+	defer ts.Close()
+
+	repo, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary", ts.URL, false)
+	defer os.RemoveAll(repo.baseDir)
+
+	assert.NoError(t, repo.Publish())
+
+	rolesWithSigs, err := repo.GetRepoRoleMetaInfo()
+	assert.NoError(t, err)
+
+	// Should only have base roles at this point
+	assert.Len(t, rolesWithSigs, len(data.BaseRoles))
+	// Each base role should only have one key, one signature, and its key should match the signature's key
+	for _, role := range rolesWithSigs {
+		assert.Len(t, role.Signatures, 1)
+		assert.Len(t, role.KeyIDs, 1)
+		assert.Equal(t, role.Signatures[0].KeyID, role.KeyIDs[0])
+	}
+
+	// Create a delegation on the top level
+	aKey := createKey(t, repo, "user", true)
+	assert.NoError(t,
+		repo.AddDelegation("targets/a", 1, []data.PublicKey{aKey}, []string{""}),
+		"error creating delegation")
+
+	assert.NoError(t, repo.Publish())
+
+	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	assert.NoError(t, err)
+
+	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+1)
+	// The delegation hasn't published any targets or metadata so it won't have a signature yet
+	for _, role := range rolesWithSigs {
+		if role.Name == "targets/a" {
+			assert.Nil(t, role.Signatures)
+		} else {
+			assert.Len(t, role.Signatures, 1)
+			assert.Equal(t, role.Signatures[0].KeyID, role.KeyIDs[0])
+		}
+		assert.Len(t, role.KeyIDs, 1)
+	}
+
+	addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt", "targets/a")
+	assert.NoError(t, repo.Publish())
+
+	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	assert.NoError(t, err)
+
+	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+1)
+	// The delegation should have a signature now
+	for _, role := range rolesWithSigs {
+		assert.Len(t, role.Signatures, 1)
+		assert.Equal(t, role.Signatures[0].KeyID, role.KeyIDs[0])
+		assert.Len(t, role.KeyIDs, 1)
+	}
+
+	// Create another delegation, one level further
+	bKey := createKey(t, repo, "user", true)
+	assert.NoError(t,
+		repo.AddDelegation("targets/a/b", 1, []data.PublicKey{bKey}, []string{""}),
+		"error creating delegation")
+
+	assert.NoError(t, repo.Publish())
+
+	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	assert.NoError(t, err)
+
+	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+2)
+	// The nested delegation hasn't published any targets or metadata so it won't have a signature yet
+	for _, role := range rolesWithSigs {
+		if role.Name == "targets/a/b" {
+			assert.Nil(t, role.Signatures)
+		} else {
+			assert.Len(t, role.Signatures, 1)
+			assert.Equal(t, role.Signatures[0].KeyID, role.KeyIDs[0])
+		}
+		assert.Len(t, role.KeyIDs, 1)
+	}
+
+	// Now make another repo and check that we don't pick up its roles
+	repo2, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary2", ts.URL, false)
+	defer os.RemoveAll(repo2.baseDir)
+
+	assert.NoError(t, repo2.Publish())
+
+	// repo2 only has the base roles
+	rolesWithSigs2, err := repo2.GetRepoRoleMetaInfo()
+	assert.NoError(t, err)
+	assert.Len(t, rolesWithSigs2, len(data.BaseRoles))
+
+	// original repo stays in same state (base roles + 2 delegations)
+	rolesWithSigs, err = repo.GetRepoRoleMetaInfo()
+	assert.NoError(t, err)
+	assert.Len(t, rolesWithSigs, len(data.BaseRoles)+2)
 }

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -37,13 +37,6 @@ func (e ErrNoSuchRole) Error() string {
 	return fmt.Sprintf("role does not exist: %s", e.Role)
 }
 
-// ErrNoRoles indicates no roles exist for this repo
-type ErrNoRoles struct{}
-
-func (e ErrNoRoles) Error() string {
-	return fmt.Sprintf("no roles exist")
-}
-
 // ErrInvalidRole represents an error regarding a role. Typically
 // something like a role for which sone of the public keys were
 // not found in the TUF repo.

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -37,6 +37,13 @@ func (e ErrNoSuchRole) Error() string {
 	return fmt.Sprintf("role does not exist: %s", e.Role)
 }
 
+// ErrNoRoles indicates no roles exist for this repo
+type ErrNoRoles struct{}
+
+func (e ErrNoRoles) Error() string {
+	return fmt.Sprintf("no roles exist")
+}
+
 // ErrInvalidRole represents an error regarding a role. Typically
 // something like a role for which sone of the public keys were
 // not found in the TUF repo.

--- a/tuf/keys/db.go
+++ b/tuf/keys/db.go
@@ -58,6 +58,15 @@ func (db *KeyDB) AddRole(r *data.Role) error {
 	return nil
 }
 
+// GetAllRoles gets all roles from the database
+func (db *KeyDB) GetAllRoles() []*data.Role {
+	roles := []*data.Role{}
+	for _, role := range db.roles {
+		roles = append(roles, role)
+	}
+	return roles
+}
+
 // GetKey pulls a key out of the database by its ID
 func (db *KeyDB) GetKey(id string) data.PublicKey {
 	return db.keys[id]

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -173,6 +173,15 @@ func (tr *Repo) RemoveBaseKeys(role string, keyIDs ...string) error {
 	return nil
 }
 
+// GetAllRoles returns a list of all role entries for this TUF repo
+func (tr *Repo) GetAllRoles() ([]*data.Role, error) {
+	roles := tr.keysDB.GetAllRoles()
+	if len(roles) == 0 {
+		return nil, data.ErrNoRoles{}
+	}
+	return roles, nil
+}
+
 // GetDelegation finds the role entry representing the provided
 // role name or ErrInvalidRole
 func (tr *Repo) GetDelegation(role string) (*data.Role, error) {

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -173,13 +173,9 @@ func (tr *Repo) RemoveBaseKeys(role string, keyIDs ...string) error {
 	return nil
 }
 
-// GetAllRoles returns a list of all role entries for this TUF repo
-func (tr *Repo) GetAllRoles() ([]*data.Role, error) {
-	roles := tr.keysDB.GetAllRoles()
-	if len(roles) == 0 {
-		return nil, data.ErrNoRoles{}
-	}
-	return roles, nil
+// GetAllLoadedRoles returns a list of all role entries loaded in this TUF repo, could be empty
+func (tr *Repo) GetAllLoadedRoles() []*data.Role {
+	return tr.keysDB.GetAllRoles()
 }
 
 // GetDelegation finds the role entry representing the provided

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -943,12 +943,11 @@ func TestGetAllRoles(t *testing.T) {
 	repo := initRepo(t, ed25519, keyDB)
 
 	// After we init, we get the base roles
-	roles, err := repo.GetAllRoles()
+	roles := repo.GetAllLoadedRoles()
 	assert.Len(t, roles, len(data.BaseRoles))
 
-	// Clear the keysDB, check that we error
+	// Clear the keysDB, check that we get an empty list
 	repo.keysDB = keys.NewDB()
-	roles, err = repo.GetAllRoles()
-	assert.Error(t, err)
-	assert.IsType(t, data.ErrNoRoles{}, err)
+	roles = repo.GetAllLoadedRoles()
+	assert.Len(t, roles, 0)
 }

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -936,3 +936,19 @@ func TestAddBaseKeysToRoot(t *testing.T) {
 		}
 	}
 }
+
+func TestGetAllRoles(t *testing.T) {
+	ed25519 := signed.NewEd25519()
+	keyDB := keys.NewDB()
+	repo := initRepo(t, ed25519, keyDB)
+
+	// After we init, we get the base roles
+	roles, err := repo.GetAllRoles()
+	assert.Len(t, roles, len(data.BaseRoles))
+
+	// Clear the keysDB, check that we error
+	repo.keysDB = keys.NewDB()
+	roles, err = repo.GetAllRoles()
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrNoRoles{}, err)
+}


### PR DESCRIPTION
client library function `ListRoles` to get all current state for a repository's roles including keys and signatures.  Adds a new `RoleWithSignatures` object to express role state that wraps each `Role` with its signatures in a `RoleWithSignatures` object.

Also fixes some typos.

Partially addresses #446.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>