### PR TITLE
Update tests while messing up metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ endef
 gen-cover: go_version
 	@mkdir -p "$(COVERDIR)"
 	$(foreach PKG,$(PKGS),$(call gocover,$(PKG)))
+	rm "$(COVERDIR)"/*testutils*.cover
 
 # Generates the cover binaries and runs them all in serial, so this can be used
 # run all tests with a yubikey without any problems

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -1,11 +1,22 @@
 package client
 
 import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/tuf/store"
+	json "github.com/jfrazelle/go/canonical/json"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/store"
@@ -94,4 +105,239 @@ func testUpdateWithLocalCacheRemoteMissingMetadata(t *testing.T, forWrite bool) 
 	metaNotFound, ok := err.(store.ErrMetaNotFound)
 	require.True(t, ok)
 	require.Equal(t, data.CanonicalTimestampRole, metaNotFound.Resource)
+}
+
+type messUpMetadata func(t *testing.T, cs signed.CryptoService, ms store.MetadataStore, role string)
+
+// corrupts metadata into something that is no longer valid JSON
+func invalidJSONMetadata(t *testing.T, _ signed.CryptoService, ms store.MetadataStore, role string) {
+	require.NoError(t, ms.SetMeta(role, []byte("nope")))
+}
+
+// corrupts the metadata into something that is valid JSON, but not unmarshalable at all
+func allUnmarshallableMetadata(t *testing.T, _ signed.CryptoService, ms store.MetadataStore, role string) {
+	metaBytes, err := json.MarshalCanonical(data.Signed{})
+	require.NoError(t, err)
+	require.NoError(t, ms.SetMeta(role, metaBytes))
+}
+
+// messes up the metadata in such a way that the hash is no longer valid
+func invalidateMetadataHash(t *testing.T, _ signed.CryptoService, ms store.MetadataStore, role string) {
+	b, err := ms.GetMeta(role, maxSize)
+	require.NoError(t, err)
+
+	var unmarshalled map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &unmarshalled))
+
+	signed, ok := unmarshalled["signed"].(map[string]interface{})
+	require.True(t, ok)
+	signed["boogeyman"] = "exists"
+
+	metaBytes, err := json.MarshalCanonical(unmarshalled)
+	require.NoError(t, err)
+
+	require.NoError(t, ms.SetMeta(role, metaBytes))
+}
+
+// deletes the metadata
+func deleteMetadata(t *testing.T, _ signed.CryptoService, ms store.MetadataStore, role string) {
+	require.NoError(t, ms.DeleteMeta(role))
+}
+
+func serializeMetadata(t *testing.T, s *data.Signed, cs signed.CryptoService, role string) []byte {
+	// delete the existing signatures
+	s.Signatures = []data.Signature{}
+
+	pubKeys := cs.ListKeys(role)
+	require.Len(t, pubKeys, 1, "no keys for %s", role)
+	pubKey := cs.GetKey(pubKeys[0])
+	require.NotNil(t, pubKey, "unable to get %s key %s", role, pubKeys[0])
+
+	require.NoError(t, signed.Sign(cs, s, pubKey))
+
+	metaBytes, err := json.MarshalCanonical(s)
+	require.NoError(t, err)
+
+	return metaBytes
+}
+
+// signs the metadata with the wrong key
+func invalidateMetadataSig(t *testing.T, _ signed.CryptoService, ms store.MetadataStore, role string) {
+	b, err := ms.GetMeta(role, maxSize)
+	require.NoError(t, err)
+
+	signedThing := data.Signed{}
+	require.NoError(t, json.Unmarshal(b, &signedThing), "error unmarshalling data for %s", role)
+
+	// create an invalid key, but not in the existing CryptoService
+	cs := signed.NewEd25519()
+	_, err = cs.Create("root", data.ED25519Key)
+	require.NoError(t, err)
+
+	metaBytes := serializeMetadata(t, &signedThing, cs, "root")
+	require.NoError(t, ms.SetMeta(role, metaBytes))
+}
+
+func signedMetaFromStore(t *testing.T, ms store.MetadataStore, role string) data.SignedMeta {
+	b, err := ms.GetMeta(role, maxSize)
+	require.NoError(t, err)
+
+	signedMeta := data.SignedMeta{}
+	require.NoError(t, json.Unmarshal(b, &signedMeta), "error unmarshalling data for %s", role)
+
+	return signedMeta
+}
+
+func signedMetaToSigned(t *testing.T, signedMeta data.SignedMeta) data.Signed {
+	s, err := json.MarshalCanonical(signedMeta.Signed)
+	require.NoError(t, err)
+	signed := json.RawMessage{}
+	require.NoError(t, signed.UnmarshalJSON(s))
+
+	return data.Signed{Signed: signed}
+}
+
+// corrupt the metadata in such a way that it is JSON parsable, and correctly signed, but will not
+// unmarshal correctly because it has the wrong type
+func corruptSignedMetadata(t *testing.T, cs signed.CryptoService, ms store.MetadataStore, role string) {
+	if role != data.CanonicalTimestampRole || len(cs.ListKeys(role)) > 0 {
+		signedMeta := signedMetaFromStore(t, ms, role)
+		signedMeta.Signed.Type = "nonexistent"
+		signedThing := signedMetaToSigned(t, signedMeta)
+		metaBytes := serializeMetadata(t, &signedThing, cs, role)
+		require.NoError(t, ms.SetMeta(role, metaBytes))
+	}
+}
+
+// decrements the metadata version, which would make it invalid - don't do anything if we don't
+// have the timestamp key
+func decrementMetadataVersion(t *testing.T, cs signed.CryptoService, ms store.MetadataStore, role string) {
+	if role != data.CanonicalTimestampRole || len(cs.ListKeys(role)) > 0 {
+		signedMeta := signedMetaFromStore(t, ms, role)
+		signedMeta.Signed.Version--
+		signedThing := signedMetaToSigned(t, signedMeta)
+		metaBytes := serializeMetadata(t, &signedThing, cs, role)
+		require.NoError(t, ms.SetMeta(role, metaBytes))
+	}
+}
+
+// expire the metadata, which would make it invalid - don't do anything if we don't have the
+// timestamp key
+func expireMetadata(t *testing.T, cs signed.CryptoService, ms store.MetadataStore, role string) {
+	if role != data.CanonicalTimestampRole || len(cs.ListKeys(role)) > 0 {
+		signedMeta := signedMetaFromStore(t, ms, role)
+		signedMeta.Signed.Expires = time.Now().AddDate(-1, -1, -1)
+		signedThing := signedMetaToSigned(t, signedMeta)
+		metaBytes := serializeMetadata(t, &signedThing, cs, role)
+		require.NoError(t, ms.SetMeta(role, metaBytes))
+	}
+}
+
+// increments a threshold for a metadata role - invalidates the metadata for which the threshold
+// is increased, since there is only 1 signature for each
+func incrementThreshold(t *testing.T, cs signed.CryptoService, ms store.MetadataStore, role string) {
+	roleSpecifyingThreshold := data.CanonicalRootRole
+	if data.IsDelegation(role) {
+		roleSpecifyingThreshold = path.Dir(role)
+	}
+
+	b, err := ms.GetMeta(roleSpecifyingThreshold, maxSize)
+	require.NoError(t, err)
+
+	signedThing := &data.Signed{}
+	require.NoError(t, json.Unmarshal(b, signedThing), "error unmarshalling data for %s",
+		roleSpecifyingThreshold)
+
+	if roleSpecifyingThreshold == data.CanonicalRootRole {
+		signedRoot, err := data.RootFromSigned(signedThing)
+		require.NoError(t, err)
+		signedRoot.Signed.Roles[role].Threshold++
+		signedThing, err = signedRoot.ToSigned()
+		require.NoError(t, err)
+	} else {
+		signedTargets, err := data.TargetsFromSigned(signedThing)
+		require.NoError(t, err)
+		for _, roleObject := range signedTargets.Signed.Delegations.Roles {
+			if roleObject.Name == role {
+				roleObject.Threshold++
+				break
+			}
+		}
+		signedThing, err = signedTargets.ToSigned()
+		require.NoError(t, err)
+	}
+
+	metaBytes := serializeMetadata(t, signedThing, cs, roleSpecifyingThreshold)
+	require.NoError(t, ms.SetMeta(roleSpecifyingThreshold, metaBytes))
+}
+
+// If a repo has corrupt metadata, an update will replace all the metadata
+func TestUpdateReplacesCorruptOrMissingMetadata(t *testing.T) {
+	// create repo with 2 level delegations
+	ts := fullTestServer(t)
+	defer ts.Close()
+
+	repo, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary", ts.URL, false)
+	defer os.RemoveAll(repo.baseDir)
+
+	delegatedRoles := []string{"targets/a", "targets/a/b"}
+	for _, delgName := range delegatedRoles {
+		delgKey, err := repo.CryptoService.Create(delgName, data.ECDSAKey)
+		require.NoError(t, err, "error creating delegation key")
+
+		require.NoError(t,
+			repo.AddDelegation(delgName, 1, []data.PublicKey{delgKey}, []string{""}),
+			"error creating delegation")
+	}
+	// add a target so the second level delegation is created
+	addTarget(t, repo, "first", "../fixtures/root-ca.crt", "targets/a/b")
+	require.NoError(t, repo.Publish())
+	_, err := repo.Update() // ensure we have all metadata to start with
+	require.NoError(t, err)
+
+	// corrupt any number of roles - an update should fix all of them
+	roles := []string{
+		data.CanonicalTimestampRole,
+		data.CanonicalSnapshotRole,
+		"targets/a",
+		"targets/a/b",
+		data.CanonicalTargetsRole,
+		data.CanonicalRootRole,
+	}
+
+	// store original metadata
+	origMeta := make(map[string][]byte)
+	for _, role := range roles {
+		b, err := repo.fileStore.GetMeta(role, maxSize)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		origMeta[role] = b
+	}
+
+	// mess up metadata in different ways, update the repo, and assert that the metadata is fixed.
+	waysToMessUp := map[string]messUpMetadata{
+		"corrupted/invalid JSON":       invalidJSONMetadata,
+		"metadata has invalid hash":    invalidateMetadataHash,
+		"missing metadata":             deleteMetadata,
+		"metadata signed by wrong key": invalidateMetadataSig,
+		"expired metadata":             expireMetadata,
+		"insufficient signatures":      incrementThreshold,
+		// decremented version just tests that updates do not need to increment
+		// by 1, only increment at all
+		"version much lower": decrementMetadataVersion,
+	}
+	for i := range roles {
+		for text, messItUp := range waysToMessUp {
+			for _, role := range roles[:i+1] {
+				messItUp(t, repo.CryptoService, repo.fileStore, role)
+			}
+			_, err := repo.Update()
+			require.NoError(t, err)
+			for role, origBytes := range origMeta {
+				b, err := repo.fileStore.GetMeta(role, maxSize)
+				require.NoError(t, err, "problem getting metadata for %s", role)
+				require.Equal(t, origBytes, b, "%s for %s expected to recover after update", text, role)
+			}
+		}
+	}
 }

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -143,6 +143,9 @@ func (u *unwritableStore) SetMeta(role string, meta []byte) error {
 // Update can succeed even if we cannot write any metadata to the repo (assuming
 // no data in the repo)
 func TestUpdateSucceedsEvenIfCannotWriteNewRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	s, err := testutils.NewMetadataSwizzler("docker.com/notary")
 	require.NoError(t, err)
 
@@ -183,6 +186,9 @@ func TestUpdateSucceedsEvenIfCannotWriteNewRepo(t *testing.T) {
 // Update can succeed even if we cannot write any metadata to the repo (assuming
 // existing data in the repo)
 func TestUpdateSucceedsEvenIfCannotWriteExistingRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	s, err := testutils.NewMetadataSwizzler("docker.com/notary")
 	require.NoError(t, err)
 
@@ -237,6 +243,9 @@ type messUpMetadata func(role string) error
 // If a repo has corrupt metadata (in that the hash doesn't match the snapshot) or
 // missing metadata, an update will replace all of it
 func TestUpdateReplacesCorruptOrMissingMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	s, err := testutils.NewMetadataSwizzler("docker.com/notary")
 	require.NoError(t, err)
 
@@ -258,7 +267,7 @@ func TestUpdateReplacesCorruptOrMissingMetadata(t *testing.T) {
 
 	waysToMessUp := map[string]messUpMetadata{
 		"invalid JSON":     swizzler.SetInvalidJSON,
-		"missing metadata": swizzler.DeleteMetadata,
+		"missing metadata": swizzler.RemoveMetadata,
 	}
 	for _, role := range s.Roles {
 		for text, messItUp := range waysToMessUp {
@@ -283,6 +292,9 @@ func TestUpdateReplacesCorruptOrMissingMetadata(t *testing.T) {
 // the repo will just get the new root from the server, whether or not the update
 // is for writing (forced update)
 func TestUpdateWhenLocalRootRecoverablyCorrupt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	s, err := testutils.NewMetadataSwizzler("docker.com/notary")
 	require.NoError(t, err)
 
@@ -346,6 +358,9 @@ func TestUpdateWhenLocalRootRecoverablyCorrupt(t *testing.T) {
 // it will refuse to update if the root key has changed and the new root is
 // not signed by the old and new key
 func TestUpdateFailsIfServerRootKeyChangedWithoutMultiSign(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	serverSwizzler, err := testutils.NewMetadataSwizzler("docker.com/notary")
 	require.NoError(t, err)
 

--- a/tuf/store/filestore.go
+++ b/tuf/store/filestore.go
@@ -39,11 +39,14 @@ type FilesystemStore struct {
 	targetsDir    string
 }
 
+func (f *FilesystemStore) getPath(name string) string {
+	fileName := fmt.Sprintf("%s.%s", name, f.metaExtension)
+	return filepath.Join(f.metaDir, fileName)
+}
+
 // GetMeta returns the meta for the given name (a role)
 func (f *FilesystemStore) GetMeta(name string, size int64) ([]byte, error) {
-	fileName := fmt.Sprintf("%s.%s", name, f.metaExtension)
-	path := filepath.Join(f.metaDir, fileName)
-	meta, err := ioutil.ReadFile(path)
+	meta, err := ioutil.ReadFile(f.getPath(name))
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = ErrMetaNotFound{Resource: name}
@@ -66,20 +69,19 @@ func (f *FilesystemStore) SetMultiMeta(metas map[string][]byte) error {
 
 // SetMeta sets the meta for a single role
 func (f *FilesystemStore) SetMeta(name string, meta []byte) error {
-	fileName := fmt.Sprintf("%s.%s", name, f.metaExtension)
-	path := filepath.Join(f.metaDir, fileName)
+	fp := f.getPath(name)
 
 	// Ensures the parent directories of the file we are about to write exist
-	err := os.MkdirAll(filepath.Dir(path), 0700)
+	err := os.MkdirAll(filepath.Dir(fp), 0700)
 	if err != nil {
 		return err
 	}
 
 	// if something already exists, just delete it and re-write it
-	os.RemoveAll(path)
+	os.RemoveAll(fp)
 
 	// Write the file to disk
-	if err = ioutil.WriteFile(path, meta, 0600); err != nil {
+	if err = ioutil.WriteFile(fp, meta, 0600); err != nil {
 		return err
 	}
 	return nil
@@ -88,4 +90,10 @@ func (f *FilesystemStore) SetMeta(name string, meta []byte) error {
 // RemoveAll clears the existing filestore by removing its base directory
 func (f *FilesystemStore) RemoveAll() error {
 	return os.RemoveAll(f.baseDir)
+}
+
+// RemoveMeta removes the metadata for a single role - if the metadata doesn't
+// exist, no error is returned
+func (f *FilesystemStore) RemoveMeta(name string) error {
+	return os.RemoveAll(f.getPath(name)) // RemoveAll succeeds if path doesn't exist
 }

--- a/tuf/store/filestore_test.go
+++ b/tuf/store/filestore_test.go
@@ -91,23 +91,20 @@ func TestGetMeta(t *testing.T) {
 	assert.Equal(t, testContent, content, "Content read from file was corrupted.")
 }
 
-func TestGetMetaNoSuchMetadata(t *testing.T) {
-	testDir, err := ioutil.TempDir("/tmp", "testFileSystemStore")
-	assert.NoError(t, err)
-	// ensure that the random directory doesn't exist
-	os.RemoveAll(testDir)
+func TestGetSetMetadata(t *testing.T) {
+	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	assert.NoError(t, err, "Initializing FilesystemStore returned unexpected error", err)
+	defer os.RemoveAll(testDir)
 
-	// don't use the constructor, which creates the directories - just
-	s := FilesystemStore{
-		baseDir:       testDir,
-		metaDir:       "metadata",
-		metaExtension: "json",
-		targetsDir:    "targets",
-	}
+	testGetSetMeta(t, func() MetadataStore { return s })
+}
 
-	_, err = s.GetMeta("testMeta", int64(5))
-	assert.Error(t, err)
-	assert.IsType(t, ErrMetaNotFound{}, err)
+func TestRemoveMetadata(t *testing.T) {
+	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	assert.NoError(t, err, "Initializing FilesystemStore returned unexpected error", err)
+	defer os.RemoveAll(testDir)
+
+	testRemoveMeta(t, func() MetadataStore { return s })
 }
 
 func TestRemoveAll(t *testing.T) {

--- a/tuf/store/httpstore.go
+++ b/tuf/store/httpstore.go
@@ -182,6 +182,12 @@ func (s HTTPStore) SetMeta(name string, blob []byte) error {
 	return translateStatusToError(resp, "POST "+name)
 }
 
+// RemoveMeta always fails, because we should never be able to delete metadata
+// remotely
+func (s HTTPStore) RemoveMeta(name string) error {
+	return ErrInvalidOperation{msg: "cannot delete metadata"}
+}
+
 // NewMultiPartMetaRequest builds a request with the provided metadata updates
 // in multipart form
 func NewMultiPartMetaRequest(url string, metas map[string][]byte) (*http.Request, error) {

--- a/tuf/store/interfaces.go
+++ b/tuf/store/interfaces.go
@@ -15,6 +15,7 @@ type MetadataStore interface {
 	SetMeta(name string, blob []byte) error
 	SetMultiMeta(map[string][]byte) error
 	RemoveAll() error
+	RemoveMeta(name string) error
 }
 
 // PublicKeyStore must be implemented by a key service

--- a/tuf/store/memorystore.go
+++ b/tuf/store/memorystore.go
@@ -54,6 +54,13 @@ func (m *memoryStore) SetMultiMeta(metas map[string][]byte) error {
 	return nil
 }
 
+// RemoveMeta removes the metadata for a single role - if the metadata doesn't
+// exist, no error is returned
+func (m *memoryStore) RemoveMeta(name string) error {
+	delete(m.meta, name)
+	return nil
+}
+
 func (m *memoryStore) GetTarget(path string) (io.ReadCloser, error) {
 	return &utils.NoopCloser{Reader: bytes.NewReader(m.files[path])}, nil
 }

--- a/tuf/store/offlinestore.go
+++ b/tuf/store/offlinestore.go
@@ -14,30 +14,35 @@ func (e ErrOffline) Error() string {
 var err = ErrOffline{}
 
 // OfflineStore is to be used as a placeholder for a nil store. It simply
-// return ErrOffline for every operation
+// returns ErrOffline for every operation
 type OfflineStore struct{}
 
-// GetMeta return ErrOffline
+// GetMeta returns ErrOffline
 func (es OfflineStore) GetMeta(name string, size int64) ([]byte, error) {
 	return nil, err
 }
 
-// SetMeta return ErrOffline
+// SetMeta returns ErrOffline
 func (es OfflineStore) SetMeta(name string, blob []byte) error {
 	return err
 }
 
-// SetMultiMeta return ErrOffline
+// SetMultiMeta returns ErrOffline
 func (es OfflineStore) SetMultiMeta(map[string][]byte) error {
 	return err
 }
 
-// GetKey return ErrOffline
+// RemoveMeta returns ErrOffline
+func (es OfflineStore) RemoveMeta(name string) error {
+	return err
+}
+
+// GetKey returns ErrOffline
 func (es OfflineStore) GetKey(role string) ([]byte, error) {
 	return nil, err
 }
 
-// GetTarget return ErrOffline
+// GetTarget returns ErrOffline
 func (es OfflineStore) GetTarget(path string) (io.ReadCloser, error) {
 	return nil, err
 }

--- a/tuf/store/store_test.go
+++ b/tuf/store/store_test.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type storeFactory func() MetadataStore
+
+// Verifies that the metadata store can get and set metadata
+func testGetSetMeta(t *testing.T, factory storeFactory) {
+	s := factory()
+	metaBytes, err := s.GetMeta("root", 300)
+	require.Error(t, err)
+	require.Nil(t, metaBytes)
+	require.IsType(t, ErrMetaNotFound{}, err)
+
+	content := []byte("root bytes")
+	require.NoError(t, s.SetMeta("root", content))
+
+	metaBytes, err = s.GetMeta("root", 300)
+	require.NoError(t, err)
+	require.Equal(t, content, metaBytes)
+}
+
+// Verifies that the metadata store can delete metadata
+func testRemoveMeta(t *testing.T, factory storeFactory) {
+	s := factory()
+
+	require.NoError(t, s.SetMeta("root", []byte("test data")))
+
+	require.NoError(t, s.RemoveMeta("root"))
+	_, err := s.GetMeta("root", 300)
+	require.Error(t, err)
+	require.IsType(t, ErrMetaNotFound{}, err)
+
+	// delete metadata should be successful even if the metadata doesn't exist
+	require.NoError(t, s.RemoveMeta("root"))
+}
+
+func TestMemoryStoreMetadata(t *testing.T) {
+	factory := func() MetadataStore {
+		return NewMemoryStore(nil, nil)
+	}
+
+	testGetSetMeta(t, factory)
+	testRemoveMeta(t, factory)
+}

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -1,0 +1,551 @@
+package testutils
+
+import (
+	"bytes"
+	"path"
+	"time"
+
+	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/passphrase"
+	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/tuf/store"
+	"github.com/jfrazelle/go/canonical/json"
+)
+
+const (
+	maxSize = 5 << 20
+)
+
+// ErrNoKeyForRole returns an error when the cryptoservice provided to
+// MetadataSwizzler has no key for a particular role
+type ErrNoKeyForRole struct {
+	Role string
+}
+
+func (e ErrNoKeyForRole) Error() string {
+	return "Swizzler's cryptoservice has no key for role " + e.Role
+}
+
+// MetadataSwizzler fuzzes the metadata in a MetadataStore
+type MetadataSwizzler struct {
+	gun           string
+	MetadataCache store.MetadataStore
+	CryptoService signed.CryptoService
+	Roles         []string // list of Roles in the metadataStore
+}
+
+// signs the new metadata, replacing whatever signature was there
+func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
+	pubKeys ...data.PublicKey) ([]byte, error) {
+
+	// delete the existing signatures
+	s.Signatures = []data.Signature{}
+
+	if len(pubKeys) > 0 {
+		if err := signed.Sign(cs, s, pubKeys...); err != nil {
+			if _, ok := err.(signed.ErrNoKeys); ok {
+				return nil, ErrNoKeyForRole{Role: role}
+			}
+			return nil, err
+		}
+	} else if role == data.CanonicalRootRole {
+		// if this is root metadata, we have to get the keys from the root because they
+		// are certs
+		root := &data.Root{}
+		if err := json.Unmarshal(s.Signed, root); err != nil {
+			return nil, err
+		}
+		for _, pubKeyID := range root.Roles[data.CanonicalRootRole].KeyIDs {
+			if err := signed.Sign(cs, s, root.Keys[pubKeyID]); err != nil {
+				if _, ok := err.(signed.ErrNoKeys); ok {
+					return nil, ErrNoKeyForRole{Role: role}
+				}
+				return nil, err
+			}
+		}
+	} else {
+		pubKeyIDs := cs.ListKeys(role)
+		if len(pubKeyIDs) < 1 {
+			return nil, ErrNoKeyForRole{role}
+		}
+		for _, pubKeyID := range pubKeyIDs {
+			if err := signed.Sign(cs, s, cs.GetKey(pubKeyID)); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	metaBytes, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return metaBytes, nil
+}
+
+// gets a Signed from the metadata store
+func signedFromStore(cache store.MetadataStore, role string) (*data.Signed, error) {
+	b, err := cache.GetMeta(role, maxSize)
+	if err != nil {
+		return nil, err
+	}
+
+	signed := &data.Signed{}
+	if err := json.Unmarshal(b, signed); err != nil {
+		return nil, err
+	}
+
+	return signed, nil
+}
+
+var delegatedRoles = []string{"targets/a", "targets/a/b"}
+
+// DefaultRoles are the defualt roles that NewMetadataSwizzler creates
+var DefaultRoles = append(data.BaseRoles, delegatedRoles...)
+
+// NewMetadataSwizzler creates a new tuf.Repo and generates metadata to fuzz.
+func NewMetadataSwizzler(gun string) (*MetadataSwizzler, error) {
+	_, tufRepo, cs, err := EmptyRepo(gun)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, delgName := range delegatedRoles {
+		// create a delegations key and a delegation in the tuf repo
+		delgKey, err := cs.Create(delgName, data.ED25519Key)
+		if err != nil {
+			return nil, err
+		}
+		role, err := data.NewRole(delgName, 1, []string{}, []string{"/"}, []string{})
+		if err != nil {
+			return nil, err
+		}
+		if err := tufRepo.UpdateDelegations(role, []data.PublicKey{delgKey}); err != nil {
+			return nil, err
+		}
+
+		// create the targets metadata
+		if _, ok := tufRepo.Targets[delgName]; !ok {
+			_, err := tufRepo.InitTargets(delgName)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	meta := make(map[string][]byte)
+
+	// now we need to create a signed target/serialize, add it to the snapshot,
+	// and save the signed target metadata to the store - this must be done
+	// in a separate loop because "targets/a" can't be serialized until "targets/a/b"
+	// has been added
+	for _, delgName := range delegatedRoles {
+		signedThing, err := tufRepo.SignTargets(delgName, data.DefaultExpires("targets"))
+		if err != nil {
+			return nil, err
+		}
+		metaBytes, err := json.MarshalCanonical(signedThing)
+		if err != nil {
+			return nil, err
+		}
+		meta[delgName] = metaBytes
+	}
+
+	// these need to be generated after the delegations are created and signed so
+	// the snapshot will have the delegation metadata
+	rs, tgs, ss, ts, err := Sign(tufRepo)
+	if err != nil {
+		return nil, err
+	}
+	rf, tgf, sf, tf, err := Serialize(rs, tgs, ss, ts)
+	if err != nil {
+		return nil, err
+	}
+
+	meta[data.CanonicalRootRole] = rf
+	meta[data.CanonicalSnapshotRole] = sf
+	meta[data.CanonicalTargetsRole] = tgf
+	meta[data.CanonicalTimestampRole] = tf
+
+	swizzler := MetadataSwizzler{
+		gun:           gun,
+		MetadataCache: store.NewMemoryStore(meta, nil),
+		CryptoService: cs,
+		Roles:         DefaultRoles,
+	}
+
+	return &swizzler, nil
+}
+
+// SetInvalidJSON corrupts metadata into something that is no longer valid JSON
+func (m *MetadataSwizzler) SetInvalidJSON(role string) error {
+	metaBytes, err := m.MetadataCache.GetMeta(role, maxSize)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes[5:])
+}
+
+// SetInvalidSigned corrupts the metadata into something that is valid JSON,
+// but not unmarshallable into signed JSON
+func (m *MetadataSwizzler) SetInvalidSigned(role string) error {
+	signedThing, err := signedFromStore(m.MetadataCache, role)
+	if err != nil {
+		return err
+	}
+	metaBytes, err := json.MarshalCanonical(map[string]interface{}{
+		"signed":     signedThing.Signed,
+		"signatures": "not list",
+	})
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes)
+}
+
+// SetInvalidSignedMeta corrupts the metadata into something that is unmarshallable
+// as a Signed object, but not unmarshallable into a SignedMeta object
+func (m *MetadataSwizzler) SetInvalidSignedMeta(role string) error {
+	signedThing, err := signedFromStore(m.MetadataCache, role)
+	if err != nil {
+		return err
+	}
+
+	var unmarshalled map[string]interface{}
+	if err := json.Unmarshal(signedThing.Signed, &unmarshalled); err != nil {
+		return err
+	}
+
+	unmarshalled["_type"] = []string{"not a string"}
+	unmarshalled["version"] = "string not int"
+	unmarshalled["expires"] = "cannot be parsed as time"
+
+	metaBytes, err := json.MarshalCanonical(unmarshalled)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(metaBytes)
+
+	metaBytes, err = serializeMetadata(m.CryptoService, signedThing, role)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes)
+}
+
+// TODO: corrupt metadata in such a way that it can be unmarshalled as a
+// SignedMeta, but not as a SignedRoot or SignedTarget, etc. (Signed*)
+
+// SetInvalidMetadataType unmarshallable, but has the wrong metadata type (not
+// actually a metadata type)
+func (m *MetadataSwizzler) SetInvalidMetadataType(role string) error {
+	signedThing, err := signedFromStore(m.MetadataCache, role)
+	if err != nil {
+		return err
+	}
+
+	var unmarshalled map[string]interface{}
+	if err := json.Unmarshal(signedThing.Signed, &unmarshalled); err != nil {
+		return err
+	}
+
+	unmarshalled["_type"] = "not_real"
+
+	metaBytes, err := json.MarshalCanonical(unmarshalled)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(metaBytes)
+
+	metaBytes, err = serializeMetadata(m.CryptoService, signedThing, role)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes)
+}
+
+// InvalidateMetadataSignatures signs with the right key(s) but wrong hash
+func (m *MetadataSwizzler) InvalidateMetadataSignatures(role string) error {
+	signedThing, err := signedFromStore(m.MetadataCache, role)
+	if err != nil {
+		return err
+	}
+	sigs := make([]data.Signature, len(signedThing.Signatures))
+	for i, origSig := range signedThing.Signatures {
+		sigs[i] = data.Signature{
+			KeyID:     origSig.KeyID,
+			Signature: []byte("invalid signature"),
+			Method:    origSig.Method,
+		}
+	}
+	signedThing.Signatures = sigs
+
+	metaBytes, err := json.Marshal(signedThing)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes)
+}
+
+// TODO: AddExtraSignedInfo - add an extra field to Signed that doesn't get
+//	unmarshalled, and the whole thing is correctly signed, so shouldn't cause
+//  problems there.  Should this fail a canonical JSON check?
+
+// RemoveMetadata deletes the metadata entirely
+func (m *MetadataSwizzler) RemoveMetadata(role string) error {
+	return m.MetadataCache.RemoveMeta(role)
+}
+
+// SignMetadataWithInvalidKey signs the metadata with the wrong key
+func (m *MetadataSwizzler) SignMetadataWithInvalidKey(role string) error {
+	signedThing, err := signedFromStore(m.MetadataCache, role)
+	if err != nil {
+		return err
+	}
+
+	// create an invalid key, but not in the existing CryptoService
+	cs := cryptoservice.NewCryptoService(
+		m.gun, trustmanager.NewKeyMemoryStore(passphrase.ConstantRetriever("")))
+	key, err := createKey(cs, m.gun, role)
+	if err != nil {
+		return err
+	}
+
+	metaBytes, err := serializeMetadata(cs, signedThing, "root", key)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes)
+}
+
+// OffsetMetadataVersion updates the metadata version
+func (m *MetadataSwizzler) OffsetMetadataVersion(role string, offset int) error {
+	signedThing, err := signedFromStore(m.MetadataCache, role)
+	if err != nil {
+		return err
+	}
+
+	var unmarshalled map[string]interface{}
+	if err := json.Unmarshal(signedThing.Signed, &unmarshalled); err != nil {
+		return err
+	}
+
+	oldVersion, ok := unmarshalled["version"].(float64)
+	if !ok {
+		oldVersion = float64(0) // just ignore the error and set it to 0
+	}
+	unmarshalled["version"] = int(oldVersion) + offset
+
+	metaBytes, err := json.MarshalCanonical(unmarshalled)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(metaBytes)
+
+	metaBytes, err = serializeMetadata(m.CryptoService, signedThing, role)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes)
+}
+
+// ExpireMetadata expires the metadata, which would make it invalid - don't do anything if
+// we don't have the timestamp key
+func (m *MetadataSwizzler) ExpireMetadata(role string) error {
+	signedThing, err := signedFromStore(m.MetadataCache, role)
+	if err != nil {
+		return err
+	}
+
+	var unmarshalled map[string]interface{}
+	if err := json.Unmarshal(signedThing.Signed, &unmarshalled); err != nil {
+		return err
+	}
+
+	unmarshalled["expires"] = time.Now().AddDate(-1, -1, -1)
+
+	metaBytes, err := json.MarshalCanonical(unmarshalled)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(metaBytes)
+
+	metaBytes, err = serializeMetadata(m.CryptoService, signedThing, role)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(role, metaBytes)
+}
+
+// SetThreshold sets a threshold for a metadata role - can invalidate metadata for which
+// the threshold is increased, if there aren't enough signatures or can be invalid because
+// the threshold is 0
+func (m *MetadataSwizzler) SetThreshold(role string, newThreshold int) error {
+	roleSpecifier := data.CanonicalRootRole
+	if data.IsDelegation(role) {
+		roleSpecifier = path.Dir(role)
+	}
+
+	b, err := m.MetadataCache.GetMeta(roleSpecifier, maxSize)
+	if err != nil {
+		return err
+	}
+
+	signedThing := &data.Signed{}
+	if err := json.Unmarshal(b, signedThing); err != nil {
+		return err
+	}
+
+	if roleSpecifier == data.CanonicalRootRole {
+		signedRoot, err := data.RootFromSigned(signedThing)
+		if err != nil {
+			return err
+		}
+		signedRoot.Signed.Roles[role].Threshold = newThreshold
+		if signedThing, err = signedRoot.ToSigned(); err != nil {
+			return err
+		}
+	} else {
+		signedTargets, err := data.TargetsFromSigned(signedThing)
+		if err != nil {
+			return err
+		}
+		for _, roleObject := range signedTargets.Signed.Delegations.Roles {
+			if roleObject.Name == role {
+				roleObject.Threshold = newThreshold
+				break
+			}
+		}
+		if signedThing, err = signedTargets.ToSigned(); err != nil {
+			return err
+		}
+	}
+
+	metaBytes, err := serializeMetadata(m.CryptoService, signedThing, roleSpecifier)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(roleSpecifier, metaBytes)
+}
+
+// ChangeRootKey swaps out the root key with a new key, and re-signs the metadata
+// with the new key
+func (m *MetadataSwizzler) ChangeRootKey() error {
+	key, err := createKey(m.CryptoService, m.gun, data.CanonicalRootRole)
+	if err != nil {
+		return err
+	}
+
+	b, err := m.MetadataCache.GetMeta(data.CanonicalRootRole, maxSize)
+	if err != nil {
+		return err
+	}
+
+	signedRoot := &data.SignedRoot{}
+	if err := json.Unmarshal(b, signedRoot); err != nil {
+		return err
+	}
+
+	signedRoot.Signed.Keys[key.ID()] = key
+	signedRoot.Signed.Roles[data.CanonicalRootRole].KeyIDs = []string{key.ID()}
+
+	var signedThing *data.Signed
+	if signedThing, err = signedRoot.ToSigned(); err != nil {
+		return err
+	}
+
+	metaBytes, err := serializeMetadata(m.CryptoService, signedThing, data.CanonicalRootRole)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(data.CanonicalRootRole, metaBytes)
+}
+
+// UpdateSnapshotHashes updates the snapshot to reflect the latest hash changes, to
+// ensure that failure isn't because the snapshot has the wrong hash.
+func (m *MetadataSwizzler) UpdateSnapshotHashes(roles ...string) error {
+	var (
+		metaBytes      []byte
+		snapshotSigned *data.Signed
+		err            error
+	)
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize); err != nil {
+		return err
+	}
+
+	snapshot := data.SignedSnapshot{}
+	if err = json.Unmarshal(metaBytes, &snapshot); err != nil {
+		return err
+	}
+
+	// just rebuild everything if roles is not specified
+	if len(roles) == 0 {
+		roles = m.Roles
+	}
+
+	for _, role := range roles {
+		if role != data.CanonicalSnapshotRole && role != data.CanonicalTimestampRole {
+			if metaBytes, err = m.MetadataCache.GetMeta(role, maxSize); err != nil {
+				return err
+			}
+
+			meta, err := data.NewFileMeta(bytes.NewReader(metaBytes), "sha256")
+			if err != nil {
+				return err
+			}
+
+			snapshot.Signed.Meta[role] = meta
+		}
+	}
+
+	if snapshotSigned, err = snapshot.ToSigned(); err != nil {
+		return err
+	}
+	metaBytes, err = serializeMetadata(m.CryptoService, snapshotSigned, data.CanonicalSnapshotRole)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(data.CanonicalSnapshotRole, metaBytes)
+}
+
+// UpdateTimestampHash updates the timestamp to reflect the latest snapshot changes, to
+// ensure that failure isn't because the timestamp has the wrong hash.
+func (m *MetadataSwizzler) UpdateTimestampHash() error {
+	var (
+		metaBytes       []byte
+		timestamp       = &data.SignedTimestamp{}
+		timestampSigned *data.Signed
+		err             error
+	)
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalTimestampRole, maxSize); err != nil {
+		return err
+	}
+	// we can't just create a new timestamp, because then the expiry would be
+	// different
+	if err = json.Unmarshal(metaBytes, timestamp); err != nil {
+		return err
+	}
+
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize); err != nil {
+		return err
+	}
+
+	snapshotMeta, err := data.NewFileMeta(bytes.NewReader(metaBytes), "sha256")
+	if err != nil {
+		return err
+	}
+
+	timestamp.Signed.Meta[data.CanonicalSnapshotRole] = snapshotMeta
+
+	timestampSigned, err = timestamp.ToSigned()
+	if err != nil {
+		return err
+	}
+	metaBytes, err = serializeMetadata(m.CryptoService, timestampSigned, data.CanonicalTimestampRole)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(data.CanonicalTimestampRole, metaBytes)
+}

--- a/tuf/testutils/swizzler_test.go
+++ b/tuf/testutils/swizzler_test.go
@@ -1,0 +1,576 @@
+// make sure that the swizzler actually sort of works, so our tests that use it actually test what we
+// think
+
+package testutils
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/docker/notary/tuf"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/keys"
+	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/tuf/store"
+	"github.com/stretchr/testify/require"
+)
+
+func getAllMeta(t *testing.T, f *MetadataSwizzler) map[string][]byte {
+	meta := make(map[string][]byte)
+	for _, role := range f.Roles {
+		origMetadata, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+		meta[role] = origMetadata
+	}
+	return meta
+}
+
+// A new swizzler should have metadata for all roles, and a snapshot of all roles
+func TestNewSwizzler(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	for _, role := range f.Roles {
+		metaBytes, ok := origMeta[role]
+		require.True(t, ok)
+		require.NotNil(t, metaBytes)
+		require.NotEmpty(t, metaBytes)
+	}
+
+	snapshot, timestamp := &data.SignedSnapshot{}, &data.SignedTimestamp{}
+	require.NoError(t, json.Unmarshal(origMeta[data.CanonicalSnapshotRole], snapshot))
+	require.NoError(t, json.Unmarshal(origMeta[data.CanonicalTimestampRole], timestamp))
+
+	for _, role := range f.Roles {
+		filemeta, ok := snapshot.Signed.Meta[role]
+		if role != data.CanonicalTimestampRole && role != data.CanonicalSnapshotRole {
+			require.True(t, ok)
+			require.NotNil(t, filemeta)
+			require.NotEmpty(t, filemeta)
+		} else {
+			require.False(t, ok)
+		}
+	}
+
+	require.Len(t, timestamp.Signed.Meta, 1)
+	filemeta, ok := timestamp.Signed.Meta[data.CanonicalSnapshotRole]
+	require.True(t, ok)
+	require.NotNil(t, filemeta)
+	require.NotEmpty(t, filemeta)
+
+	// targets should have 1 delegated role, as should targets/a
+	targets, targetsA := &data.SignedTargets{}, &data.SignedTargets{}
+	require.NoError(t, json.Unmarshal(origMeta[data.CanonicalTargetsRole], targets))
+	require.NoError(t, json.Unmarshal(origMeta["targets/a"], targetsA))
+
+	require.Len(t, targets.Signed.Delegations.Roles, 1)
+	require.Equal(t, "targets/a", targets.Signed.Delegations.Roles[0].Name)
+
+	require.Len(t, targetsA.Signed.Delegations.Roles, 1)
+	require.Equal(t, "targets/a/b", targetsA.Signed.Delegations.Roles[0].Name)
+}
+
+// This invalidates the metadata so that it can no longer be unmarshalled as
+// JSON as any sort
+func TestSwizzlerSetInvalidJSON(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.SetInvalidJSON(data.CanonicalSnapshotRole)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != data.CanonicalSnapshotRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			// it should not be JSON unmarshallable
+			var generic interface{}
+			require.Error(t, json.Unmarshal(newMeta, &generic))
+		}
+	}
+}
+
+// This modifies metdata so that it is unmarshallable as JSON, but cannot be
+// unmarshalled as a Signed object
+func TestSwizzlerSetInvalidSigned(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.SetInvalidSigned(data.CanonicalTargetsRole)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != data.CanonicalTargetsRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			// it be JSON unmarshallable, but not data.Signed marshallable
+			var generic interface{}
+			require.NoError(t, json.Unmarshal(newMeta, &generic))
+			signedThing := data.Signed{}
+			require.Error(t, json.Unmarshal(newMeta, &signedThing))
+		}
+	}
+}
+
+// This modifies metdata so that it is unmarshallable as JSON, but cannot be
+// unmarshalled as a Signed object
+func TestSwizzlerSetInvalidSignedMeta(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.SetInvalidSignedMeta(data.CanonicalTargetsRole)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != data.CanonicalTargetsRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			// can be unmarshaled as Signed, but not as SignedMeta
+			signedThing := data.Signed{}
+			require.NoError(t, json.Unmarshal(newMeta, &signedThing))
+			signedMeta := data.SignedMeta{}
+			require.Error(t, json.Unmarshal(newMeta, &signedMeta))
+		}
+	}
+}
+
+// This modifies metdata so that it is unmarshallable as JSON, but cannot be
+// unmarshalled as a Signed object
+func TestSwizzlerSetInvalidMetadataType(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.SetInvalidMetadataType(data.CanonicalTargetsRole)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != data.CanonicalTargetsRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			signedMeta := data.SignedMeta{}
+			require.NoError(t, json.Unmarshal(newMeta, &signedMeta))
+			require.NotEqual(t, data.CanonicalTargetsRole, signedMeta.Signed.Type)
+		}
+	}
+}
+
+// This modifies the metadata so that the signed part has an extra, extraneous
+// field.  This does not prevent it from being unmarshalled as Signed* object,
+// but the signature is no longer valid because the hash is different.
+func TestSwizzlerInvalidateMetadataSignatures(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.InvalidateMetadataSignatures(data.CanonicalRootRole)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != data.CanonicalRootRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			// it be JSON unmarshallable into a data.Signed, and it's signed by
+			// root, but it is NOT the correct signature because the hash
+			// does not match
+			origSigned, newSigned := &data.Signed{}, &data.Signed{}
+			require.NoError(t, json.Unmarshal(metaBytes, origSigned))
+			require.NoError(t, json.Unmarshal(newMeta, newSigned))
+			require.Len(t, newSigned.Signatures, len(origSigned.Signatures))
+			for i := range origSigned.Signatures {
+				require.Equal(t, origSigned.Signatures[i].KeyID, newSigned.Signatures[i].KeyID)
+				require.Equal(t, origSigned.Signatures[i].Method, newSigned.Signatures[i].Method)
+				require.NotEqual(t, origSigned.Signatures[i].Signature, newSigned.Signatures[i].Signature)
+			}
+			require.True(t, bytes.Equal(origSigned.Signed, newSigned.Signed))
+		}
+	}
+}
+
+// This just deletes the metadata entirely from the cache
+func TestSwizzlerRemoveMetadata(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.RemoveMetadata("targets/a")
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		if role != "targets/a" {
+			require.NoError(t, err)
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.Error(t, err)
+			require.IsType(t, store.ErrMetaNotFound{}, err)
+		}
+	}
+}
+
+// This signs the metadata with the wrong key
+func TestSwizzlerSignMetadataWithInvalidKey(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.SignMetadataWithInvalidKey(data.CanonicalTimestampRole)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != data.CanonicalTimestampRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			// it is JSON unmarshallable as a timestamp, but the signature ID
+			// does not match.
+			require.NoError(t, json.Unmarshal(newMeta, &data.SignedTimestamp{}))
+			origSigned, newSigned := &data.Signed{}, &data.Signed{}
+			require.NoError(t, json.Unmarshal(metaBytes, origSigned))
+			require.NoError(t, json.Unmarshal(newMeta, newSigned))
+			require.Len(t, origSigned.Signatures, 1)
+			require.Len(t, newSigned.Signatures, 1)
+			require.NotEqual(t, origSigned.Signatures[0].KeyID, newSigned.Signatures[0].KeyID)
+		}
+	}
+}
+
+// This updates the metadata version with a particular number
+func TestSwizzlerOffsetMetadataVersion(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.OffsetMetadataVersion("targets/a", -2)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != "targets/a" {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			origSigned, newSigned := &data.SignedMeta{}, &data.SignedMeta{}
+			require.NoError(t, json.Unmarshal(metaBytes, origSigned))
+			require.NoError(t, json.Unmarshal(newMeta, newSigned))
+			require.Equal(t, 1, origSigned.Signed.Version)
+			require.Equal(t, -1, newSigned.Signed.Version)
+		}
+	}
+}
+
+// This causes the metadata to be expired
+func TestSwizzlerExpireMetadata(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.ExpireMetadata(data.CanonicalRootRole)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		if role != data.CanonicalRootRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			origSigned, newSigned := &data.SignedMeta{}, &data.SignedMeta{}
+			now := time.Now()
+			require.NoError(t, json.Unmarshal(metaBytes, origSigned))
+			require.NoError(t, json.Unmarshal(newMeta, newSigned))
+			require.True(t, now.Before(origSigned.Signed.Expires))
+			require.True(t, now.After(newSigned.Signed.Expires))
+		}
+	}
+}
+
+// This sets the threshold for a base role
+func TestSwizzlerSetThresholdBaseRole(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.SetThreshold(data.CanonicalTargetsRole, 3)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		// the threshold for base roles is set in root
+		if role != data.CanonicalRootRole {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			signedRoot := &data.SignedRoot{}
+			require.NoError(t, json.Unmarshal(newMeta, signedRoot))
+			for r, roleInfo := range signedRoot.Signed.Roles {
+				if r != data.CanonicalTargetsRole {
+					require.Equal(t, 1, roleInfo.Threshold)
+				} else {
+					require.Equal(t, 3, roleInfo.Threshold)
+				}
+			}
+		}
+	}
+}
+
+// This sets the threshold for a delegation
+func TestSwizzlerSetThresholdDelegatedRole(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.SetThreshold("targets/a/b", 3)
+
+	for role, metaBytes := range origMeta {
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		// the threshold for "targets/a/b" is in "targets/a"
+		if role != "targets/a" {
+			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
+		} else {
+			require.False(t, bytes.Equal(metaBytes, newMeta))
+			signedTargets := &data.SignedTargets{}
+			require.NoError(t, json.Unmarshal(newMeta, signedTargets))
+			require.Len(t, signedTargets.Signed.Delegations.Roles, 1)
+			require.Equal(t, "targets/a/b", signedTargets.Signed.Delegations.Roles[0].Name)
+			require.Equal(t, 3, signedTargets.Signed.Delegations.Roles[0].Threshold)
+		}
+	}
+}
+
+// This changes the root key
+func TestSwizzlerChangeRootKey(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta := getAllMeta(t, f)
+
+	f.ChangeRootKey()
+
+	kdb := keys.NewDB()
+	tufRepo := tuf.NewRepo(kdb, f.CryptoService)
+
+	// we want to test these in a specific order
+	roles := []string{data.CanonicalRootRole, data.CanonicalTargetsRole, data.CanonicalSnapshotRole,
+		data.CanonicalTimestampRole, "targets/a", "targets/a/b"}
+
+	for _, role := range roles {
+		origMeta := origMeta[role]
+		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		require.NoError(t, err)
+
+		// the threshold for base roles is set in root
+		switch role {
+		case data.CanonicalRootRole:
+			require.False(t, bytes.Equal(origMeta, newMeta))
+			origRoot, newRoot := &data.SignedRoot{}, &data.SignedRoot{}
+			require.NoError(t, json.Unmarshal(origMeta, origRoot))
+			require.NoError(t, json.Unmarshal(newMeta, newRoot))
+
+			require.NotEqual(t, len(origRoot.Signed.Keys), len(newRoot.Signed.Keys))
+
+			for r, origRole := range origRoot.Signed.Roles {
+				newRole := newRoot.Signed.Roles[r]
+				require.Len(t, origRole.KeyIDs, 1)
+				require.Len(t, newRole.KeyIDs, 1)
+				if r == data.CanonicalRootRole {
+					require.NotEqual(t, origRole.KeyIDs[0], newRole.KeyIDs[0])
+				} else {
+					require.Equal(t, origRole.KeyIDs[0], newRole.KeyIDs[0])
+				}
+			}
+
+			require.NoError(t, tufRepo.SetRoot(newRoot))
+			signedThing, err := newRoot.ToSigned()
+			require.NoError(t, err)
+			require.NoError(t, signed.Verify(signedThing, data.CanonicalRootRole, 1, kdb))
+		default:
+			require.True(t, bytes.Equal(origMeta, newMeta), "bytes have changed for role %s", role)
+		}
+	}
+}
+
+// UpdateSnapshotHashes will recreate all snapshot hashes, useful if some metadata
+// has been fuzzed and we want all the hashes to be correct.  If roles are provided,
+// only hashes for those roles will be re-generated.
+func TestSwizzlerUpdateSnapshotHashesSpecifiedRoles(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	require.NoError(t, err)
+
+	// nothing has changed, signed data should be the same (signatures might
+	// change because signatures may have random elements
+	f.UpdateSnapshotHashes(data.CanonicalTargetsRole)
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+
+	origSigned, newSigned := &data.Signed{}, &data.Signed{}
+	require.NoError(t, json.Unmarshal(origMeta, origSigned))
+	require.NoError(t, json.Unmarshal(newMeta, newSigned))
+	require.True(t, bytes.Equal(origSigned.Signed, newSigned.Signed))
+
+	// change these 3 metadata items
+	f.InvalidateMetadataSignatures(data.CanonicalTargetsRole)
+	f.InvalidateMetadataSignatures("targets/a")
+	f.InvalidateMetadataSignatures("targets/a/b")
+	// update the snapshot with just 1 role
+	f.UpdateSnapshotHashes(data.CanonicalTargetsRole)
+
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(origMeta, newMeta))
+
+	origSnapshot, newSnapshot := &data.SignedSnapshot{}, &data.SignedSnapshot{}
+	require.NoError(t, json.Unmarshal(origMeta, origSnapshot))
+	require.NoError(t, json.Unmarshal(newMeta, newSnapshot))
+
+	// only the targets checksum was regenerated, since that was specified
+	for _, role := range f.Roles {
+		switch role {
+		case data.CanonicalTimestampRole:
+			continue
+		case data.CanonicalTargetsRole:
+			require.NotEqual(t, origSnapshot.Signed.Meta[role], newSnapshot.Signed.Meta[role])
+		default:
+			require.Equal(t, origSnapshot.Signed.Meta[role], newSnapshot.Signed.Meta[role])
+		}
+	}
+}
+
+// UpdateSnapshotHashes will recreate all snapshot hashes, useful if some metadata
+// has been fuzzed and we want all the hashes to be correct.  If no roles are provided,
+// all hashes are regenerated
+func TestSwizzlerUpdateSnapshotHashesNoSpecifiedRoles(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	require.NoError(t, err)
+
+	// nothing has changed, signed data should be the same (signatures might
+	// change because signatures may have random elements
+	f.UpdateSnapshotHashes()
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	require.NoError(t, err)
+
+	origSigned, newSigned := &data.Signed{}, &data.Signed{}
+	require.NoError(t, json.Unmarshal(origMeta, origSigned))
+	require.NoError(t, json.Unmarshal(newMeta, newSigned))
+	require.True(t, bytes.Equal(origSigned.Signed, newSigned.Signed))
+
+	// change these 2 metadata items
+	f.InvalidateMetadataSignatures(data.CanonicalTargetsRole)
+	f.InvalidateMetadataSignatures("targets/a")
+	f.InvalidateMetadataSignatures("targets/a/b")
+	// update the snapshot with just no specified roles
+	f.UpdateSnapshotHashes()
+
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(origMeta, newMeta))
+
+	origSnapshot, newSnapshot := &data.SignedSnapshot{}, &data.SignedSnapshot{}
+	require.NoError(t, json.Unmarshal(origMeta, origSnapshot))
+	require.NoError(t, json.Unmarshal(newMeta, newSnapshot))
+
+	for _, role := range f.Roles {
+		switch role {
+		case data.CanonicalTimestampRole:
+			continue
+		case data.CanonicalTargetsRole:
+			fallthrough
+		case "targets/a":
+			fallthrough
+		case "targets/a/b":
+			require.NotEqual(t, origSnapshot.Signed.Meta[role], newSnapshot.Signed.Meta[role])
+		default:
+			require.Equal(t, origSnapshot.Signed.Meta[role], newSnapshot.Signed.Meta[role])
+		}
+	}
+}
+
+// UpdateTimestamp will re-calculate the snapshot hash
+func TestSwizzlerUpdateTimestamp(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+	origMeta, err := f.MetadataCache.GetMeta(data.CanonicalTimestampRole, maxSize)
+	require.NoError(t, err)
+
+	// nothing has changed, signed data should be the same (signatures might
+	// change because signatures may have random elements
+	f.UpdateTimestampHash()
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalTimestampRole, maxSize)
+	require.NoError(t, err)
+
+	origSigned, newSigned := &data.Signed{}, &data.Signed{}
+	require.NoError(t, json.Unmarshal(origMeta, origSigned))
+	require.NoError(t, json.Unmarshal(newMeta, newSigned))
+	require.True(t, bytes.Equal(origSigned.Signed, newSigned.Signed))
+
+	// update snapshot
+	f.OffsetMetadataVersion(data.CanonicalSnapshotRole, 1)
+	// update the timestamp
+	f.UpdateTimestampHash()
+
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalTimestampRole, maxSize)
+	require.NoError(t, err)
+	require.False(t, bytes.Equal(origMeta, newMeta))
+
+	origTimestamp, newTimestamp := &data.SignedTimestamp{}, &data.SignedTimestamp{}
+	require.NoError(t, json.Unmarshal(origMeta, origTimestamp))
+	require.NoError(t, json.Unmarshal(newMeta, newTimestamp))
+
+	require.Len(t, origTimestamp.Signed.Meta, 1)
+	require.Len(t, newTimestamp.Signed.Meta, 1)
+	require.False(t, reflect.DeepEqual(
+		origTimestamp.Signed.Meta[data.CanonicalSnapshotRole],
+		newTimestamp.Signed.Meta[data.CanonicalSnapshotRole]))
+}
+
+// functions which require re-signing the metadata will return ErrNoKeyForRole if
+// the signing key is missing
+func TestMissingSigningKey(t *testing.T) {
+	f, err := NewMetadataSwizzler("docker.com/notary")
+	require.NoError(t, err)
+
+	// delete the snapshot, timestamp, and root keys
+	noKeys := []string{
+		data.CanonicalSnapshotRole, data.CanonicalTimestampRole, data.CanonicalRootRole}
+	for _, role := range noKeys {
+		k := f.CryptoService.ListKeys(role)
+		require.Len(t, k, 1)
+		require.NoError(t, f.CryptoService.RemoveKey(k[0]))
+	}
+
+	// these are all the functions that require re-signing
+	require.IsType(t, ErrNoKeyForRole{}, f.OffsetMetadataVersion(data.CanonicalSnapshotRole, 1))
+	require.IsType(t, ErrNoKeyForRole{}, f.ExpireMetadata(data.CanonicalSnapshotRole))
+	require.IsType(t, ErrNoKeyForRole{}, f.SetThreshold(data.CanonicalSnapshotRole, 2))
+	require.IsType(t, ErrNoKeyForRole{}, f.UpdateSnapshotHashes())
+	require.IsType(t, ErrNoKeyForRole{}, f.UpdateTimestampHash())
+}


### PR DESCRIPTION
Trying to keep this PR size relatively manageable in size (sorry, it's pretty big :().  This includes a utility and some tests for updating a repo when the repo itself has been corrupted.

Tests to update a repo when the server has corrupted metadata are forthcoming in another PR.

(note this PR also removes coverage calculation for the testutils package, which is a library we use only for testing)

Closes #451
Partially addresses #361 