### PR TITLE
Add some comments about the notary constants, and other lint fixes.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -545,7 +545,7 @@ func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
 	// All top level delegations (ex: targets/level1) are stored exclusively in targets.json
 	targets, ok := r.tufRepo.Targets[data.CanonicalTargetsRole]
 	if !ok {
-		return nil, store.ErrMetaNotFound{data.CanonicalTargetsRole}
+		return nil, store.ErrMetaNotFound{Resource: data.CanonicalTargetsRole}
 	}
 
 	allDelegations := targets.Signed.Delegations.Roles

--- a/const.go
+++ b/const.go
@@ -2,10 +2,14 @@ package notary
 
 // application wide constants
 const (
-	// Require a minimum of one threshold for roles, currently we do not support a higher threshold
-	MinThreshold    = 1
-	PrivKeyPerms    = 0700
-	PubCertPerms    = 0755
-	Sha256HexSize   = 64
+	// MinThreshold requires a minimum of one threshold for roles; currently we do not support a higher threshold
+	MinThreshold = 1
+	// PrivKeyPerms are the file permissions to use when writing private keys to disk
+	PrivKeyPerms = 0700
+	// PubCertPerms are the file permissions to use when writing public certificates to disk
+	PubCertPerms = 0755
+	// Sha256HexSize is how big a Sha256 hex is in number of characters
+	Sha256HexSize = 64
+	// TrustedCertsDir is the directory, under the notary repo base directory, where trusted certs are stored
 	TrustedCertsDir = "trusted_certificates"
 )


### PR DESCRIPTION
It seems that `make vet` sometimes disagrees locally vs on CircleCI.  This
just fixes my local `make vet` complaints.

Signed-off-by: Ying Li <ying.li@docker.com>

Sometimes my local `make vet` seems to let me get away without commenting, too, so I'm not sure where the disparity is.