### PR TITLE
update metrics endpoint

### DIFF
--- a/docs/notary-server.md
+++ b/docs/notary-server.md
@@ -188,5 +188,5 @@ Notary Server provides the following features for operational friendliness:
 1. A [Bugsnag](https://bugsnag.com) hook for error logs, if a Bugsnag
 	configuration is provided.
 
-1. A [prometheus](http://prometheus.io/) endpoint at `/_notary_server/metrics`
+1. A [prometheus](http://prometheus.io/) endpoint at `/metrics`
 	which provides HTTP stats.

--- a/server/server.go
+++ b/server/server.go
@@ -108,7 +108,7 @@ func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.Cry
 			hand(handlers.DeleteHandler, "push", "pull")))
 
 	r.Methods("GET").Path("/_notary_server/health").HandlerFunc(health.StatusHandler)
-	r.Methods("GET").Path("/_notary_server/metrics").Handler(prometheus.Handler())
+	r.Methods("GET").Path("/metrics").Handler(prometheus.Handler())
 	r.Methods("GET", "POST", "PUT", "HEAD", "DELETE").Path("/{other:.*}").Handler(
 		hand(handlers.NotFoundHandler))
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -59,7 +59,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	res, err := http.Get(ts.URL + "/_notary_server/metrics")
+	res, err := http.Get(ts.URL + "/metrics")
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 }


### PR DESCRIPTION
Request from the ops team that prometheus metrics for server are found at /metrics. I guess they use this as a standard endpoint for this info.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)