### PR TITLE
use only canonical IDs for display on delegation CLI commands,

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2312,7 +2312,9 @@ func TestPublishRemoveDelgation(t *testing.T) {
 	assert.NoError(t, delgRepo.Publish())
 
 	// owner removes delegation
-	assert.NoError(t, ownerRepo.RemoveDelegation("targets/a", []string{aKey.ID()}, []string{}, false))
+	aKeyCanonicalID, err := utils.CanonicalKeyID(aKey)
+	assert.NoError(t, err)
+	assert.NoError(t, ownerRepo.RemoveDelegation("targets/a", []string{aKeyCanonicalID}, []string{}, false))
 	assert.NoError(t, ownerRepo.Publish())
 
 	// delegated repo can now no longer publish to delegated role
@@ -2696,7 +2698,9 @@ func TestRemoveDelegationChangefileApplicable(t *testing.T) {
 	assert.Len(t, targetRole.Signed.Delegations.Keys, 1)
 
 	// now remove it
-	assert.NoError(t, repo.RemoveDelegation("targets/a", []string{rootKeyID}, []string{}, false))
+	rootKeyCanonicalID, err := utils.CanonicalKeyID(rootPubKey)
+	assert.NoError(t, err)
+	assert.NoError(t, repo.RemoveDelegation("targets/a", []string{rootKeyCanonicalID}, []string{}, false))
 	changes = getChanges(t, repo)
 	assert.Len(t, changes, 2)
 	assert.NoError(t, applyTargetsChange(repo.tufRepo, changes[1]))

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -504,10 +504,14 @@ func TestApplyTargetsDelegationCreateAlreadyExisting(t *testing.T) {
 	// when attempting to create the same role again, check that we added a key
 	err = applyTargetsChange(repo, ch)
 	assert.NoError(t, err)
-	delegation, err := repo.GetDelegation("targets/level1")
+	delegation, keys, err := repo.GetDelegation("targets/level1")
 	assert.NoError(t, err)
 	assert.Contains(t, delegation.Paths, "level1")
 	assert.Equal(t, len(delegation.KeyIDs), 2)
+	for _, keyID := range delegation.KeyIDs {
+		_, ok := keys[keyID]
+		assert.True(t, ok)
+	}
 }
 
 func TestApplyTargetsDelegationAlreadyExistingMergePaths(t *testing.T) {
@@ -559,7 +563,7 @@ func TestApplyTargetsDelegationAlreadyExistingMergePaths(t *testing.T) {
 	// merged with previous details
 	err = applyTargetsChange(repo, ch)
 	assert.NoError(t, err)
-	delegation, err := repo.GetDelegation("targets/level1")
+	delegation, _, err := repo.GetDelegation("targets/level1")
 	assert.NoError(t, err)
 	// Assert we have both paths
 	assert.Contains(t, delegation.Paths, "level2")

--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -206,7 +207,11 @@ func (d *delegationCommander) delegationAdd(cmd *cobra.Command, args []string) e
 	// Make keyID slice for better CLI print
 	pubKeyIDs := []string{}
 	for _, pubKey := range pubKeys {
-		pubKeyIDs = append(pubKeyIDs, pubKey.ID())
+		pubKeyID, err := utils.CanonicalKeyID(pubKey)
+		if err != nil {
+			return err
+		}
+		pubKeyIDs = append(pubKeyIDs, pubKeyID)
 	}
 
 	cmd.Println("")

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -172,7 +173,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 
 	rawPubBytes, _ := ioutil.ReadFile(tempFile.Name())
 	parsedPubKey, _ := trustmanager.ParsePEMPublicKey(rawPubBytes)
-	keyID := parsedPubKey.ID()
+	keyID, err := utils.CanonicalKeyID(parsedPubKey)
+	assert.NoError(t, err)
 
 	var output string
 
@@ -219,6 +221,7 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "targets/delegation")
+	assert.Contains(t, output, keyID)
 
 	// Setup another certificate
 	tempFile2, err := ioutil.TempFile("/tmp", "pemfile2")
@@ -238,9 +241,10 @@ func TestClientDelegationsInteraction(t *testing.T) {
 
 	rawPubBytes2, _ := ioutil.ReadFile(tempFile2.Name())
 	parsedPubKey2, _ := trustmanager.ParsePEMPublicKey(rawPubBytes2)
-	keyID2 := parsedPubKey2.ID()
+	keyID2, err := utils.CanonicalKeyID(parsedPubKey2)
+	assert.NoError(t, err)
 
-	// add to the delegation by specifying the same role, this time add a path
+	// add to the delegation by specifying the same role, this time add another key and path
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", tempFile2.Name(), "--paths", "path")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "Addition of delegation role")
@@ -254,6 +258,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, output, ",")
 	assert.Contains(t, output, "path")
+	assert.Contains(t, output, keyID)
+	assert.Contains(t, output, keyID2)
 
 	// remove the delegation's first key
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", keyID)
@@ -267,7 +273,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	// list delegations - we should see the delegation but with only the second key
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
 	assert.NoError(t, err)
-	assert.NotContains(t, output, ",")
+	assert.NotContains(t, output, keyID)
+	assert.Contains(t, output, keyID2)
 
 	// remove the delegation's second key
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", keyID2)
@@ -297,6 +304,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, output, ",")
 	assert.Contains(t, output, "path1,path2")
+	assert.Contains(t, output, keyID)
+	assert.Contains(t, output, keyID2)
 
 	// add delegation with multiple certs and multiple paths
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--paths", "path3")
@@ -329,6 +338,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	assert.Contains(t, output, "path1")
 	assert.NotContains(t, output, "path2")
 	assert.NotContains(t, output, "path3")
+	assert.Contains(t, output, keyID)
+	assert.Contains(t, output, keyID2)
 
 	// remove the remaining path, should not remove the delegation entirely
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "--paths", "path1")
@@ -346,6 +357,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	assert.NotContains(t, output, "path1")
 	assert.NotContains(t, output, "path2")
 	assert.NotContains(t, output, "path3")
+	assert.Contains(t, output, keyID)
+	assert.Contains(t, output, keyID2)
 
 	// remove by force to delete the delegation entirely
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "-y")

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -639,9 +639,11 @@ func TestGetDelegationRoleAndMetadataExistDelegationExists(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, repo.UpdateDelegations(role, data.KeyList{testKey}))
 
