### PR TITLE
Use seperate databases for notary server and signer

### DIFF
--- a/docs/notary-mysql.md
+++ b/docs/notary-mysql.md
@@ -1,0 +1,23 @@
+<!--[metadata]>
++++
+title = "Notary MySQL"
+description = "Description of the Notary MySQL"
+keywords = ["docker, notary, notary-mysql"]
+[menu.main]
+parent="mn_notary"
++++
+<![end-metadata]-->
+
+# Notary MySQL
+
+The Notary MySQL is one of the backends for [Notary Server](notary-server.md) and
+[Notary Signer](notary-signer.md).
+
+### Recommendation
+For security, especially in production deployments, one should create users
+with restricted permissions and separate databases for the `server` and
+`signer` since the `signer` only needs the `private_keys` table, and the
+`server` only needs `timestamp_keys` and `tuf_files`.
+
+We use such a setup in our compose file to provide people with more accurate
+guidance in deploying their own instances.

--- a/fixtures/server-config.json
+++ b/fixtures/server-config.json
@@ -18,6 +18,6 @@
 	},
 	"storage": {
 		"backend": "mysql",
-		"db_url": "root@tcp(notarymysql:3306)/notary?parseTime=True"
+		"db_url": "server@tcp(notarymysql:3306)/notaryserver?parseTime=True"
 	}
 }

--- a/fixtures/signer-config.json
+++ b/fixtures/signer-config.json
@@ -11,6 +11,6 @@
 	},
 	"storage": {
 		"backend": "mysql",
-		"db_url": "root@tcp(notarymysql:3306)/notary?parseTime=True"
+		"db_url": "signer@tcp(notarymysql:3306)/notarysigner?parseTime=True"
 	}
 }

--- a/notarymysql/Dockerfile
+++ b/notarymysql/Dockerfile
@@ -7,8 +7,9 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 ADD start /start
-ADD initial.sql /initial.sql
-ADD migrate.sql /migrate.sql
+ADD initial-notaryserver.sql /initial-notaryserver.sql
+ADD initial-notarysigner.sql /initial-notarysigner.sql
+ADD migrate-notaryserver.sql /migrate-notaryserver.sql
 RUN chmod 755 /start
 
 EXPOSE 3306

