### PR TITLE
Tiny refactor: to keep code style consistent

### DIFF
--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -133,7 +133,7 @@ func setupCommand(notaryCmd *cobra.Command) {
 	notaryCmd.AddCommand(cmdTufStatus)
 	notaryCmd.AddCommand(cmdTufPublish)
 	notaryCmd.AddCommand(cmdTufLookup)
-	notaryCmd.AddCommand(cmdVerify)
+	notaryCmd.AddCommand(cmdTufVerify)
 }
 
 func main() {

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -75,11 +75,11 @@ var cmdTufStatus = &cobra.Command{
 	Run:   tufStatus,
 }
 
-var cmdVerify = &cobra.Command{
+var cmdTufVerify = &cobra.Command{
 	Use:   "verify [ GUN ] <target>",
 	Short: "Verifies if the content is included in the remote trusted collection",
 	Long:  "Verifies if the data passed in STDIN is included in the remote trusted collection identified by the Global Unique Name.",
-	Run:   verify,
+	Run:   tufVerify,
 }
 
 func tufAdd(cmd *cobra.Command, args []string) {
@@ -273,7 +273,7 @@ func tufRemove(cmd *cobra.Command, args []string) {
 	cmd.Printf("Removal of %s from %s staged for next publish.\n", targetName, gun)
 }
 
-func verify(cmd *cobra.Command, args []string) {
+func tufVerify(cmd *cobra.Command, args []string) {
 	if len(args) < 2 {
 		cmd.Usage()
 		fatalf("Must specify a GUN and target")


### PR DESCRIPTION
The other CLI commands about tuf are all begin with cmdTufXXX
which I think `verify` should be the same too.

Signed-off-by: Hu Keping <hukeping@huawei.com>