-	gottenRole, err := repo.GetDelegation("targets/level1/level2")
+	gottenRole, gottenKeys, err := repo.GetDelegation("targets/level1/level2")
 	assert.NoError(t, err)
 	assert.Equal(t, role, gottenRole)
+	_, ok := gottenKeys[testKey.ID()]
+	assert.True(t, ok)
 }
 
 // If the parent exists, the metadata exists, and the delegation isn't in it,
@@ -662,7 +664,7 @@ func TestGetDelegationRoleAndMetadataExistDelegationDoesntExists(t *testing.T) {
 	// ensure metadata exists
 	repo.InitTargets("targets/level1")
 
-	_, err = repo.GetDelegation("targets/level1/level2")
+	_, _, err = repo.GetDelegation("targets/level1/level2")
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrNoSuchRole{}, err)
 }
@@ -685,7 +687,7 @@ func TestGetDelegationRoleAndMetadataDoesntExists(t *testing.T) {
 	_, ok := repo.Targets["targets/test"]
 	assert.False(t, ok, "no targets file should be created for empty delegation")
 
-	_, err = repo.GetDelegation("targets/level1/level2")
+	_, _, err = repo.GetDelegation("targets/level1/level2")
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrNoSuchRole{}, err)
 }
@@ -696,7 +698,7 @@ func TestGetDelegationParentMissing(t *testing.T) {
 	keyDB := keys.NewDB()
 	repo := initRepo(t, ed25519, keyDB)
 
-	_, err := repo.GetDelegation("targets/level1/level2")
+	_, _, err := repo.GetDelegation("targets/level1/level2")
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
 }


### PR DESCRIPTION
Since we display the canonical key ID when asking a delegation user to passphrases and also need to store the key under its canonical key ID when saving to `tuf_files`, it makes sense to only show the canonical ID to the user on notary CLI.

Before this change, we used the TUF key IDs on notary CLI commands, but still required the canonical key ID in the filename and would show the user the canoncial key ID if they needed to enter a passphrase when signing with that key.

This does require us to do more work to translate between key ID types, but this is only done for `delegation list` (to translate TUF key IDs to canonical IDs to show to the user) or a `publish` after a `delegation remove` (to translate user-supplied canonical IDs to TUF key IDs to apply the changelist logic).

This is unfortunately not the most elegant solution, but it will only affect delegation keys -- behavior for root/targets/snapshot keys remains unchanged.

Closes #506 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>