### PR TITLE
allow for configurable log level, change default for CLI

### DIFF
--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -822,6 +822,28 @@ func TestDefaultRootKeyGeneration(t *testing.T) {
 	assertNumKeys(t, tempDir, 1, 0, true)
 }
 
+// Tests the interaction with the verbose and log-level flags
+func TestLogLevelFlags(t *testing.T) {
+	// Test default to fatal
+	setVerbosityLevel()
+	assert.Equal(t, "fatal", logrus.GetLevel().String())
+
+	// Test that verbose (-v) sets to error
+	verbose = true
+	setVerbosityLevel()
+	assert.Equal(t, "error", logrus.GetLevel().String())
+
+	// Test that debug (-D) sets to debug
+	debug = true
+	setVerbosityLevel()
+	assert.Equal(t, "debug", logrus.GetLevel().String())
+
+	// Test that unsetting verboseError still uses verboseDebug
+	verbose = false
+	setVerbosityLevel()
+	assert.Equal(t, "debug", logrus.GetLevel().String())
+}
+
 func tempDirWithConfig(t *testing.T, config string) string {
 	tempDir, err := ioutil.TempDir("/tmp", "repo")
 	assert.NoError(t, err)

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -20,6 +20,7 @@ const (
 )
 
 var (
+	debug             bool
 	verbose           bool
 	trustDir          string
 	configFile        string
@@ -37,10 +38,7 @@ func init() {
 }
 
 func parseConfig() *viper.Viper {
-	if verbose {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(os.Stderr)
-	}
+	setVerbosityLevel()
 
 	// Get home directory for current user
 	homeDir, err := homedir.Dir()
@@ -112,6 +110,7 @@ func setupCommand(notaryCmd *cobra.Command) {
 	notaryCmd.PersistentFlags().StringVarP(&trustDir, "trustDir", "d", "", "Directory where the trust data is persisted to")
 	notaryCmd.PersistentFlags().StringVarP(&configFile, "configFile", "c", "", "Path to the configuration file to use")
 	notaryCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
+	notaryCmd.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "Debug output")
 	notaryCmd.PersistentFlags().StringVarP(&remoteTrustServer, "server", "s", "", "Remote trust server location")
 
 	cmdKeyGenerator := &keyCommander{
@@ -179,4 +178,16 @@ func getPassphraseRetriever() passphrase.Retriever {
 		}
 		return baseRetriever(keyName, alias, createNew, numAttempts)
 	}
+}
+
+// Set the logging level to fatal on default, or the most specific level the user specified (debug or error)
+func setVerbosityLevel() {
+	if debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	} else if verbose {
+		logrus.SetLevel(logrus.ErrorLevel)
+	} else {
+		logrus.SetLevel(logrus.FatalLevel)
+	}
+	logrus.SetOutput(os.Stderr)
 }


### PR DESCRIPTION
Currently the default logging level is error - it'd be nice to have configurable logging levels for notary, and only default to a higher level such as `fatal` for a less noisy CLI.

This is motivated by when I was testing remote snapshot rotation via the CLI, and any online command after the `key rotate` command brought about an Info log for a signature mismatch for Snapshot, and an associated Error log.  This is particularly noisy in this instance because these logs occur before we download a new root and retry the TUF update, ultimately running the command successfully to completion:

```
$ notary key rotate snap3 -t snapshot -r true
$ notary publish snap3
Pushing changes to snap3
Enter passphrase for root key with ID b96f107:
$ notary list snap3
INFO[0000] failed ECDSA signature validation
ERRO[0000] Client Update (Snapshot): valid signatures did not meet threshold
  NAME                                DIGEST                                SIZE (BYTES)    ROLE
----------------------------------------------------------------------------------------------------
  v1     e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   0              targets
```

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>