### PR TITLE
ensure filestore GetMeta only returns up to size bytes.  Add max size constant

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,10 +25,6 @@ import (
 	"github.com/docker/notary/tuf/store"
 )
 
-const (
-	maxSize = 5 << 20
-)
-
 func init() {
 	data.SetDefaultExpiryTimes(
 		map[string]int{
@@ -747,7 +743,7 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	tufRepo := tuf.NewRepo(kdb, r.CryptoService)
 
 	logrus.Debugf("Loading trusted collection.")
-	rootJSON, err := r.fileStore.GetMeta("root", 0)
+	rootJSON, err := r.fileStore.GetMeta("root", notary.MaxMetaSize)
 	if err != nil {
 		return err
 	}
@@ -760,7 +756,7 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	if err != nil {
 		return err
 	}
-	targetsJSON, err := r.fileStore.GetMeta("targets", 0)
+	targetsJSON, err := r.fileStore.GetMeta("targets", notary.MaxMetaSize)
 	if err != nil {
 		return err
 	}
@@ -771,7 +767,7 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	}
 	tufRepo.SetTargets("targets", targets)
 
-	snapshotJSON, err := r.fileStore.GetMeta("snapshot", 0)
+	snapshotJSON, err := r.fileStore.GetMeta("snapshot", notary.MaxMetaSize)
 	if err == nil {
 		snapshot := &data.SignedSnapshot{}
 		err = json.Unmarshal(snapshotJSON, snapshot)
@@ -876,7 +872,7 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Cl
 	// try to read root from cache first. We will trust this root
 	// until we detect a problem during update which will cause
 	// us to download a new root and perform a rotation.
-	rootJSON, cachedRootErr := r.fileStore.GetMeta("root", maxSize)
+	rootJSON, cachedRootErr := r.fileStore.GetMeta("root", notary.MaxMetaSize)
 
 	if cachedRootErr == nil {
 		signedRoot, cachedRootErr = r.validateRoot(rootJSON)
@@ -890,7 +886,7 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Cl
 		// checking for initialization of the repo).
 
 		// if remote store successfully set up, try and get root from remote
-		tmpJSON, err := remote.GetMeta("root", maxSize)
+		tmpJSON, err := remote.GetMeta("root", notary.MaxMetaSize)
 		if err != nil {
 			// we didn't have a root in cache and were unable to load one from
 			// the server. Nothing we can do but error.

--- a/client/client.go
+++ b/client/client.go
@@ -743,7 +743,7 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	tufRepo := tuf.NewRepo(kdb, r.CryptoService)
 
 	logrus.Debugf("Loading trusted collection.")
-	rootJSON, err := r.fileStore.GetMeta("root", notary.MaxMetaSize)
+	rootJSON, err := r.fileStore.GetMeta("root", -1)
 	if err != nil {
 		return err
 	}
@@ -756,7 +756,7 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	if err != nil {
 		return err
 	}
-	targetsJSON, err := r.fileStore.GetMeta("targets", notary.MaxMetaSize)
+	targetsJSON, err := r.fileStore.GetMeta("targets", -1)
 	if err != nil {
 		return err
 	}
@@ -767,7 +767,7 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	}
 	tufRepo.SetTargets("targets", targets)
 
-	snapshotJSON, err := r.fileStore.GetMeta("snapshot", notary.MaxMetaSize)
+	snapshotJSON, err := r.fileStore.GetMeta("snapshot", -1)
 	if err == nil {
 		snapshot := &data.SignedSnapshot{}
 		err = json.Unmarshal(snapshotJSON, snapshot)
@@ -872,7 +872,7 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Cl
 	// try to read root from cache first. We will trust this root
 	// until we detect a problem during update which will cause
 	// us to download a new root and perform a rotation.
-	rootJSON, cachedRootErr := r.fileStore.GetMeta("root", notary.MaxMetaSize)
+	rootJSON, cachedRootErr := r.fileStore.GetMeta("root", -1)
 
 	if cachedRootErr == nil {
 		signedRoot, cachedRootErr = r.validateRoot(rootJSON)
@@ -886,7 +886,8 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufclient.Cl
 		// checking for initialization of the repo).
 
 		// if remote store successfully set up, try and get root from remote
-		tmpJSON, err := remote.GetMeta("root", notary.MaxMetaSize)
+		// We don't have any local data to determine the size of root, so try the maximum (though it is restricted at 100MB)
+		tmpJSON, err := remote.GetMeta("root", -1)
 		if err != nil {
 			// we didn't have a root in cache and were unable to load one from
 			// the server. Nothing we can do but error.

--- a/const.go
+++ b/const.go
@@ -2,9 +2,10 @@ package notary
 
 // application wide constants
 const (
-	// MaxMetaSize is the maximum size of metadata - 5MiB.
-	// Should be used only for testing, downloading new timestamps, or downloading roles when we have no local metadata
-	MaxMetaSize int64 = 5 << 20
+	// MaxDownloadSize is the maximum size we'll download for metadata if no limit is given
+	MaxDownloadSize int64 = 100 << 20
+	// MaxTimestampSize is the maximum size of timestamp metadata - 1MiB.
+	MaxTimestampSize int64 = 1 << 20
 	// MinRSABitSize is the minimum bit size for RSA keys allowed in notary
 	MinRSABitSize = 2048
 	// MinThreshold requires a minimum of one threshold for roles; currently we do not support a higher threshold

--- a/const.go
+++ b/const.go
@@ -2,7 +2,8 @@ package notary
 
 // application wide constants
 const (
-	// MaxMetaSize is the maximum size of metadata - 5MiB
+	// MaxMetaSize is the maximum size of metadata - 5MiB.
+	// Should be used only for testing, downloading new timestamps, or downloading roles when we have no local metadata
 	MaxMetaSize int64 = 5 << 20
 	// MinRSABitSize is the minimum bit size for RSA keys allowed in notary
 	MinRSABitSize = 2048

--- a/const.go
+++ b/const.go
@@ -2,6 +2,8 @@ package notary
 
 // application wide constants
 const (
+	// MaxMetaSize is the maximum size of metadata - 5MiB
+	MaxMetaSize int64 = 5 << 20
 	// MinRSABitSize is the minimum bit size for RSA keys allowed in notary
 	MinRSABitSize = 2048
 	// MinThreshold requires a minimum of one threshold for roles; currently we do not support a higher threshold

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/notary"
 	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
@@ -18,8 +19,6 @@ import (
 	"github.com/docker/notary/tuf/store"
 	"github.com/docker/notary/tuf/utils"
 )
-
-const maxSize int64 = 5 << 20
 
 // Client is a usability wrapper around a raw TUF repo
 type Client struct {
@@ -131,7 +130,7 @@ func (c Client) checkRoot() error {
 func (c *Client) downloadRoot() error {
 	logrus.Debug("Downloading Root...")
 	role := data.CanonicalRootRole
-	size := maxSize
+	size := notary.MaxMetaSize
 	var expectedSha256 []byte
 	if c.local.Snapshot != nil {
 		size = c.local.Snapshot.Signed.Meta[role].Length
@@ -252,7 +251,7 @@ func (c *Client) downloadTimestamp() error {
 		old         *data.Signed
 		version     = 0
 	)
-	cachedTS, err := c.cache.GetMeta(role, maxSize)
+	cachedTS, err := c.cache.GetMeta(role, notary.MaxMetaSize)
 	if err == nil {
 		cached := &data.Signed{}
 		err := json.Unmarshal(cachedTS, cached)
@@ -266,7 +265,7 @@ func (c *Client) downloadTimestamp() error {
 	}
 	// unlike root, targets and snapshot, always try and download timestamps
 	// from remote, only using the cache one if we couldn't reach remote.
-	raw, s, err := c.downloadSigned(role, maxSize, nil)
+	raw, s, err := c.downloadSigned(role, notary.MaxMetaSize, nil)
 	if err != nil || len(raw) == 0 {
 		if old == nil {
 			if err == nil {

--- a/tuf/store/filestore.go
+++ b/tuf/store/filestore.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"github.com/docker/notary"
 	"io/ioutil"
 	"os"
 	"path"
@@ -45,6 +46,7 @@ func (f *FilesystemStore) getPath(name string) string {
 }
 
 // GetMeta returns the meta for the given name (a role) up to size bytes
+// If size is -1, this corresponds to "infinite," but we cut off at 100MB
 func (f *FilesystemStore) GetMeta(name string, size int64) ([]byte, error) {
 	meta, err := ioutil.ReadFile(f.getPath(name))
 	if err != nil {
@@ -52,6 +54,9 @@ func (f *FilesystemStore) GetMeta(name string, size int64) ([]byte, error) {
 			err = ErrMetaNotFound{Resource: name}
 		}
 		return nil, err
+	}
+	if size == -1 {
+		size = notary.MaxDownloadSize
 	}
 	// Only return up to size bytes
 	if int64(len(meta)) < size {

--- a/tuf/store/filestore.go
+++ b/tuf/store/filestore.go
@@ -44,7 +44,7 @@ func (f *FilesystemStore) getPath(name string) string {
 	return filepath.Join(f.metaDir, fileName)
 }
 
-// GetMeta returns the meta for the given name (a role)
+// GetMeta returns the meta for the given name (a role) up to size bytes
 func (f *FilesystemStore) GetMeta(name string, size int64) ([]byte, error) {
 	meta, err := ioutil.ReadFile(f.getPath(name))
 	if err != nil {
@@ -53,7 +53,11 @@ func (f *FilesystemStore) GetMeta(name string, size int64) ([]byte, error) {
 		}
 		return nil, err
 	}
-	return meta, nil
+	// Only return up to size bytes
+	if int64(len(meta)) < size {
+		return meta, nil
+	}
+	return meta[:size], nil
 }
 
 // SetMultiMeta sets the metadata for multiple roles in one operation

--- a/tuf/store/filestore_test.go
+++ b/tuf/store/filestore_test.go
@@ -89,6 +89,12 @@ func TestGetMeta(t *testing.T) {
 	assert.Nil(t, err, "GetMeta returned unexpected error: %v", err)
 
 	assert.Equal(t, testContent, content, "Content read from file was corrupted.")
+
+	// Check that we return only up to size bytes
+	content, err = s.GetMeta("testMeta", 4)
+	assert.Nil(t, err, "GetMeta returned unexpected error: %v", err)
+
+	assert.Equal(t, []byte("test"), content, "Content read from file was corrupted.")
 }
 
 func TestGetSetMetadata(t *testing.T) {

--- a/tuf/store/filestore_test.go
+++ b/tuf/store/filestore_test.go
@@ -90,6 +90,12 @@ func TestGetMeta(t *testing.T) {
 
 	assert.Equal(t, testContent, content, "Content read from file was corrupted.")
 
+	// Check that -1 size reads everything
+	content, err = s.GetMeta("testMeta", int64(-1))
+	assert.Nil(t, err, "GetMeta returned unexpected error: %v", err)
+
+	assert.Equal(t, testContent, content, "Content read from file was corrupted.")
+
 	// Check that we return only up to size bytes
 	content, err = s.GetMeta("testMeta", 4)
 	assert.Nil(t, err, "GetMeta returned unexpected error: %v", err)

--- a/tuf/store/memorystore.go
+++ b/tuf/store/memorystore.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/docker/notary"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/utils"
 )
@@ -31,9 +32,13 @@ type memoryStore struct {
 	keys  map[string][]data.PrivateKey
 }
 
+// If size is -1, this corresponds to "infinite," but we cut off at 100MB
 func (m *memoryStore) GetMeta(name string, size int64) ([]byte, error) {
 	d, ok := m.meta[name]
 	if ok {
+		if size == -1 {
+			size = notary.MaxDownloadSize
+		}
 		if int64(len(d)) < size {
 			return d, nil
 		}

--- a/tuf/store/memorystore_test.go
+++ b/tuf/store/memorystore_test.go
@@ -21,6 +21,10 @@ func TestMemoryStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, metaContent, meta)
 
+	meta, err = s.GetMeta("exists", -1)
+	require.NoError(t, err)
+	require.Equal(t, metaContent, meta)
+
 	err = s.RemoveAll()
 	require.NoError(t, err)
 

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -6,16 +6,13 @@ import (
 	"time"
 
 	"github.com/docker/go/canonical/json"
+	"github.com/docker/notary"
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
-)
-
-const (
-	maxSize = 5 << 20
 )
 
 // ErrNoKeyForRole returns an error when the cryptoservice provided to
@@ -87,7 +84,7 @@ func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
 
 // gets a Signed from the metadata store
 func signedFromStore(cache store.MetadataStore, role string) (*data.Signed, error) {
-	b, err := cache.GetMeta(role, maxSize)
+	b, err := cache.GetMeta(role, notary.MaxMetaSize)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +117,7 @@ func NewMetadataSwizzler(gun string, initialMetadata map[string][]byte,
 
 // SetInvalidJSON corrupts metadata into something that is no longer valid JSON
 func (m *MetadataSwizzler) SetInvalidJSON(role string) error {
-	metaBytes, err := m.MetadataCache.GetMeta(role, maxSize)
+	metaBytes, err := m.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 	if err != nil {
 		return err
 	}
@@ -327,7 +324,7 @@ func (m *MetadataSwizzler) SetThreshold(role string, newThreshold int) error {
 		roleSpecifier = path.Dir(role)
 	}
 
-	b, err := m.MetadataCache.GetMeta(roleSpecifier, maxSize)
+	b, err := m.MetadataCache.GetMeta(roleSpecifier, notary.MaxMetaSize)
 	if err != nil {
 		return err
 	}
@@ -377,7 +374,7 @@ func (m *MetadataSwizzler) ChangeRootKey() error {
 		return err
 	}
 
-	b, err := m.MetadataCache.GetMeta(data.CanonicalRootRole, maxSize)
+	b, err := m.MetadataCache.GetMeta(data.CanonicalRootRole, notary.MaxMetaSize)
 	if err != nil {
 		return err
 	}
@@ -410,7 +407,7 @@ func (m *MetadataSwizzler) UpdateSnapshotHashes(roles ...string) error {
 		snapshotSigned *data.Signed
 		err            error
 	)
-	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize); err != nil {
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize); err != nil {
 		return err
 	}
 
@@ -426,7 +423,7 @@ func (m *MetadataSwizzler) UpdateSnapshotHashes(roles ...string) error {
 
 	for _, role := range roles {
 		if role != data.CanonicalSnapshotRole && role != data.CanonicalTimestampRole {
-			if metaBytes, err = m.MetadataCache.GetMeta(role, maxSize); err != nil {
+			if metaBytes, err = m.MetadataCache.GetMeta(role, notary.MaxMetaSize); err != nil {
 				return err
 			}
 
@@ -458,7 +455,7 @@ func (m *MetadataSwizzler) UpdateTimestampHash() error {
 		timestampSigned *data.Signed
 		err             error
 	)
-	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalTimestampRole, maxSize); err != nil {
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalTimestampRole, notary.MaxMetaSize); err != nil {
 		return err
 	}
 	// we can't just create a new timestamp, because then the expiry would be
@@ -467,7 +464,7 @@ func (m *MetadataSwizzler) UpdateTimestampHash() error {
 		return err
 	}
 
-	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize); err != nil {
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize); err != nil {
 		return err
 	}
 

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/docker/go/canonical/json"
-	"github.com/docker/notary"
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
@@ -84,7 +83,7 @@ func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
 
 // gets a Signed from the metadata store
 func signedFromStore(cache store.MetadataStore, role string) (*data.Signed, error) {
-	b, err := cache.GetMeta(role, notary.MaxMetaSize)
+	b, err := cache.GetMeta(role, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +116,7 @@ func NewMetadataSwizzler(gun string, initialMetadata map[string][]byte,
 
 // SetInvalidJSON corrupts metadata into something that is no longer valid JSON
 func (m *MetadataSwizzler) SetInvalidJSON(role string) error {
-	metaBytes, err := m.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+	metaBytes, err := m.MetadataCache.GetMeta(role, -1)
 	if err != nil {
 		return err
 	}
@@ -324,7 +323,7 @@ func (m *MetadataSwizzler) SetThreshold(role string, newThreshold int) error {
 		roleSpecifier = path.Dir(role)
 	}
 
-	b, err := m.MetadataCache.GetMeta(roleSpecifier, notary.MaxMetaSize)
+	b, err := m.MetadataCache.GetMeta(roleSpecifier, -1)
 	if err != nil {
 		return err
 	}
@@ -374,7 +373,7 @@ func (m *MetadataSwizzler) ChangeRootKey() error {
 		return err
 	}
 
-	b, err := m.MetadataCache.GetMeta(data.CanonicalRootRole, notary.MaxMetaSize)
+	b, err := m.MetadataCache.GetMeta(data.CanonicalRootRole, -1)
 	if err != nil {
 		return err
 	}
@@ -407,7 +406,7 @@ func (m *MetadataSwizzler) UpdateSnapshotHashes(roles ...string) error {
 		snapshotSigned *data.Signed
 		err            error
 	)
-	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize); err != nil {
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, -1); err != nil {
 		return err
 	}
 
@@ -423,7 +422,7 @@ func (m *MetadataSwizzler) UpdateSnapshotHashes(roles ...string) error {
 
 	for _, role := range roles {
 		if role != data.CanonicalSnapshotRole && role != data.CanonicalTimestampRole {
-			if metaBytes, err = m.MetadataCache.GetMeta(role, notary.MaxMetaSize); err != nil {
+			if metaBytes, err = m.MetadataCache.GetMeta(role, -1); err != nil {
 				return err
 			}
 
@@ -455,7 +454,7 @@ func (m *MetadataSwizzler) UpdateTimestampHash() error {
 		timestampSigned *data.Signed
 		err             error
 	)
-	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalTimestampRole, notary.MaxMetaSize); err != nil {
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalTimestampRole, -1); err != nil {
 		return err
 	}
 	// we can't just create a new timestamp, because then the expiry would be
@@ -464,7 +463,7 @@ func (m *MetadataSwizzler) UpdateTimestampHash() error {
 		return err
 	}
 
-	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize); err != nil {
+	if metaBytes, err = m.MetadataCache.GetMeta(data.CanonicalSnapshotRole, -1); err != nil {
 		return err
 	}
 

--- a/tuf/testutils/swizzler_test.go
+++ b/tuf/testutils/swizzler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/notary"
 	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
@@ -81,7 +82,7 @@ func TestSwizzlerSetInvalidJSON(t *testing.T) {
 	f.SetInvalidJSON(data.CanonicalSnapshotRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != data.CanonicalSnapshotRole {
@@ -103,7 +104,7 @@ func TestSwizzlerSetInvalidSigned(t *testing.T) {
 	f.SetInvalidSigned(data.CanonicalTargetsRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTargetsRole {
@@ -127,7 +128,7 @@ func TestSwizzlerSetInvalidSignedMeta(t *testing.T) {
 	f.SetInvalidSignedMeta(data.CanonicalTargetsRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTargetsRole {
@@ -151,7 +152,7 @@ func TestSwizzlerSetInvalidMetadataType(t *testing.T) {
 	f.SetInvalidMetadataType(data.CanonicalTargetsRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTargetsRole {
@@ -174,7 +175,7 @@ func TestSwizzlerInvalidateMetadataSignatures(t *testing.T) {
 	f.InvalidateMetadataSignatures(data.CanonicalRootRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != data.CanonicalRootRole {
@@ -205,7 +206,7 @@ func TestSwizzlerRemoveMetadata(t *testing.T) {
 	f.RemoveMetadata("targets/a")
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		if role != "targets/a" {
 			require.NoError(t, err)
 			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
@@ -223,7 +224,7 @@ func TestSwizzlerSignMetadataWithInvalidKey(t *testing.T) {
 	f.SignMetadataWithInvalidKey(data.CanonicalTimestampRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTimestampRole {
@@ -250,7 +251,7 @@ func TestSwizzlerOffsetMetadataVersion(t *testing.T) {
 	f.OffsetMetadataVersion("targets/a", -2)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != "targets/a" {
@@ -273,7 +274,7 @@ func TestSwizzlerExpireMetadata(t *testing.T) {
 	f.ExpireMetadata(data.CanonicalRootRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		if role != data.CanonicalRootRole {
@@ -297,7 +298,7 @@ func TestSwizzlerSetThresholdBaseRole(t *testing.T) {
 	f.SetThreshold(data.CanonicalTargetsRole, 3)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		// the threshold for base roles is set in root
@@ -325,7 +326,7 @@ func TestSwizzlerSetThresholdDelegatedRole(t *testing.T) {
 	f.SetThreshold("targets/a/b", 3)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		// the threshold for "targets/a/b" is in "targets/a"
@@ -357,7 +358,7 @@ func TestSwizzlerChangeRootKey(t *testing.T) {
 
 	for _, role := range roles {
 		origMeta := origMeta[role]
-		newMeta, err := f.MetadataCache.GetMeta(role, maxSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
 		require.NoError(t, err)
 
 		// the threshold for base roles is set in root
@@ -400,7 +401,7 @@ func TestSwizzlerUpdateSnapshotHashesSpecifiedRoles(t *testing.T) {
 	// nothing has changed, signed data should be the same (signatures might
 	// change because signatures may have random elements
 	f.UpdateSnapshotHashes(data.CanonicalTargetsRole)
-	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
 
 	origSigned, newSigned := &data.Signed{}, &data.Signed{}
 	require.NoError(t, json.Unmarshal(origMeta[data.CanonicalSnapshotRole], origSigned))
@@ -414,7 +415,7 @@ func TestSwizzlerUpdateSnapshotHashesSpecifiedRoles(t *testing.T) {
 	// update the snapshot with just 1 role
 	f.UpdateSnapshotHashes(data.CanonicalTargetsRole)
 
-	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
 	require.NoError(t, err)
 	require.False(t, bytes.Equal(origMeta[data.CanonicalSnapshotRole], newMeta))
 
@@ -444,7 +445,7 @@ func TestSwizzlerUpdateSnapshotHashesNoSpecifiedRoles(t *testing.T) {
 	// nothing has changed, signed data should be the same (signatures might
 	// change because signatures may have random elements
 	f.UpdateSnapshotHashes()
-	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
 	require.NoError(t, err)
 
 	origSigned, newSigned := &data.Signed{}, &data.Signed{}
@@ -459,7 +460,7 @@ func TestSwizzlerUpdateSnapshotHashesNoSpecifiedRoles(t *testing.T) {
 	// update the snapshot with just no specified roles
 	f.UpdateSnapshotHashes()
 
-	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, maxSize)
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
 	require.NoError(t, err)
 	require.False(t, bytes.Equal(origMeta[data.CanonicalSnapshotRole], newMeta))
 
@@ -490,7 +491,7 @@ func TestSwizzlerUpdateTimestamp(t *testing.T) {
 	// nothing has changed, signed data should be the same (signatures might
 	// change because signatures may have random elements
 	f.UpdateTimestampHash()
-	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalTimestampRole, maxSize)
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalTimestampRole, notary.MaxMetaSize)
 	require.NoError(t, err)
 
 	origSigned, newSigned := &data.Signed{}, &data.Signed{}
@@ -503,7 +504,7 @@ func TestSwizzlerUpdateTimestamp(t *testing.T) {
 	// update the timestamp
 	f.UpdateTimestampHash()
 
-	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalTimestampRole, maxSize)
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalTimestampRole, notary.MaxMetaSize)
 	require.NoError(t, err)
 	require.False(t, bytes.Equal(origMeta[data.CanonicalTimestampRole], newMeta))
 

--- a/tuf/testutils/swizzler_test.go
+++ b/tuf/testutils/swizzler_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/notary"
 	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
@@ -82,7 +81,7 @@ func TestSwizzlerSetInvalidJSON(t *testing.T) {
 	f.SetInvalidJSON(data.CanonicalSnapshotRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != data.CanonicalSnapshotRole {
@@ -104,7 +103,7 @@ func TestSwizzlerSetInvalidSigned(t *testing.T) {
 	f.SetInvalidSigned(data.CanonicalTargetsRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTargetsRole {
@@ -128,7 +127,7 @@ func TestSwizzlerSetInvalidSignedMeta(t *testing.T) {
 	f.SetInvalidSignedMeta(data.CanonicalTargetsRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTargetsRole {
@@ -152,7 +151,7 @@ func TestSwizzlerSetInvalidMetadataType(t *testing.T) {
 	f.SetInvalidMetadataType(data.CanonicalTargetsRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTargetsRole {
@@ -175,7 +174,7 @@ func TestSwizzlerInvalidateMetadataSignatures(t *testing.T) {
 	f.InvalidateMetadataSignatures(data.CanonicalRootRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != data.CanonicalRootRole {
@@ -206,7 +205,7 @@ func TestSwizzlerRemoveMetadata(t *testing.T) {
 	f.RemoveMetadata("targets/a")
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		if role != "targets/a" {
 			require.NoError(t, err)
 			require.True(t, bytes.Equal(metaBytes, newMeta), "bytes have changed for role %s", role)
@@ -224,7 +223,7 @@ func TestSwizzlerSignMetadataWithInvalidKey(t *testing.T) {
 	f.SignMetadataWithInvalidKey(data.CanonicalTimestampRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != data.CanonicalTimestampRole {
@@ -251,7 +250,7 @@ func TestSwizzlerOffsetMetadataVersion(t *testing.T) {
 	f.OffsetMetadataVersion("targets/a", -2)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != "targets/a" {
@@ -274,7 +273,7 @@ func TestSwizzlerExpireMetadata(t *testing.T) {
 	f.ExpireMetadata(data.CanonicalRootRole)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		if role != data.CanonicalRootRole {
@@ -298,7 +297,7 @@ func TestSwizzlerSetThresholdBaseRole(t *testing.T) {
 	f.SetThreshold(data.CanonicalTargetsRole, 3)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		// the threshold for base roles is set in root
@@ -326,7 +325,7 @@ func TestSwizzlerSetThresholdDelegatedRole(t *testing.T) {
 	f.SetThreshold("targets/a/b", 3)
 
 	for role, metaBytes := range origMeta {
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		// the threshold for "targets/a/b" is in "targets/a"
@@ -358,7 +357,7 @@ func TestSwizzlerChangeRootKey(t *testing.T) {
 
 	for _, role := range roles {
 		origMeta := origMeta[role]
-		newMeta, err := f.MetadataCache.GetMeta(role, notary.MaxMetaSize)
+		newMeta, err := f.MetadataCache.GetMeta(role, -1)
 		require.NoError(t, err)
 
 		// the threshold for base roles is set in root
@@ -401,7 +400,7 @@ func TestSwizzlerUpdateSnapshotHashesSpecifiedRoles(t *testing.T) {
 	// nothing has changed, signed data should be the same (signatures might
 	// change because signatures may have random elements
 	f.UpdateSnapshotHashes(data.CanonicalTargetsRole)
-	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, -1)
 
 	origSigned, newSigned := &data.Signed{}, &data.Signed{}
 	require.NoError(t, json.Unmarshal(origMeta[data.CanonicalSnapshotRole], origSigned))
@@ -415,7 +414,7 @@ func TestSwizzlerUpdateSnapshotHashesSpecifiedRoles(t *testing.T) {
 	// update the snapshot with just 1 role
 	f.UpdateSnapshotHashes(data.CanonicalTargetsRole)
 
-	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, -1)
 	require.NoError(t, err)
 	require.False(t, bytes.Equal(origMeta[data.CanonicalSnapshotRole], newMeta))
 
@@ -445,7 +444,7 @@ func TestSwizzlerUpdateSnapshotHashesNoSpecifiedRoles(t *testing.T) {
 	// nothing has changed, signed data should be the same (signatures might
 	// change because signatures may have random elements
 	f.UpdateSnapshotHashes()
-	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, -1)
 	require.NoError(t, err)
 
 	origSigned, newSigned := &data.Signed{}, &data.Signed{}
@@ -460,7 +459,7 @@ func TestSwizzlerUpdateSnapshotHashesNoSpecifiedRoles(t *testing.T) {
 	// update the snapshot with just no specified roles
 	f.UpdateSnapshotHashes()
 
-	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, notary.MaxMetaSize)
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalSnapshotRole, -1)
 	require.NoError(t, err)
 	require.False(t, bytes.Equal(origMeta[data.CanonicalSnapshotRole], newMeta))
 
@@ -491,7 +490,7 @@ func TestSwizzlerUpdateTimestamp(t *testing.T) {
 	// nothing has changed, signed data should be the same (signatures might
 	// change because signatures may have random elements
 	f.UpdateTimestampHash()
-	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalTimestampRole, notary.MaxMetaSize)
+	newMeta, err := f.MetadataCache.GetMeta(data.CanonicalTimestampRole, -1)
 	require.NoError(t, err)
 
 	origSigned, newSigned := &data.Signed{}, &data.Signed{}
@@ -504,7 +503,7 @@ func TestSwizzlerUpdateTimestamp(t *testing.T) {
 	// update the timestamp
 	f.UpdateTimestampHash()
 
-	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalTimestampRole, notary.MaxMetaSize)
+	newMeta, err = f.MetadataCache.GetMeta(data.CanonicalTimestampRole, -1)
 	require.NoError(t, err)
 	require.False(t, bytes.Equal(origMeta[data.CanonicalTimestampRole], newMeta))
 


### PR DESCRIPTION
store/filestore.go's `GetMeta` now considers the `size` argument and will only return up to `size` bytes.  If `size` is -1, we get "all" data for the resource but stop at 100MB under the hood -- this is consistent across the memory, file, and remote stores.  I also refactored `MaxTimestampSize` to const.go for convenience.

This follows up on discussion from https://github.com/docker/notary/pull/494/files#r50593036

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>