### PR TITLE
Stop logging out critical info of database

### DIFF
--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -104,7 +104,6 @@ func setUpCryptoservices(configuration *viper.Viper, allowedBackends []string) (
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a new keydbstore: %v", err)
 		}
-		logrus.Debugf("Using %s DB: %s", storeConfig.Backend, storeConfig.Source)
 
 		health.RegisterPeriodicFunc(
 			"DB operational", dbStore.HealthCheck, time.Second*60)


### PR DESCRIPTION
The signer will print out the user name and password of the database
which could cause security problem.

The server side is OK.

Signed-off-by: Hu Keping <hukeping@huawei.com>