### PR TITLE
List timestamps

### DIFF
--- a/const.go
+++ b/const.go
@@ -12,4 +12,6 @@ const (
 	Sha256HexSize = 64
 	// TrustedCertsDir is the directory, under the notary repo base directory, where trusted certs are stored
 	TrustedCertsDir = "trusted_certificates"
+	// Sha256HexRegex is the regex for checking the validity of a string as a sha256 regex in hex.
+	Sha256HexRegex = "^([a-fA-F0-9]{64})$"
 )

--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -29,7 +29,7 @@ var (
 	ErrBadPagination = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "BAD_PAGINATION",
 		Message:        "The pagination parameters are invalid.",
-		Description:    "Either the start or number parameters could not be parsed as integers greater than or equal to zero.",
+		Description:    "The cursor or limit parameters could not be parsed. The cursor parameter must be a hex encoded sha256 checksum, and the limit must be an integer >= 0",
 		HTTPStatusCode: http.StatusBadRequest,
 	})
 	ErrInvalidRole = errcode.Register(errGroup, errcode.ErrorDescriptor{

--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -26,6 +26,12 @@ var (
 		Description:    "No file/role name is provided to associate an update with.",
 		HTTPStatusCode: http.StatusBadRequest,
 	})
+	ErrBadPagination = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "BAD_PAGINATION",
+		Message:        "The pagination parameters are invalid.",
+		Description:    "Either the start or number parameters could not be parsed as integers greater than or equal to zero.",
+		HTTPStatusCode: http.StatusBadRequest,
+	})
 	ErrInvalidRole = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "INVALID_ROLE",
 		Message:        "The role you are attempting to operate on is invalid.",

--- a/server/handlers/response_types.go
+++ b/server/handlers/response_types.go
@@ -1,0 +1,7 @@
+package handlers
+
+// VersionResponse wraps a list of versions incase we want
+// to add more metadata later without breaking old clients.
+type VersionResponse struct {
+	Versions [][]byte `json:"versions"`
+}

--- a/server/server.go
+++ b/server/server.go
@@ -97,10 +97,29 @@ func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.Cry
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("GetRoleByHash"),
 			hand(handlers.GetHandler, "pull")))
+
+	// Version Routes
 	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/versions/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Handler(
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("ListVersions"),
-			hand(handlers.ListVersionsHandler, "pull")))
+			hand(handlers.ListVersionsHandler, "pull")),
+	)
+	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/versions/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Queries(
+		"number", "{number:[0-9]+}",
+	).Handler(
+		prometheus.InstrumentHandlerWithOpts(
+			prometheusOpts("ListVersions"),
+			hand(handlers.ListVersionsHandler, "pull")),
+	)
+	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/versions/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Queries(
+		"number", "{number:[0-9]+}",
+		"start", "{start:[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128}}",
+	).Handler(
+		prometheus.InstrumentHandlerWithOpts(
+			prometheusOpts("ListVersions"),
+			hand(handlers.ListVersionsHandler, "pull")),
+	)
+
 	r.Methods("GET").Path(
 		"/v2/{imageName:.*}/_trust/tuf/{tufRole:snapshot|timestamp}.key").Handler(
 		prometheus.InstrumentHandlerWithOpts(

--- a/server/server.go
+++ b/server/server.go
@@ -104,21 +104,6 @@ func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.Cry
 			prometheusOpts("ListVersions"),
 			hand(handlers.ListVersionsHandler, "pull")),
 	)
