### PR TITLE
return a better error message if the HTTP status code was 401

### DIFF
--- a/tuf/store/httpstore.go
+++ b/tuf/store/httpstore.go
@@ -33,6 +33,9 @@ type ErrServerUnavailable struct {
 }
 
 func (err ErrServerUnavailable) Error() string {
+	if err.code == 401 {
+		return fmt.Sprintf("you are not authorized to perform this operation: server returned 401.")
+	}
 	return fmt.Sprintf("unable to reach trust server at this time: %d.", err.code)
 }
 

--- a/tuf/store/httpstore_test.go
+++ b/tuf/store/httpstore_test.go
@@ -266,3 +266,14 @@ func TestHTTPOffline(t *testing.T) {
 	assert.NoError(t, err)
 	assert.IsType(t, &OfflineStore{}, s)
 }
+
+func TestErrServerUnavailable(t *testing.T) {
+	for i := 200; i < 600; i++ {
+		err := ErrServerUnavailable{code: i}
+		if i == 401 {
+			assert.Contains(t, err.Error(), "not authorized")
+		} else {
+			assert.Contains(t, err.Error(), "unable to reach trust server")
+		}
+	}
+}


### PR DESCRIPTION
Closes #288 

We've made other changes that mean we can better message a 401 on the client. This just provides a clearer error message.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)