### PR TITLE
tokenAuth should also 'succeed' if we get a 401

### DIFF
--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -432,8 +432,9 @@ func tokenAuth(trustServerURL string, baseTransport *http.Transport, gun string,
 	}
 	// non-nil err means we must close body
 	defer resp.Body.Close()
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		// If we didn't get a 2XX range status code, we're not talking to a notary server.
+	if (resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices) &&
+		resp.StatusCode != http.StatusUnauthorized {
+		// If we didn't get a 2XX range or 401 status code, we're not talking to a notary server.
 		// The http client should be configured to handle redirects so at this point, 3XX is
 		// not a valid status code.
 		logrus.Errorf("could not reach %s: %d", trustServerURL, resp.StatusCode)

--- a/cmd/notary/tuf_test.go
+++ b/cmd/notary/tuf_test.go
@@ -17,11 +17,44 @@ func TestTokenAuth(t *testing.T) {
 	require.Nil(t, tokenAuth("https://localhost:9999", baseTransport, gun, readOnly))
 }
 
+func StatusOKTestHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	w.Write([]byte("{}"))
+}
+
+func TestTokenAuth200Status(t *testing.T) {
+	var (
+		readOnly      bool
+		baseTransport = &http.Transport{}
+		gun           = "test"
+	)
+	s := httptest.NewServer(http.HandlerFunc(NotAuthorizedTestHandler))
+	defer s.Close()
+
+	require.NotNil(t, tokenAuth(s.URL, baseTransport, gun, readOnly))
+}
+
+func NotAuthorizedTestHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(401)
+}
+
+func TestTokenAuth401Status(t *testing.T) {
+	var (
+		readOnly      bool
+		baseTransport = &http.Transport{}
+		gun           = "test"
+	)
+	s := httptest.NewServer(http.HandlerFunc(NotAuthorizedTestHandler))
+	defer s.Close()
+
+	require.NotNil(t, tokenAuth(s.URL, baseTransport, gun, readOnly))
+}
+
 func NotFoundTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(404)
 }
 
-func TestTokenAuthNon200Status(t *testing.T) {
+func TestTokenAuthNon200Non401Status(t *testing.T) {
 	var (
 		readOnly      bool
 		baseTransport = &http.Transport{}


### PR DESCRIPTION
I had an incorrect understanding of the response codes that would be returned from `/v2/`. A 401 is considered valid and will result in authentication being done later.

Tests have been added to ensure tokenAuth succeeds when the server returns a 401

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)