-	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/versions/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Queries(
-		"number", "{number:[0-9]+}",
-	).Handler(
-		prometheus.InstrumentHandlerWithOpts(
-			prometheusOpts("ListVersions"),
-			hand(handlers.ListVersionsHandler, "pull")),
-	)
-	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/versions/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Queries(
-		"number", "{number:[0-9]+}",
-		"start", "{start:[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128}}",
-	).Handler(
-		prometheus.InstrumentHandlerWithOpts(
-			prometheusOpts("ListVersions"),
-			hand(handlers.ListVersionsHandler, "pull")),
-	)
 
 	r.Methods("GET").Path(
 		"/v2/{imageName:.*}/_trust/tuf/{tufRole:snapshot|timestamp}.key").Handler(

--- a/server/server.go
+++ b/server/server.go
@@ -97,6 +97,10 @@ func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.Cry
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("GetRoleByHash"),
 			hand(handlers.GetHandler, "pull")))
+	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/versions/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Handler(
+		prometheus.InstrumentHandlerWithOpts(
+			prometheusOpts("ListVersions"),
+			hand(handlers.ListVersionsHandler, "pull")))
 	r.Methods("GET").Path(
 		"/v2/{imageName:.*}/_trust/tuf/{tufRole:snapshot|timestamp}.key").Handler(
 		prometheus.InstrumentHandlerWithOpts(

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,10 +9,12 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	_ "github.com/docker/distribution/registry/auth/silly"
+	"github.com/docker/notary/server/handlers"
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
@@ -158,4 +160,95 @@ func TestGetRoleByHash(t *testing.T) {
 	defer res.Body.Close()
 	// if content is equal, checksums are guaranteed to be equal
 	assert.EqualValues(t, j, body)
+}
+
+func TestListVersions(t *testing.T) {
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	_, store := storage.SetUpSQLite(t, tempBaseDir)
+	defer os.RemoveAll(tempBaseDir)
+
+	ts := data.SignedTimestamp{
+		Signatures: make([]data.Signature, 0),
+		Signed: data.Timestamp{
+			Type:    data.TUFTypes["timestamp"],
+			Version: 1,
+			Expires: data.DefaultExpires("timestamp"),
+		},
+	}
+	tsJSON1, err := json.Marshal(&ts)
+	assert.NoError(t, err)
+	update := storage.MetaUpdate{
+		Role:    data.CanonicalTimestampRole,
+		Version: 1,
+		Data:    tsJSON1,
+	}
+	store.UpdateCurrent("gun", update)
+
+	// create and add a newer timestamp. We're going to try and request
+	// the older version we created above.
+	ts = data.SignedTimestamp{
+		Signatures: make([]data.Signature, 0),
+		Signed: data.Timestamp{
+			Type:    data.TUFTypes["timestamp"],
+			Version: 2,
+			Expires: data.DefaultExpires("timestamp"),
+		},
+	}
+	tsJSON2, err := json.Marshal(&ts)
+	assert.NoError(t, err)
+	update = storage.MetaUpdate{
+		Role:    data.CanonicalTimestampRole,
+		Version: 2,
+		Data:    tsJSON2,
+	}
+	store.UpdateCurrent("gun", update)
+	checksumBytes := sha256.Sum256(tsJSON2)
+	checksum := hex.EncodeToString(checksumBytes[:])
+
+	ctx := context.WithValue(
+		context.Background(), "metaStore", store)
+
+	ctx = context.WithValue(ctx, "keyAlgorithm", data.ED25519Key)
+
+	handler := RootHandler(nil, ctx, signed.NewEd25519())
+	serv := httptest.NewServer(handler)
+	defer serv.Close()
+
+	res, err := http.Get(fmt.Sprintf(
+		"%s/v2/gun/_trust/tuf/versions/%s.json",
+		serv.URL,
+		data.CanonicalTimestampRole,
+	))
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	defer res.Body.Close()
+
+	vers := handlers.VersionResponse{}
+	err = json.Unmarshal(body, &vers)
+	assert.NoError(t, err)
+	assert.Len(t, vers.Versions, 2)
+	assert.EqualValues(t, tsJSON2, vers.Versions[0])
+	assert.EqualValues(t, tsJSON1, vers.Versions[1])
+
+	res, err = http.Get(fmt.Sprintf(
+		"%s/v2/gun/_trust/tuf/versions/%s.json?start=%s&number=1",
+		serv.URL,
+		data.CanonicalTimestampRole,
+		checksum,
+	))
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err = ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	defer res.Body.Close()
+
+	vers = handlers.VersionResponse{}
+	err = json.Unmarshal(body, &vers)
+	assert.NoError(t, err)
+	assert.Len(t, vers.Versions, 1)
+	assert.EqualValues(t, tsJSON1, vers.Versions[0])
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -234,7 +234,7 @@ func TestListVersions(t *testing.T) {
 	assert.EqualValues(t, tsJSON1, vers.Versions[1])
 
 	res, err = http.Get(fmt.Sprintf(
-		"%s/v2/gun/_trust/tuf/versions/%s.json?start=%s&number=1",
+		"%s/v2/gun/_trust/tuf/versions/%s.json?cursor=%s&limit=1",
 		serv.URL,
 		data.CanonicalTimestampRole,
 		checksum,

--- a/server/storage/database.go
+++ b/server/storage/database.go
@@ -152,6 +152,26 @@ func returnRead(q *gorm.DB, row TUFFile) ([]byte, error) {
 	return row.Data, nil
 }
 
+// GetVersions returns all versions of the given gun+role, newest to oldest
+func (db *SQLStorage) GetVersions(gun, role string, start, numToReturn int) ([][]byte, error) {
+	var res [][]byte
+	q := db.Select("data").Where(&TUFFile{Gun: gun, Role: role}).Order("version desc")
+	if start > 0 {
+		q = q.Offset(start)
+	}
+	if numToReturn > 0 {
+		q = q.Limit(numToReturn)
+	}
+	q = q.Find(&res)
+
+	if q.RecordNotFound() {
+		return nil, ErrNotFound{}
+	} else if q.Error != nil {
+		return nil, q.Error
+	}
+	return res, nil
+}
+
 // Delete deletes all the records for a specific GUN
 func (db *SQLStorage) Delete(gun string) error {
 	return db.Where(&TUFFile{Gun: gun}).Delete(TUFFile{}).Error

--- a/server/storage/database_test.go
+++ b/server/storage/database_test.go
@@ -517,6 +517,7 @@ func TestGetVersions(t *testing.T) {
 		MetaUpdate{Role: "timestamp", Version: 3, Data: tsJSON3},
 	)
 
+	// test getting everything via zero value parameters
 	versions, err := store.GetVersions("gun", "timestamp", "", 0)
 	require.NoError(t, err)
 
@@ -525,7 +526,38 @@ func TestGetVersions(t *testing.T) {
 	require.EqualValues(t, tsJSON2, versions[1])
 	require.EqualValues(t, tsJSON1, versions[2])
 
+	// test limit being larger than total number of entries
+	versions, err = store.GetVersions("gun", "timestamp", "", 10)
+	require.NoError(t, err)
+
+	require.Len(t, versions, 3)
+	require.EqualValues(t, tsJSON3, versions[0])
+	require.EqualValues(t, tsJSON2, versions[1])
+	require.EqualValues(t, tsJSON1, versions[2])
+
+	// no checksum, limit number of entries returned
+	versions, err = store.GetVersions("gun", "timestamp", "", 1)
+	require.NoError(t, err)
+
+	require.Len(t, versions, 1)
+	require.EqualValues(t, tsJSON3, versions[0])
+
+	// test returning all when providing checksum
+	versions, err = store.GetVersions("gun", "timestamp", checksum, 0)
+	require.NoError(t, err)
+
+	require.Len(t, versions, 1)
+	require.EqualValues(t, tsJSON1, versions[0])
+
+	// checksum provided, limit number of entries
 	versions, err = store.GetVersions("gun", "timestamp", checksum, 1)
+	require.NoError(t, err)
+
+	require.Len(t, versions, 1)
+	require.EqualValues(t, tsJSON1, versions[0])
+
+	// test limit being larger than subset of available entries
+	versions, err = store.GetVersions("gun", "timestamp", checksum, 10)
 	require.NoError(t, err)
 
 	require.Len(t, versions, 1)
@@ -563,7 +595,6 @@ func TestGetVersionsNotFound(t *testing.T) {
 		MetaUpdate{Role: "timestamp", Version: 1, Data: tsJSON1},
 	)
 
-	// table is empty
 	_, err = store.GetVersions(
 		"gun",
 		"timestamp",

--- a/server/storage/database_test.go
+++ b/server/storage/database_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/testutils"
+	"github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
+	"github.com/mattn/go-sqlite3"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 )
@@ -35,28 +38,6 @@ func SampleUpdate(version int) MetaUpdate {
 		Version: version,
 		Data:    []byte("1"),
 	}
-}
-
-// SetUpSQLite creates a sqlite database for testing
-func SetUpSQLite(t *testing.T, dbDir string) (*gorm.DB, *SQLStorage) {
-	dbStore, err := NewSQLStorage("sqlite3", dbDir+"test_db")
-	require.NoError(t, err)
-
-	// Create the DB tables
-	err = CreateTUFTable(dbStore.DB)
-	require.NoError(t, err)
-
-	err = CreateKeyTable(dbStore.DB)
-	require.NoError(t, err)
-
-	// verify that the tables are empty
-	var count int
-	for _, model := range [2]interface{}{&TUFFile{}, &Key{}} {
-		query := dbStore.DB.Model(model).Count(&count)
-		require.NoError(t, query.Error)
-		require.Equal(t, 0, count)
-	}
-	return &dbStore.DB, dbStore
 }
 
 // TestSQLUpdateCurrent asserts that UpdateCurrent will add a new TUF file
@@ -500,4 +481,134 @@ func TestDBGetChecksumNotFound(t *testing.T) {
 	_, err = store.GetChecksum("gun", data.CanonicalTimestampRole, "12345")
 	require.Error(t, err)
 	require.IsType(t, ErrNotFound{}, err)
+}
+
+func TestGetVersions(t *testing.T) {
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	_, store := SetUpSQLite(t, tempBaseDir)
+	defer os.RemoveAll(tempBaseDir)
+
+	_, repo, _, err := testutils.EmptyRepo("gun")
+	require.NoError(t, err)
+
+	ts, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
+	tsJSON1, err := json.Marshal(ts)
+	require.NoError(t, err)
+	store.UpdateCurrent(
+		"gun",
+		MetaUpdate{Role: "timestamp", Version: 1, Data: tsJSON1},
+	)
+
+	ts, err = repo.SignTimestamp(data.DefaultExpires("timestamp"))
+	tsJSON2, err := json.Marshal(ts)
+	require.NoError(t, err)
+	store.UpdateCurrent(
+		"gun",
+		MetaUpdate{Role: "timestamp", Version: 2, Data: tsJSON2},
+	)
+	checksumBytes := sha256.Sum256(tsJSON2)
+	checksum := hex.EncodeToString(checksumBytes[:])
+
+	ts, err = repo.SignTimestamp(data.DefaultExpires("timestamp"))
+	tsJSON3, err := json.Marshal(ts)
+	require.NoError(t, err)
+	store.UpdateCurrent(
+		"gun",
+		MetaUpdate{Role: "timestamp", Version: 3, Data: tsJSON3},
+	)
+
+	versions, err := store.GetVersions("gun", "timestamp", "", 0)
+	require.NoError(t, err)
+
+	require.Len(t, versions, 3)
+	require.EqualValues(t, tsJSON3, versions[0])
+	require.EqualValues(t, tsJSON2, versions[1])
+	require.EqualValues(t, tsJSON1, versions[2])
+
+	versions, err = store.GetVersions("gun", "timestamp", checksum, 1)
+	require.NoError(t, err)
+
+	require.Len(t, versions, 1)
+	require.EqualValues(t, tsJSON1, versions[0])
+}
+
+func TestGetVersionsNotFound(t *testing.T) {
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	store, err := NewSQLStorage("sqlite3", tempBaseDir+"test_db")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempBaseDir)
+
+	// tables don't exist
+	_, err = store.GetVersions("gun", "timestamp", "", 0)
+	require.Error(t, err)
+
+	tempBaseDir, err = ioutil.TempDir("", "notary-test-")
+	_, store = SetUpSQLite(t, tempBaseDir)
+	defer os.RemoveAll(tempBaseDir)
+
+	// table is empty
+	_, err = store.GetVersions("gun", "timestamp", "", 0)
+	require.Error(t, err)
+	require.IsType(t, ErrNotFound{}, err)
+
+	// checksum not found
+	_, repo, _, err := testutils.EmptyRepo("gun")
+	require.NoError(t, err)
+
+	ts, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
+	tsJSON1, err := json.Marshal(ts)
+	require.NoError(t, err)
+	store.UpdateCurrent(
+		"gun",
+		MetaUpdate{Role: "timestamp", Version: 1, Data: tsJSON1},
+	)
+
+	// table is empty
+	_, err = store.GetVersions(
+		"gun",
+		"timestamp",
+		"173d71993529e47adf58301e58d916085f30ca08797581d7bf200da94595db89",
+		0,
+	)
+	require.Error(t, err)
+	require.IsType(t, ErrNotFound{}, err)
+}
+
+func TestTranslateOldVersionError(t *testing.T) {
+	err := mysql.MySQLError{
+		Number: 1022,
+	}
+	translated := translateOldVersionError(&err)
+	require.IsType(t, &ErrOldVersion{}, translated)
+
+	err = mysql.MySQLError{
+		Number: 1062,
+	}
+	translated = translateOldVersionError(&err)
+	require.IsType(t, &ErrOldVersion{}, translated)
+
+	err = mysql.MySQLError{
+		Number: 1000,
+	}
+	translated = translateOldVersionError(&err)
+	require.IsType(t, &mysql.MySQLError{}, translated)
+
+	sqliteErr := sqlite3.Error{
+		Code:         sqlite3.ErrConstraint,
+		ExtendedCode: sqlite3.ErrConstraintUnique,
+	}
+	translated = translateOldVersionError(&sqliteErr)
+	require.IsType(t, &ErrOldVersion{}, translated)
+
+	sqliteErr = sqlite3.Error{
+		Code: sqlite3.ErrConstraint,
+	}
+	translated = translateOldVersionError(&sqliteErr)
+	require.IsType(t, &sqlite3.Error{}, translated)
+
+	sqliteErr = sqlite3.Error{
+		ExtendedCode: sqlite3.ErrConstraintUnique,
+	}
+	translated = translateOldVersionError(&sqliteErr)
+	require.IsType(t, &sqlite3.Error{}, translated)
 }

--- a/server/storage/interface.go
+++ b/server/storage/interface.go
@@ -34,6 +34,17 @@ type MetaStore interface {
 	// found, it returns storage.ErrNotFound
 	GetChecksum(gun, tufRole, checksum string) (data []byte, err error)
 
+	// GetVersions returns an ordered list of versions, newest to oldest
+	// for the given gun and role. Only the binary data is returned as
+	// all other values stored in the DB for convenience should be
+	// generated/validated from this raw json by the consumer.
+	// Start allows for an offset counting back from the newest version
+	// and numToResturn can limit how many results are returned.
+	// If numToReturn is 0, it means return all results. If less than
+	// numToReturn results are returned, there are no more results to
+	// return.
+	GetVersions(gun, tufRole string, start, numToReturn int) (versions [][]byte, err error)
+
 	// Delete removes all metadata for a given GUN.  It does not return an
 	// error if no metadata exists for the given GUN.
 	Delete(gun string) error

--- a/server/storage/interface.go
+++ b/server/storage/interface.go
@@ -38,12 +38,13 @@ type MetaStore interface {
 	// for the given gun and role. Only the binary data is returned as
 	// all other values stored in the DB for convenience should be
 	// generated/validated from this raw json by the consumer.
-	// Start allows for an offset counting back from the newest version
-	// and numToResturn can limit how many results are returned.
+	// start is a checksum which will be used as a non-inclusive offset
+	// An empty start value means start from (and include) the most recent version
+	// numToResturn can limit how many results are returned.
 	// If numToReturn is 0, it means return all results. If less than
 	// numToReturn results are returned, there are no more results to
 	// return.
-	GetVersions(gun, tufRole string, start, numToReturn int) (versions [][]byte, err error)
+	GetVersions(gun, tufRole, start string, numToReturn int) (versions [][]byte, err error)
 
 	// Delete removes all metadata for a given GUN.  It does not return an
 	// error if no metadata exists for the given GUN.

--- a/server/storage/interface.go
+++ b/server/storage/interface.go
@@ -40,7 +40,7 @@ type MetaStore interface {
 	// generated/validated from this raw json by the consumer.
 	// start is a checksum which will be used as a non-inclusive offset
 	// An empty start value means start from (and include) the most recent version
-	// numToResturn can limit how many results are returned.
+	// numToReturn can limit how many results are returned.
 	// If numToReturn is 0, it means return all results. If less than
 	// numToReturn results are returned, there are no more results to
 	// return.

--- a/server/storage/memory.go
+++ b/server/storage/memory.go
@@ -91,6 +91,16 @@ func (st *MemStorage) GetChecksum(gun, role, checksum string) (data []byte, err 
 	return data, nil
 }
 
+// GetVersions for MemStorage only returns the latest version
+// as it does not store multiple versions
+func (st *MemStorage) GetVersions(gun, role string, start, numToReturn int) ([][]byte, error) {
+	data, err := st.GetCurrent(gun, role)
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{data}, nil
+}
+
 // Delete deletes all the metadata for a given GUN
 func (st *MemStorage) Delete(gun string) error {
 	st.lock.Lock()

--- a/server/storage/memory.go
+++ b/server/storage/memory.go
@@ -106,11 +106,11 @@ func (st *MemStorage) GetVersions(gun, role, start string, numToReturn int) ([][
 	)
 	if start != "" {
 		for st.tufMeta[id][idx].checksum != start {
+			idx++
 			if idx == len(st.tufMeta[id]) {
 				// checksum given but wasn't found
 				return nil, ErrNotFound{}
 			}
-			idx++
 		}
 		idx-- // GetVersions does not include the checksum given
 	} else {

--- a/server/storage/utils.go
+++ b/server/storage/utils.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/require"
+)
+
+// SetUpSQLite creates a sqlite database for testing
+func SetUpSQLite(t *testing.T, dbDir string) (*gorm.DB, *SQLStorage) {
+	dbStore, err := NewSQLStorage("sqlite3", dbDir+"test_db")
+	require.NoError(t, err)
+
+	// Create the DB tables
+	err = CreateTUFTable(dbStore.DB)
+	require.NoError(t, err)
+
+	err = CreateKeyTable(dbStore.DB)
+	require.NoError(t, err)
+
+	// verify that the tables are empty
+	var count int
+	for _, model := range [2]interface{}{&TUFFile{}, &Key{}} {
+		query := dbStore.DB.Model(model).Count(&count)
+		require.NoError(t, query.Error)
+		require.Equal(t, 0, count)
+	}
+	return &dbStore.DB, dbStore
+}


### PR DESCRIPTION
Server code for listing timestamps.

It doesn't implement a rigid pagination but instead relies on clients to keep track of pages themselves, letting them send a non-inclusive starting hash and a number of items to return.