### PR TITLE
Don't run all the tests with yubikey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ _space := $(empty) $(empty)
 COVERDIR=.cover
 COVERPROFILE?=$(COVERDIR)/cover.out
 COVERMODE=count
-PKGS = $(shell go list ./... | tr '\n' ' ')
+PKGS ?= $(shell go list ./... | tr '\n' ' ')
 
 GO_VERSION = $(shell go version | awk '{print $$3}')
 
@@ -124,7 +124,7 @@ endef
 gen-cover: go_version
 	@mkdir -p "$(COVERDIR)"
 	$(foreach PKG,$(PKGS),$(call gocover,$(PKG)))
-	rm "$(COVERDIR)"/*testutils*.coverage.txt
+	rm -f "$(COVERDIR)"/*testutils*.coverage.txt
 
 # Generates the cover binaries and runs them all in serial, so this can be used
 # run all tests with a yubikey without any problems
@@ -139,6 +139,9 @@ ci: OPTS = -tags "${NOTARY_BUILDTAGS}" -race -coverpkg "$(shell ./coverpkg.sh $(
     GO_EXC := godep go
 # Codecov knows how to merge multiple coverage files, so covmerge is not needed
 ci: gen-cover
+
+yubikey-tests: override PKGS = github.com/docker/notary/cmd/notary github.com/docker/notary/trustmanager/yubikey
+yubikey-tests: ci
 
 covmerge:
 	@gocovmerge $(shell ls -1 $(COVERDIR)/* | tr "\n" " ") > $(COVERPROFILE)

--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,6 @@ machine:
     CIRCLE_PAIN: "mode: set"
   # Put the coverage profile somewhere codecov's script can find it
     COVERPROFILE: coverage.out
-  # Set the pull request number so codecov can figure it out
-    PULL_REQUEST: ${CI_PULL_REQUEST##*/}
 
   hosts:
   # Not used yet


### PR DESCRIPTION
Since we have a single builder, and they're slow, we don't want this to be a bottleneck.  If we can figure out how to have multiple VMs, one for each yubikey in the builder, then we can probably start running full tests again.