### PR TITLE
Add check for RSA key len before adding delegation

### DIFF
--- a/const.go
+++ b/const.go
@@ -2,6 +2,8 @@ package notary
 
 // application wide constants
 const (
+	// MinRSABitSize is the minimum bit size for RSA keys allowed in notary
+	MinRSABitSize = 2048
 	// MinThreshold requires a minimum of one threshold for roles; currently we do not support a higher threshold
 	MinThreshold = 1
 	// PrivKeyPerms are the file permissions to use when writing private keys to disk


### PR DESCRIPTION
If the cert we're adding to the delegation has a RSA key and it's too short (< 2048), we'll reject before adding the delegation.  Without this check, the server will reject when we try to publish with the short key.  Closes #504.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>