### PR TITLE
Add tests for when the server 404's or 50X's when updating

### DIFF
--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -461,7 +461,6 @@ func TestUpdateRemoteRoot50XCannotUseLocalCache(t *testing.T) {
 // but is missing other data, then we propagate the ErrMetaNotFound.  Skipping
 // force check, because that only matters for root.
 func TestUpdateNonRootRemoteMissingMetadataNoLocalCache(t *testing.T) {
-	// TODO: fix json syntax error
 	for _, role := range append(data.BaseRoles, "targets/a", "targets/a/b") {
 		if role == data.CanonicalRootRole {
 			continue
@@ -531,7 +530,6 @@ func TestUpdateNonRootRemoteMissingMetadataCannotUseLocalCache(t *testing.T) {
 // If there is no local cache, we just update. If the server 50X's when getting
 // metadata, we propagate ErrServerUnavailable.
 func TestUpdateNonRootRemote50XNoLocalCache(t *testing.T) {
-	// TODO: fix json syntax error
 	for _, role := range append(data.BaseRoles, "targets/a", "targets/a/b") {
 		if role == data.CanonicalRootRole {
 			continue

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -54,7 +54,7 @@ func (c *Client) Update() error {
 	if err != nil {
 		logrus.Debug("Error occurred. Root will be downloaded and another update attempted")
 		if err := c.downloadRoot(); err != nil {
-			logrus.Error("client Update (Root):", err)
+			logrus.Error("Client Update (Root):", err)
 			return err
 		}
 		// If we error again, we now have the latest root and just want to fail
@@ -266,9 +266,6 @@ func (c *Client) downloadTimestamp() error {
 	// from remote, only using the cache one if we couldn't reach remote.
 	raw, s, err := c.downloadSigned(role, maxSize, nil)
 	if err != nil || len(raw) == 0 {
-		if err, ok := err.(store.ErrMetaNotFound); ok {
-			return err
-		}
 		if old == nil {
 			if err == nil {
 				// couldn't retrieve data from server and don't have valid
@@ -277,7 +274,8 @@ func (c *Client) downloadTimestamp() error {
 			}
 			return err
 		}
-		logrus.Debug("using cached timestamp")
+		logrus.Debug(err.Error())
+		logrus.Warn("Error while downloading remote metadata, using cached timestamp - this might not be the latest version available remotely")
 		s = old
 	} else {
 		download = true


### PR DESCRIPTION
I re-worked the first couple of tests in `client_update_tests` to cover more cases and moved them to the bottom of the file.

I also changed client so that:

1.  we don't get an unexpected end of JSON error when the server errors while downloading a timestamp
2.  we just use the cached timestamp now when the server 404's on getting a timestamp (previously, we used the cached timestamp when we got any other error than 404 - not sure we should default to cached if we do get a 404, but the behavior should probably be consistent for non-200 status codes)
3.  warn users that we are using a stale timestamp file and hence may have a stale view of the repo, if we use the cached timestamp

Partially addresses #361.