--- a/notarymysql/initial-notaryserver.sql
+++ b/notarymysql/initial-notaryserver.sql
@@ -18,21 +18,3 @@ CREATE TABLE `timestamp_keys` (
 	`public` blob NOT NULL,
 	PRIMARY KEY (`gun`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-DROP TABLE IF EXISTS `private_keys`;
-CREATE TABLE `private_keys` (
-	`id` int(11) NOT NULL AUTO_INCREMENT,
-	`created_at` timestamp NULL DEFAULT NULL,
-	`updated_at` timestamp NULL DEFAULT NULL,
-	`deleted_at` timestamp NULL DEFAULT NULL,
-	`key_id`  varchar(255) NOT NULL,
-	`encryption_alg`  varchar(255) NOT NULL,
-	`keywrap_alg`  varchar(255) NOT NULL,
-	`algorithm`  varchar(50) NOT NULL,
-	`passphrase_alias`  varchar(50) NOT NULL,
-	`public`  blob NOT NULL,
-	`private`  blob NOT NULL,
-	PRIMARY KEY (`id`),
-	UNIQUE (`key_id`),
-	UNIQUE (`key_id`,`algorithm`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/notarymysql/initial-notarysigner.sql
+++ b/notarymysql/initial-notarysigner.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS `private_keys`;
+CREATE TABLE `private_keys` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`created_at` timestamp NULL DEFAULT NULL,
+	`updated_at` timestamp NULL DEFAULT NULL,
+	`deleted_at` timestamp NULL DEFAULT NULL,
+	`key_id`  varchar(255) NOT NULL,
+	`encryption_alg`  varchar(255) NOT NULL,
+	`keywrap_alg`  varchar(255) NOT NULL,
+	`algorithm`  varchar(50) NOT NULL,
+	`passphrase_alias`  varchar(50) NOT NULL,
+	`public`  blob NOT NULL,
+	`private`  blob NOT NULL,
+	PRIMARY KEY (`id`),
+	UNIQUE (`key_id`),
+	UNIQUE (`key_id`,`algorithm`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/notarymysql/migrate-notaryserver.sql
+++ b/notarymysql/migrate-notaryserver.sql
@@ -1,4 +1,4 @@
--- This migrates initial.sql to tables that are needed for GORM
+-- This migrates initial-notaryserver.sql to tables that are needed for GORM
 
 ALTER TABLE `tuf_files`
 ADD COLUMN `created_at` timestamp NULL DEFAULT NULL AFTER `id`,

--- a/notarymysql/start
+++ b/notarymysql/start
@@ -1,11 +1,24 @@
 #!/bin/bash
 set -e
 
-DB_NAME='notary'
+# Although the Notary-Server and Notary-Signer could use the same
+# database, it's better to seperate that for security.
+DB_NAME_SERVER='notaryserver'
+DB_NAME_SIGNER='notarysigner'
+DB_NAME=($DB_NAME_SERVER,$DB_NAME_SIGNER)
+
 DB_TABLE_FILES='tuf_files'
 DB_TABLE_KEYS='timestamp_keys'
 DB_USER='root'
 DB_PASS=''
+
+# Default username and password for Notary-Server
+DB_USER_SERVER='server'
+DB_PASS_SERVER=''
+
+# Default username and password for Notary-Signer
+DB_USER_SIGNER='signer'
+DB_PASS_SIGNER=''
 
 DB_REMOTE_ROOT_NAME=''
 DB_REMOTE_ROOT_PASS=''
@@ -101,10 +114,15 @@ if [ -n "${DB_USER}" -o -n "${DB_NAME}" ]; then
         echo "Creating database \"$db\"..."
         mysql --defaults-file=/etc/mysql/debian.cnf \
           -e "CREATE DATABASE IF NOT EXISTS \`$db\` DEFAULT CHARACTER SET \`utf8\` COLLATE \`utf8_unicode_ci\`;"
-          if [ -n "${DB_USER}" ]; then
-            echo "Granting access to database \"$db\" for user \"${DB_USER}\"..."
+          if [ -n "${DB_USER_SERVER}" -a $db = $DB_NAME_SERVER ]; then
+            echo "Granting access to database \"$db\" for user \"${DB_USER_SERVER}\"..."
             mysql --defaults-file=/etc/mysql/debian.cnf \
-            -e "GRANT ALL PRIVILEGES ON \`$db\`.* TO '${DB_USER}' IDENTIFIED BY '${DB_PASS}';"
+            -e "GRANT ALL PRIVILEGES ON \`$db\`.* TO '${DB_USER_SERVER}' IDENTIFIED BY '${DB_PASS_SERVER}';"
+          fi
+          if [ -n "${DB_USER_SIGNER}" -a $db = $DB_NAME_SIGNER ]; then
+            echo "Granting access to database \"$db\" for user \"${DB_USER_SIGNER}\"..."
+            mysql --defaults-file=/etc/mysql/debian.cnf \
+            -e "GRANT ALL PRIVILEGES ON \`$db\`.* TO '${DB_USER_SIGNER}' IDENTIFIED BY '${DB_PASS_SIGNER}';"
           fi
           # Create our Database:
           mysql -uroot $db < ./initial.sql

--- a/notarymysql/start
+++ b/notarymysql/start
@@ -5,11 +5,11 @@ set -e
 # the early days which we would not use it any longer.
 DB_NAME_OLD='notary'
 
-# Message which will be displayed when the database 'notary' exsit.
+# Message which will be displayed when the database 'notary' exsits.
 DB_WARNING="
 =============== WARNING =================
 # The schema has changed.               #
-# People should migrate those tables in #
+# Make sure you migrate the tables in   #
 # 'notary'                              #
 # to                                    #
 # 'notaryserver' and 'notarysigner'     #
@@ -17,7 +17,7 @@ DB_WARNING="
 "
 
 # Although the Notary-Server and Notary-Signer could use the same
-# database, it's better to seperate that for security.
+# database, it's better to separate that for security.
 DB_NAME_SERVER='notaryserver'
 DB_NAME_SIGNER='notarysigner'
 DB_NAME=($DB_NAME_SERVER,$DB_NAME_SIGNER)
@@ -121,8 +121,8 @@ if [ -n "${DB_USER}" -o -n "${DB_NAME}" ]; then
     sleep 1
   done
 
-  # To check whether the old database is exist or not and warning people to
-  # manually migrate those tables.
+  # Check whether the old database exists and warn users to
+  # manually migrate those tables if so.
   if [ -n "${DB_NAME_OLD}" ]; then
       if mysql --defaults-file=/etc/mysql/debian.cnf -e "USE $DB_NAME_OLD;" 2>/dev/null; then
         echo "$DB_WARNING"

--- a/notarymysql/start
+++ b/notarymysql/start
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -e
 
+# This database is used by both of Notary-Server and Notary-Signer
+# the early days which we would not use it any longer.
+DB_NAME_OLD='notary'
+
+# Message which will be displayed when the database 'notary' exsit.
+DB_WARNING="
+=============== WARNING =================
+# The schema has changed.               #
+# People should migrate those tables in #
+# 'notary'                              #
+# to                                    #
+# 'notaryserver' and 'notarysigner'     #
+=========================================
+"
+
 # Although the Notary-Server and Notary-Signer could use the same
 # database, it's better to seperate that for security.
 DB_NAME_SERVER='notaryserver'
@@ -105,6 +120,14 @@ if [ -n "${DB_USER}" -o -n "${DB_NAME}" ]; then
     fi
     sleep 1
   done
+
+  # To check whether the old database is exist or not and warning people to
+  # manually migrate those tables.
+  if [ -n "${DB_NAME_OLD}" ]; then
+      if mysql --defaults-file=/etc/mysql/debian.cnf -e "USE $DB_NAME_OLD;" 2>/dev/null; then
+        echo "$DB_WARNING"
+      fi
+  fi
 
   if [ -n "${DB_NAME}" ]; then
     for db in $(awk -F',' '{for (i = 1 ; i <= NF ; i++) print $i}' <<< "${DB_NAME}"); do

--- a/notarymysql/start
+++ b/notarymysql/start
@@ -141,15 +141,17 @@ if [ -n "${DB_USER}" -o -n "${DB_NAME}" ]; then
             echo "Granting access to database \"$db\" for user \"${DB_USER_SERVER}\"..."
             mysql --defaults-file=/etc/mysql/debian.cnf \
             -e "GRANT ALL PRIVILEGES ON \`$db\`.* TO '${DB_USER_SERVER}' IDENTIFIED BY '${DB_PASS_SERVER}';"
+            # Create our Database:
+            mysql -uroot $db < ./initial-notaryserver.sql
+            mysql -uroot $db < ./migrate-notaryserver.sql
           fi
           if [ -n "${DB_USER_SIGNER}" -a $db = $DB_NAME_SIGNER ]; then
             echo "Granting access to database \"$db\" for user \"${DB_USER_SIGNER}\"..."
             mysql --defaults-file=/etc/mysql/debian.cnf \
             -e "GRANT ALL PRIVILEGES ON \`$db\`.* TO '${DB_USER_SIGNER}' IDENTIFIED BY '${DB_PASS_SIGNER}';"
+            # Create our Database:
+            mysql -uroot $db < ./initial-notarysigner.sql
           fi
-          # Create our Database:
-          mysql -uroot $db < ./initial.sql
-          mysql -uroot $db < ./migrate.sql
       fi
     done
   fi


### PR DESCRIPTION
For security, server should not be able to access the `private_key` table
and we can go further more, say, use seperate databases for the server
and signer.

This patch set will do:
- [PATCH 1/4] creates two users corresponding to the different databases.
- [PATCH 2/4] Check whether the database `notary` exist or not and warn people to manually migrate those tables if it exist.
- [PATCH 3/4] make database `notaryserver` and `notarysigner` only create the tables they need.
- [PATCH 4/4] add the recommendation to guide people deploying a more secure MySQL for notary.

Closes #330 

Signed-off-by: Hu Keping <hukeping@huawei.com>

[skip ci]