### PR TITLE
Consistent Download

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -885,7 +886,10 @@ func (r *NotaryRepository) Update(forWrite bool) (*tufclient.Client, error) {
 	}
 	err = c.Update()
 	if err != nil {
-		if notFound, ok := err.(store.ErrMetaNotFound); ok && notFound.Resource == data.CanonicalRootRole {
+		// notFound.Resource may include a checksum so when the role is root,
+		// it will be root.json or root.<checksum>.json. Therefore best we can
+		// do it match a "root." prefix
+		if notFound, ok := err.(store.ErrMetaNotFound); ok && strings.HasPrefix(notFound.Resource, data.CanonicalRootRole+".") {
 			return nil, r.errRepositoryNotExist()
 		}
 		return nil, err

--- a/server/server.go
+++ b/server/server.go
@@ -89,13 +89,13 @@ func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.Cry
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("UpdateTuf"),
 			hand(handlers.AtomicUpdateHandler, "push", "pull")))
-	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Handler(
-		prometheus.InstrumentHandlerWithOpts(
-			prometheusOpts("GetRole"),
-			hand(handlers.GetHandler, "pull")))
 	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.{checksum:[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128}}.json").Handler(
 		prometheus.InstrumentHandlerWithOpts(
 			prometheusOpts("GetRoleByHash"),
+			hand(handlers.GetHandler, "pull")))
+	r.Methods("GET").Path("/v2/{imageName:.*}/_trust/tuf/{tufRole:root|targets(?:/[^/\\s]+)*|snapshot|timestamp}.json").Handler(
+		prometheus.InstrumentHandlerWithOpts(
+			prometheusOpts("GetRole"),
 			hand(handlers.GetHandler, "pull")))
 	r.Methods("GET").Path(
 		"/v2/{imageName:.*}/_trust/tuf/{tufRole:snapshot|timestamp}.key").Handler(

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -177,7 +177,7 @@ func (c *Client) downloadRoot() error {
 	var raw []byte
 	if download {
 		// use consistent download if we have the checksum.
-		raw, s, err = c.downloadSigned(role, size, expectedSha256, len(expectedSha256) > 0)
+		raw, s, err = c.downloadSigned(role, size, expectedSha256)
 		if err != nil {
 			return err
 		}
@@ -265,7 +265,7 @@ func (c *Client) downloadTimestamp() error {
 	}
 	// unlike root, targets and snapshot, always try and download timestamps
 	// from remote, only using the cache one if we couldn't reach remote.
-	raw, s, err := c.downloadSigned(role, notary.MaxTimestampSize, nil, false)
+	raw, s, err := c.downloadSigned(role, notary.MaxTimestampSize, nil)
 	if err == nil {
 		ts, err = c.verifyTimestamp(s, version, c.keysDB)
 		if err == nil {
@@ -342,7 +342,7 @@ func (c *Client) downloadSnapshot() error {
 	}
 	var s *data.Signed
 	if download {
-		raw, s, err = c.downloadSigned(role, size, expectedSha256, true)
+		raw, s, err = c.downloadSigned(role, size, expectedSha256)
 		if err != nil {
 			return err
 		}
@@ -419,8 +419,8 @@ func (c *Client) downloadTargets(role string) error {
 	return nil
 }
 
-func (c *Client) downloadSigned(role string, size int64, expectedSha256 []byte, consistent bool) ([]byte, *data.Signed, error) {
-	rolePath := utils.URLFilePath(role, expectedSha256, consistent)
+func (c *Client) downloadSigned(role string, size int64, expectedSha256 []byte) ([]byte, *data.Signed, error) {
+	rolePath := utils.ConsistentName(role, expectedSha256)
 	raw, err := c.remote.GetMeta(rolePath, size)
 	if err != nil {
 		return nil, nil, err
@@ -480,7 +480,7 @@ func (c Client) getTargetsFile(role string, keyIDs []string, snapshotMeta data.F
 	size := snapshotMeta[role].Length
 	var s *data.Signed
 	if download {
-		raw, s, err = c.downloadSigned(role, size, expectedSha256, true)
+		raw, s, err = c.downloadSigned(role, size, expectedSha256)
 		if err != nil {
 			return nil, err
 		}

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary"
@@ -540,19 +539,4 @@ func (c Client) TargetMeta(role, path string, excludeRoles ...string) (*data.Fil
 		}
 	}
 	return meta, ""
-}
-
-// DownloadTarget downloads the target to dst from the remote
-func (c Client) DownloadTarget(dst io.Writer, path string, meta *data.FileMeta) error {
-	reader, err := c.remote.GetTarget(path)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-	r := io.TeeReader(
-		io.LimitReader(reader, meta.Length),
-		dst,
-	)
-	err = utils.ValidateTarget(r, meta)
-	return err
 }

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -235,18 +235,17 @@ func TestCheckRootExpired(t *testing.T) {
 func TestChecksumMismatch(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
 	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	remoteStorage := testutils.NewCorruptingMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
 	orig, err := json.Marshal(sampleTargets)
 	origSha256 := sha256.Sum256(orig)
-	orig[0] = '}' // corrupt data, should be a {
 	assert.NoError(t, err)
 
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:])
+	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:], false)
 	assert.IsType(t, ErrChecksumMismatch{}, err)
 }
 
@@ -263,7 +262,7 @@ func TestChecksumMatch(t *testing.T) {
 
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:])
+	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:], false)
 	assert.NoError(t, err)
 }
 
@@ -284,7 +283,7 @@ func TestSizeMismatchLong(t *testing.T) {
 
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", l, origSha256[:])
+	_, _, err = client.downloadSigned("targets", l, origSha256[:], false)
 	// size just limits the data received, the error is caught
 	// either during checksum verification or during json deserialization
 	assert.IsType(t, ErrChecksumMismatch{}, err)
@@ -306,7 +305,7 @@ func TestSizeMismatchShort(t *testing.T) {
 
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", l, origSha256[:])
+	_, _, err = client.downloadSigned("targets", l, origSha256[:], false)
 	// size just limits the data received, the error is caught
 	// either during checksum verification or during json deserialization
 	assert.IsType(t, ErrChecksumMismatch{}, err)
@@ -457,7 +456,7 @@ func TestDownloadTargetChecksumMismatch(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	remoteStorage := testutils.NewCorruptingMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample targets
@@ -466,13 +465,10 @@ func TestDownloadTargetChecksumMismatch(t *testing.T) {
 	orig, err := json.Marshal(signedOrig)
 	assert.NoError(t, err)
 	origSha256 := sha256.Sum256(orig)
-	orig[0] = '}' // corrupt data, should be a {
 	err = remoteStorage.SetMeta("targets", orig)
 	assert.NoError(t, err)
 
 	// create local snapshot with targets file
-	// It's necessary to do it this way rather than calling repo.SignSnapshot
-	// so that we have the wrong sha256 in the snapshot.
 	snap := data.SignedSnapshot{
 		Signed: data.Snapshot{
 			Meta: data.Files{
@@ -583,28 +579,52 @@ func TestUpdateDownloadRootHappy(t *testing.T) {
 }
 
 func TestUpdateDownloadRootBadChecksum(t *testing.T) {
+	remoteStore := testutils.NewCorruptingMemoryStore(nil, nil)
+
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
-	client := NewClient(repo, remoteStorage, kdb, localStorage)
+	client := NewClient(repo, remoteStore, kdb, localStorage)
 
-	// sign snapshot to make sure we have a checksum for root
-	_, err = repo.SignSnapshot(data.DefaultExpires("snapshot"))
-	assert.NoError(t, err)
-
-	// create and "upload" sample root, snapshot, and timestamp
+	// sign and "upload" sample root
 	signedOrig, err := repo.SignRoot(data.DefaultExpires("root"))
 	assert.NoError(t, err)
 	orig, err := json.Marshal(signedOrig)
 	assert.NoError(t, err)
-	err = remoteStorage.SetMeta("root", orig)
+	err = remoteStore.SetMeta("root", orig)
+	assert.NoError(t, err)
+
+	// sign snapshot to make sure we have current checksum for root
+	_, err = repo.SignSnapshot(data.DefaultExpires("snapshot"))
+	assert.NoError(t, err)
+
+	err = client.downloadRoot()
+	assert.IsType(t, ErrChecksumMismatch{}, err)
+}
+
+func TestUpdateDownloadRootChecksumNotFound(t *testing.T) {
+	remoteStore := store.NewMemoryStore(nil, nil)
+	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
+	assert.NoError(t, err)
+	localStorage := store.NewMemoryStore(nil, nil)
+	client := NewClient(repo, remoteStore, kdb, localStorage)
+
+	// sign snapshot to make sure we have current checksum for root
+	_, err = repo.SignSnapshot(data.DefaultExpires("snapshot"))
+	assert.NoError(t, err)
+
+	// sign and "upload" sample root
+	signedOrig, err := repo.SignRoot(data.DefaultExpires("root"))
+	assert.NoError(t, err)
+	orig, err := json.Marshal(signedOrig)
+	assert.NoError(t, err)
+	err = remoteStore.SetMeta("root", orig)
 	assert.NoError(t, err)
 
 	// don't sign snapshot again to ensure checksum is out of date (bad)
 
 	err = client.downloadRoot()
-	assert.IsType(t, ErrChecksumMismatch{}, err)
+	assert.IsType(t, store.ErrMetaNotFound{}, err)
 }
 
 func TestDownloadTimestampHappy(t *testing.T) {
@@ -739,7 +759,7 @@ func TestDownloadSnapshotNoChecksum(t *testing.T) {
 	assert.IsType(t, ErrMissingMeta{}, err)
 }
 
-func TestDownloadSnapshotBadChecksum(t *testing.T) {
+func TestDownloadSnapshotChecksumNotFound(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	localStorage := store.NewMemoryStore(nil, nil)
@@ -761,7 +781,7 @@ func TestDownloadSnapshotBadChecksum(t *testing.T) {
 	// by not signing timestamp again we ensure it has the wrong checksum
 
 	err = client.downloadSnapshot()
-	assert.IsType(t, ErrChecksumMismatch{}, err)
+	assert.IsType(t, store.ErrMetaNotFound{}, err)
 }
 
 // TargetMeta returns the file metadata for a file path in the role subtree,

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -245,7 +245,7 @@ func TestChecksumMismatch(t *testing.T) {
 
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:], false)
+	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:])
 	assert.IsType(t, ErrChecksumMismatch{}, err)
 }
 
@@ -262,14 +262,14 @@ func TestChecksumMatch(t *testing.T) {
 
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:], false)
+	_, _, err = client.downloadSigned("targets", int64(len(orig)), origSha256[:])
 	assert.NoError(t, err)
 }
 
 func TestSizeMismatchLong(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
 	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	remoteStorage := testutils.NewLongMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
@@ -278,12 +278,9 @@ func TestSizeMismatchLong(t *testing.T) {
 	assert.NoError(t, err)
 	l := int64(len(orig))
 
-	orig = append([]byte(" "), orig...)
-	assert.Equal(t, l+1, int64(len(orig)))
-
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", l, origSha256[:], false)
+	_, _, err = client.downloadSigned("targets", l, origSha256[:])
 	// size just limits the data received, the error is caught
 	// either during checksum verification or during json deserialization
 	assert.IsType(t, ErrChecksumMismatch{}, err)
@@ -292,7 +289,7 @@ func TestSizeMismatchLong(t *testing.T) {
 func TestSizeMismatchShort(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
 	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	remoteStorage := testutils.NewShortMemoryStore(nil, nil)
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
@@ -301,11 +298,9 @@ func TestSizeMismatchShort(t *testing.T) {
 	assert.NoError(t, err)
 	l := int64(len(orig))
 
-	orig = orig[1:]
-
 	remoteStorage.SetMeta("targets", orig)
 
-	_, _, err = client.downloadSigned("targets", l, origSha256[:], false)
+	_, _, err = client.downloadSigned("targets", l, origSha256[:])
 	// size just limits the data received, the error is caught
 	// either during checksum verification or during json deserialization
 	assert.IsType(t, ErrChecksumMismatch{}, err)

--- a/tuf/store/interfaces.go
+++ b/tuf/store/interfaces.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"io"
-
 	"github.com/docker/notary/tuf/data"
 )
 
@@ -23,17 +21,9 @@ type PublicKeyStore interface {
 	GetKey(role string) ([]byte, error)
 }
 
-// TargetStore represents a collection of targets that can be walked similarly
-// to walking a directory, passing a callback that receives the path and meta
-// for each target
-type TargetStore interface {
-	WalkStagedTargets(paths []string, targetsFn targetsWalkFunc) error
-}
-
 // LocalStore represents a local TUF sture
 type LocalStore interface {
 	MetadataStore
-	TargetStore
 }
 
 // RemoteStore is similar to LocalStore with the added expectation that it should
@@ -41,5 +31,4 @@ type LocalStore interface {
 type RemoteStore interface {
 	MetadataStore
 	PublicKeyStore
-	GetTarget(path string) (io.ReadCloser, error)
 }

--- a/tuf/store/memorystore.go
+++ b/tuf/store/memorystore.go
@@ -19,7 +19,7 @@ func NewMemoryStore(meta map[string][]byte, files map[string][]byte) *MemoryStor
 		// add all seed meta to consistent
 		for name, data := range meta {
 			checksum := sha256.Sum256(data)
-			path := utils.URLFilePath(name, checksum[:], true)
+			path := utils.ConsistentName(name, checksum[:])
 			consistent[path] = data
 		}
 	}
@@ -73,7 +73,7 @@ func (m *MemoryStore) SetMeta(name string, meta []byte) error {
 	m.meta[name] = meta
 
 	checksum := sha256.Sum256(meta)
-	path := utils.URLFilePath(name, checksum[:], true)
+	path := utils.ConsistentName(name, checksum[:])
 	m.consistent[path] = meta
 	return nil
 }
@@ -92,7 +92,7 @@ func (m *MemoryStore) SetMultiMeta(metas map[string][]byte) error {
 func (m *MemoryStore) RemoveMeta(name string) error {
 	if meta, ok := m.meta[name]; ok {
 		checksum := sha256.Sum256(meta)
-		path := utils.URLFilePath(name, checksum[:], true)
+		path := utils.ConsistentName(name, checksum[:])
 		delete(m.meta, name)
 		delete(m.consistent, path)
 	}

--- a/tuf/testutils/corrupt_memorystore.go
+++ b/tuf/testutils/corrupt_memorystore.go
@@ -1,0 +1,24 @@
+package testutils
+
+import (
+	"github.com/docker/notary/tuf/store"
+)
+
+// CorruptingMemoryStore corrupts all data returned by GetMeta
+type CorruptingMemoryStore struct {
+	store.MemoryStore
+}
+
+func NewCorruptingMemoryStore(meta map[string][]byte, files map[string][]byte) *CorruptingMemoryStore {
+	s := store.NewMemoryStore(meta, files)
+	return &CorruptingMemoryStore{MemoryStore: *s}
+}
+
+func (cm CorruptingMemoryStore) GetMeta(name string, size int64) ([]byte, error) {
+	d, err := cm.MemoryStore.GetMeta(name, size)
+	if err != nil {
+		return nil, err
+	}
+	d[0] = '}' // all our content is JSON so must start with {
+	return d, err
+}

--- a/tuf/testutils/corrupt_memorystore.go
+++ b/tuf/testutils/corrupt_memorystore.go
@@ -9,11 +9,15 @@ type CorruptingMemoryStore struct {
 	store.MemoryStore
 }
 
+// NewCorruptingMemoryStore returns a new instance of memory store that
+// corrupts all data requested from it.
 func NewCorruptingMemoryStore(meta map[string][]byte, files map[string][]byte) *CorruptingMemoryStore {
 	s := store.NewMemoryStore(meta, files)
 	return &CorruptingMemoryStore{MemoryStore: *s}
 }
 
+// GetMeta returns up to size bytes of meta identified by string. It will
+// always be corrupted by setting the first character to }
 func (cm CorruptingMemoryStore) GetMeta(name string, size int64) ([]byte, error) {
 	d, err := cm.MemoryStore.GetMeta(name, size)
 	if err != nil {

--- a/tuf/testutils/corrupt_memorystore.go
+++ b/tuf/testutils/corrupt_memorystore.go
@@ -26,3 +26,46 @@ func (cm CorruptingMemoryStore) GetMeta(name string, size int64) ([]byte, error)
 	d[0] = '}' // all our content is JSON so must start with {
 	return d, err
 }
+
+// LongMemoryStore corrupts all data returned by GetMeta
+type LongMemoryStore struct {
+	store.MemoryStore
+}
+
+// NewLongMemoryStore returns a new instance of memory store that
+// returns one byte too much data on any request to GetMeta
+func NewLongMemoryStore(meta map[string][]byte, files map[string][]byte) *LongMemoryStore {
+	s := store.NewMemoryStore(meta, files)
+	return &LongMemoryStore{MemoryStore: *s}
+}
+
+// GetMeta returns one byte too much
+func (lm LongMemoryStore) GetMeta(name string, size int64) ([]byte, error) {
+	d, err := lm.MemoryStore.GetMeta(name, size)
+	if err != nil {
+		return nil, err
+	}
+	d = append(d, ' ')
+	return d, err
+}
+
+// ShortMemoryStore corrupts all data returned by GetMeta
+type ShortMemoryStore struct {
+	store.MemoryStore
+}
+
+// NewShortMemoryStore returns a new instance of memory store that
+// returns one byte too little data on any request to GetMeta
+func NewShortMemoryStore(meta map[string][]byte, files map[string][]byte) *ShortMemoryStore {
+	s := store.NewMemoryStore(meta, files)
+	return &ShortMemoryStore{MemoryStore: *s}
+}
+
+// GetMeta returns one byte too few
+func (sm ShortMemoryStore) GetMeta(name string, size int64) ([]byte, error) {
+	d, err := sm.MemoryStore.GetMeta(name, size)
+	if err != nil {
+		return nil, err
+	}
+	return d[1:], err
+}

--- a/tuf/utils/utils.go
+++ b/tuf/utils/utils.go
@@ -148,11 +148,11 @@ func FindRoleIndex(rs []*data.Role, name string) int {
 	return -1
 }
 
-// URLFilePath generates the appropriate HTTP URL path for the role,
+// ConsistentName generates the appropriate HTTP URL path for the role,
 // based on whether the repo is marked as consistent. The RemoteStore
 // is responsible for adding file extensions.
-func URLFilePath(role string, hashSha256 []byte, consistent bool) string {
-	if consistent && len(hashSha256) > 0 {
+func ConsistentName(role string, hashSha256 []byte) string {
+	if len(hashSha256) > 0 {
 		hash := hex.EncodeToString(hashSha256)
 		return fmt.Sprintf("%s.%s", role, hash)
 	}

--- a/tuf/utils/utils.go
+++ b/tuf/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -145,4 +146,15 @@ func FindRoleIndex(rs []*data.Role, name string) int {
 		}
 	}
 	return -1
+}
+
+// URLFilePath generates the appropriate HTTP URL path for the role,
+// based on whether the repo is marked as consistent. The RemoteStore
+// is responsible for adding file extensions.
+func URLFilePath(role string, hashSha256 []byte, consistent bool) string {
+	if consistent && len(hashSha256) > 0 {
+		hash := hex.EncodeToString(hashSha256)
+		return fmt.Sprintf("%s.%s", role, hash)
+	}
+	return role
 }


### PR DESCRIPTION
The client will use the checksum in downloading whenever a checksum is available. This means it will never use one for timestamp and will only use one for downloading root if a snapshot was successfully downloaded first, however it will always use one for downloading the snapshot and all targets (incl. delegations) files.

Also deleted dead code related to loading and downloading targets while I was in the store code. It has never seen use in Notary.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)