### PR TITLE
Notary for 1.10 in docs.docker.com

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,6 @@
 <!--[metadata]>
 +++
+draft=true
 title = "Notary CLI"
 description = "Description of the Notary CLI"
 keywords = ["docker, notary, trust, image, signing, repository, cli"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,18 @@
-<!--[metadata]>
+<!--* [metadata]>
 +++
-title = "Docker Notary"
+title = "Notary"
 description = "List of Notary Documentation"
 keywords = ["docker, notary, trust, image, signing, repository, tuf"]
 [menu.main]
 identifier="mn_notary"
-parent="mn_docker_hub"
+parent="mn_components"
 weight=4
 +++
 <![end-metadata]-->
 
 # List of Notary Documentation
 
-* [Overview of Docker Notary](overview.md)
-* [Notary CLI](cli.md)
+* [Server Architecture](notary-server.md)
+* [Signer](notary-signer.md)
+* [Server Configuration File](notary-server-config.md)
+* [Signer Configuration File](notary-signer-config.md)

--- a/docs/notary-mysql.md
+++ b/docs/notary-mysql.md
@@ -5,6 +5,7 @@ description = "Description of the Notary MySQL"
 keywords = ["docker, notary, notary-mysql"]
 [menu.main]
 parent="mn_notary"
+weight=9
 +++
 <![end-metadata]-->
 

--- a/docs/notary-server-config.md
+++ b/docs/notary-server-config.md
@@ -1,10 +1,11 @@
 <!--[metadata]>
 +++
-title = "Notary Server Configuration File"
+title = "Server Configuration File"
 description = "Specifies the configuration file for Notary Server"
 keywords = ["docker, notary, notary-server, configuration"]
 [menu.main]
 parent="mn_notary"
+weight=80
 +++
 <![end-metadata]-->
 

--- a/docs/notary-server.md
+++ b/docs/notary-server.md
@@ -1,6 +1,6 @@
 <!--[metadata]>
 +++
-title = "Notary Server"
+title = "Server Architecture"
 description = "Description of the Notary Server"
 keywords = ["docker, notary, notary-server"]
 [menu.main]
@@ -8,7 +8,7 @@ parent="mn_notary"
 +++
 <![end-metadata]-->
 
-# Notary Server
+# Notary Server Architecture
 
 The Notary Server stores and updates the signed
 [TUF metadata files](
@@ -35,7 +35,7 @@ and a cert bundle from this authorization server containing the public key it
 uses to sign tokens.
 
 If token authentication is enabled on Notary Server, then any client that
-does not have a token will be redirected to the authoriziation server.
+does not have a token will be redirected to the authorization server.
 The client will log in, obtain a token, and then present the token to
 Notary Server on future requests.
 
@@ -66,7 +66,7 @@ certificates for your deployment of Notary Server, please make
 sure that the certificates **are not CAs**.  Otherwise if the server is
 compromised, it can sign any number of other client certs.
 
-As an example, please see [this script](opensslCertGen.sh) to see how to
+As an example, please see [this script](https://github.com/docker/notary/blob/master/docs/opensslCertGen.sh) to see how to
 generate client SSL certs with basic constraints using OpenSSL.
 
 ### How to configure and run Notary Server

--- a/docs/notary-signer-config.md
+++ b/docs/notary-signer-config.md
@@ -1,10 +1,11 @@
 <!--[metadata]>
 +++
-title = "Notary Signer Configuration File"
+title = "Signer Configuration File"
 description = "Specifies the configuration file for Notary Signer"
 keywords = ["docker, notary, notary-signer, configuration"]
 [menu.main]
 parent="mn_notary"
+weight=90
 +++
 <![end-metadata]-->
 

--- a/docs/notary-signer.md
+++ b/docs/notary-signer.md
@@ -1,6 +1,6 @@
 <!--[metadata]>
 +++
-title = "Notary Signer"
+title = "Signer"
 description = "Description of the Notary Signer"
 keywords = ["docker, notary, notary-singer"]
 [menu.main]
@@ -26,7 +26,7 @@ Note that when you generate client certificates to be used with Notary Signer,
 please make sure that the certificates **are not CAs**.  Otherwise any client
 that is compromised can sign any number of other client certs.
 
-As an example, please see [this script](opensslCertGen.sh) to see how to
+As an example, please see [this script](https://github.com/docker/notary/blob/master/docs/opensslCertGen.sh) to see how to
 generate client SSL certs with basic constraints using OpenSSL.
 
 ### Signer storage
@@ -135,7 +135,7 @@ However, the attacker cannot do anything useful with the timestamp keys unless
 they also [compromise the Notary Server](
 notary-server.md#what-happens-if-the-server-is-compromised)
 
-The attacker can prevent Notary Signer from signing timestap metadata from
+The attacker can prevent Notary Signer from signing timestamp metadata from
 Notary Server and return invalid public key IDs when the Notary Server
 requests it.  This means an attacker can execute a denial of service attack
 that prevents the Notary Server from being able to update any metadata.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,5 +1,6 @@
 <!--[metadata]>
 +++
+draft=true
 title = "Overview of Docker Notary"
 description = "Overview of Docker Notary"
 keywords = ["docker, notary, trust, image, signing, repository"]


### PR DESCRIPTION
For the 1.10 release we are moving to product-name taxonomy to help users find documentation about a product. Registry and Notary are moving under a menu Marketing calls Component Projects. This PR makes this menu:

![image](https://cloud.githubusercontent.com/assets/1347209/12645107/96afa7a2-c57c-11e5-8757-3acf6e50e9f6.png)


Note: The rest of the menu may look a bit foobared --- don't freak. I have multiple PRs in play across several repos and when they all close the currently exposed codes will go away.

Signed-off-by: Mary Anthony <mary@docker.com>