### PR TITLE
removing last vestiges of target download code

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -116,7 +116,6 @@ func repositoryFromKeystores(baseDir, gun, baseURL string, rt http.RoundTripper,
 		nRepo.tufRepoPath,
 		"metadata",
 		"json",
-		"",
 	)
 	if err != nil {
 		return nil, err

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -99,7 +99,7 @@ func TestUpdateSucceedsEvenIfCannotWriteNewRepo(t *testing.T) {
 	serverMeta, _, err := testutils.NewRepoMetadata("docker.com/notary", metadataDelegations...)
 	require.NoError(t, err)
 
-	ts := readOnlyServer(t, store.NewMemoryStore(serverMeta, nil), http.StatusNotFound)
+	ts := readOnlyServer(t, store.NewMemoryStore(serverMeta), http.StatusNotFound)
 	defer ts.Close()
 
 	for role := range serverMeta {
@@ -215,7 +215,7 @@ func TestUpdateReplacesCorruptOrMissingMetadata(t *testing.T) {
 	serverMeta, cs, err := testutils.NewRepoMetadata("docker.com/notary", metadataDelegations...)
 	require.NoError(t, err)
 
-	ts := readOnlyServer(t, store.NewMemoryStore(serverMeta, nil), http.StatusNotFound)
+	ts := readOnlyServer(t, store.NewMemoryStore(serverMeta), http.StatusNotFound)
 	defer ts.Close()
 
 	repo := newBlankRepo(t, ts.URL)

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -23,7 +23,6 @@ func getRemoteStore(baseURL, gun string, rt http.RoundTripper) (store.RemoteStor
 		baseURL+"/v2/"+gun+"/_trust/tuf/",
 		"",
 		"json",
-		"",
 		"key",
 		rt,
 	)

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -32,7 +32,6 @@ func TestValidationErrorFormat(t *testing.T) {
 		fmt.Sprintf("%s/v2/gun/_trust/tuf/", server.URL),
 		"",
 		"json",
-		"",
 		"key",
 		http.DefaultTransport,
 	)

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -23,8 +23,8 @@ func TestRotation(t *testing.T) {
 	kdb := keys.NewDB()
 	signer := signed.NewEd25519()
 	repo := tuf.NewRepo(kdb, signer)
-	remote := store.NewMemoryStore(nil, nil)
-	cache := store.NewMemoryStore(nil, nil)
+	remote := store.NewMemoryStore(nil)
+	cache := store.NewMemoryStore(nil)
 
 	// Generate initial root key and role and add to key DB
 	rootKey, err := signer.Create("root", data.ED25519Key)
@@ -78,8 +78,8 @@ func TestRotationNewSigMissing(t *testing.T) {
 	kdb := keys.NewDB()
 	signer := signed.NewEd25519()
 	repo := tuf.NewRepo(kdb, signer)
-	remote := store.NewMemoryStore(nil, nil)
-	cache := store.NewMemoryStore(nil, nil)
+	remote := store.NewMemoryStore(nil)
+	cache := store.NewMemoryStore(nil)
 
 	// Generate initial root key and role and add to key DB
 	rootKey, err := signer.Create("root", data.ED25519Key)
@@ -139,8 +139,8 @@ func TestRotationOldSigMissing(t *testing.T) {
 	kdb := keys.NewDB()
 	signer := signed.NewEd25519()
 	repo := tuf.NewRepo(kdb, signer)
-	remote := store.NewMemoryStore(nil, nil)
-	cache := store.NewMemoryStore(nil, nil)
+	remote := store.NewMemoryStore(nil)
+	cache := store.NewMemoryStore(nil)
 
 	// Generate initial root key and role and add to key DB
 	rootKey, err := signer.Create("root", data.ED25519Key)
@@ -197,7 +197,7 @@ func TestRotationOldSigMissing(t *testing.T) {
 
 func TestCheckRootExpired(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
-	storage := store.NewMemoryStore(nil, nil)
+	storage := store.NewMemoryStore(nil)
 	client := NewClient(repo, storage, nil, storage)
 
 	root := &data.SignedRoot{}
@@ -234,8 +234,8 @@ func TestCheckRootExpired(t *testing.T) {
 
 func TestChecksumMismatch(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := testutils.NewCorruptingMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := testutils.NewCorruptingMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
@@ -251,8 +251,8 @@ func TestChecksumMismatch(t *testing.T) {
 
 func TestChecksumMatch(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
@@ -268,8 +268,8 @@ func TestChecksumMatch(t *testing.T) {
 
 func TestSizeMismatchLong(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := testutils.NewLongMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := testutils.NewLongMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
@@ -288,8 +288,8 @@ func TestSizeMismatchLong(t *testing.T) {
 
 func TestSizeMismatchShort(t *testing.T) {
 	repo := tuf.NewRepo(nil, nil)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := testutils.NewShortMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := testutils.NewShortMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, nil, localStorage)
 
 	sampleTargets := data.NewTargets()
@@ -309,8 +309,8 @@ func TestSizeMismatchShort(t *testing.T) {
 func TestDownloadTargetsHappy(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	signedOrig, err := repo.SignTargets("targets", data.DefaultExpires("targets"))
@@ -337,8 +337,8 @@ func TestDownloadTargetsLarge(t *testing.T) {
 
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	hash := sha256.Sum256([]byte{})
@@ -375,8 +375,8 @@ func TestDownloadTargetsLarge(t *testing.T) {
 func TestDownloadTargetsDeepHappy(t *testing.T) {
 	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	delegations := []string{
@@ -450,8 +450,8 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 func TestDownloadTargetChecksumMismatch(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := testutils.NewCorruptingMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := testutils.NewCorruptingMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample targets
@@ -488,8 +488,8 @@ func TestDownloadTargetChecksumMismatch(t *testing.T) {
 func TestDownloadTargetsNoChecksum(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample targets
@@ -511,8 +511,8 @@ func TestDownloadTargetsNoChecksum(t *testing.T) {
 func TestDownloadTargetsNoSnapshot(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample targets
@@ -532,8 +532,8 @@ func TestDownloadTargetsNoSnapshot(t *testing.T) {
 func TestBootstrapDownloadRootHappy(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample root
@@ -554,8 +554,8 @@ func TestBootstrapDownloadRootHappy(t *testing.T) {
 func TestUpdateDownloadRootHappy(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample root, snapshot, and timestamp
@@ -574,11 +574,11 @@ func TestUpdateDownloadRootHappy(t *testing.T) {
 }
 
 func TestUpdateDownloadRootBadChecksum(t *testing.T) {
-	remoteStore := testutils.NewCorruptingMemoryStore(nil, nil)
+	remoteStore := testutils.NewCorruptingMemoryStore(nil)
 
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStore, kdb, localStorage)
 
 	// sign and "upload" sample root
@@ -598,10 +598,10 @@ func TestUpdateDownloadRootBadChecksum(t *testing.T) {
 }
 
 func TestUpdateDownloadRootChecksumNotFound(t *testing.T) {
-	remoteStore := store.NewMemoryStore(nil, nil)
+	remoteStore := store.NewMemoryStore(nil)
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStore, kdb, localStorage)
 
 	// sign snapshot to make sure we have current checksum for root
@@ -625,8 +625,8 @@ func TestUpdateDownloadRootChecksumNotFound(t *testing.T) {
 func TestDownloadTimestampHappy(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample timestamp
@@ -644,8 +644,8 @@ func TestDownloadTimestampHappy(t *testing.T) {
 func TestDownloadSnapshotHappy(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample snapshot and timestamp
@@ -676,8 +676,8 @@ func TestDownloadSnapshotLarge(t *testing.T) {
 	}
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// Add a ton of empty delegation roles to targets to make snapshot data huge
@@ -715,8 +715,8 @@ func TestDownloadSnapshotLarge(t *testing.T) {
 func TestDownloadSnapshotNoTimestamp(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample snapshot and timestamp
@@ -736,8 +736,8 @@ func TestDownloadSnapshotNoTimestamp(t *testing.T) {
 func TestDownloadSnapshotNoChecksum(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// create and "upload" sample snapshot and timestamp
@@ -757,8 +757,8 @@ func TestDownloadSnapshotNoChecksum(t *testing.T) {
 func TestDownloadSnapshotChecksumNotFound(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	// sign timestamp to ensure it has a checksum for snapshot
@@ -786,7 +786,7 @@ func TestDownloadSnapshotChecksumNotFound(t *testing.T) {
 func TestTargetMeta(t *testing.T) {
 	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, nil, kdb, localStorage)
 
 	delegations := []string{
@@ -840,8 +840,8 @@ func TestTargetMeta(t *testing.T) {
 func TestDownloadTimestampNoTimestamps(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	err = client.downloadTimestamp()
@@ -856,8 +856,8 @@ func TestDownloadTimestampNoTimestamps(t *testing.T) {
 func TestDownloadTimestampNoLocalTimestampRemoteTimestampEmpty(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
-	remoteStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: {}}, nil)
+	localStorage := store.NewMemoryStore(nil)
+	remoteStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: {}})
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	err = client.downloadTimestamp()
@@ -870,7 +870,7 @@ func TestDownloadTimestampNoLocalTimestampRemoteTimestampEmpty(t *testing.T) {
 func TestDownloadTimestampNoLocalTimestampRemoteTimestampInvalid(t *testing.T) {
 	kdb, repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(nil, nil)
+	localStorage := store.NewMemoryStore(nil)
 
 	// add a timestamp to the remote cache
 	tsSigned, err := repo.SignTimestamp(data.DefaultExpires("timestamp"))
@@ -878,7 +878,7 @@ func TestDownloadTimestampNoLocalTimestampRemoteTimestampInvalid(t *testing.T) {
 	tsSigned.Signatures[0].Signature = []byte("12345") // invalidate the signature
 	ts, err := json.Marshal(tsSigned)
 	assert.NoError(t, err)
-	remoteStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts}, nil)
+	remoteStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts})
 
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 	err = client.downloadTimestamp()
@@ -896,9 +896,9 @@ func TestDownloadTimestampLocalTimestampNoRemoteTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 	ts, err := json.Marshal(tsSigned)
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts}, nil)
+	localStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts})
 
-	remoteStorage := store.NewMemoryStore(nil, nil)
+	remoteStorage := store.NewMemoryStore(nil)
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 
 	err = client.downloadTimestamp()
@@ -915,13 +915,13 @@ func TestDownloadTimestampLocalTimestampInvalidRemoteTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 	ts, err := json.Marshal(tsSigned)
 	assert.NoError(t, err)
-	localStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts}, nil)
+	localStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts})
 
 	// add a timestamp to the remote cache
 	tsSigned.Signatures[0].Signature = []byte("12345") // invalidate the signature
 	ts, err = json.Marshal(tsSigned)
 	assert.NoError(t, err)
-	remoteStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts}, nil)
+	remoteStorage := store.NewMemoryStore(map[string][]byte{data.CanonicalTimestampRole: ts})
 
 	client := NewClient(repo, remoteStorage, kdb, localStorage)
 	err = client.downloadTimestamp()

--- a/tuf/store/filestore.go
+++ b/tuf/store/filestore.go
@@ -10,16 +10,11 @@ import (
 )
 
 // NewFilesystemStore creates a new store in a directory tree
-func NewFilesystemStore(baseDir, metaSubDir, metaExtension, targetsSubDir string) (*FilesystemStore, error) {
+func NewFilesystemStore(baseDir, metaSubDir, metaExtension string) (*FilesystemStore, error) {
 	metaDir := path.Join(baseDir, metaSubDir)
-	targetsDir := path.Join(baseDir, targetsSubDir)
 
 	// Make sure we can create the necessary dirs and they are writable
 	err := os.MkdirAll(metaDir, 0700)
-	if err != nil {
-		return nil, err
-	}
-	err = os.MkdirAll(targetsDir, 0700)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +23,6 @@ func NewFilesystemStore(baseDir, metaSubDir, metaExtension, targetsSubDir string
 		baseDir:       baseDir,
 		metaDir:       metaDir,
 		metaExtension: metaExtension,
-		targetsDir:    targetsDir,
 	}, nil
 }
 
@@ -37,7 +31,6 @@ type FilesystemStore struct {
 	baseDir       string
 	metaDir       string
 	metaExtension string
-	targetsDir    string
 }
 
 func (f *FilesystemStore) getPath(name string) string {

--- a/tuf/store/filestore_test.go
+++ b/tuf/store/filestore_test.go
@@ -13,7 +13,7 @@ import (
 const testDir = "/tmp/testFilesystemStore/"
 
 func TestNewFilesystemStore(t *testing.T) {
-	_, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	_, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
 
@@ -21,15 +21,10 @@ func TestNewFilesystemStore(t *testing.T) {
 	assert.Nil(t, err, "Error attempting to stat metadata dir: %v", err)
 	assert.NotNil(t, info, "Nil FileInfo from stat on metadata dir")
 	assert.True(t, 0700&info.Mode() != 0, "Metadata directory is not writable")
-
-	info, err = os.Stat(path.Join(testDir, "targets"))
-	assert.Nil(t, err, "Error attempting to stat targets dir: %v", err)
-	assert.NotNil(t, info, "Nil FileInfo from stat on targets dir")
-	assert.True(t, 0700&info.Mode() != 0, "Targets directory is not writable")
 }
 
 func TestSetMeta(t *testing.T) {
-	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
 
@@ -44,7 +39,7 @@ func TestSetMeta(t *testing.T) {
 }
 
 func TestSetMetaWithNoParentDirectory(t *testing.T) {
-	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
 
@@ -60,7 +55,7 @@ func TestSetMetaWithNoParentDirectory(t *testing.T) {
 
 // if something already existed there, remove it first and write a new file
 func TestSetMetaRemovesExistingFileBeforeWriting(t *testing.T) {
-	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
 
@@ -77,7 +72,7 @@ func TestSetMetaRemovesExistingFileBeforeWriting(t *testing.T) {
 }
 
 func TestGetMeta(t *testing.T) {
-	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
 
@@ -104,7 +99,7 @@ func TestGetMeta(t *testing.T) {
 }
 
 func TestGetSetMetadata(t *testing.T) {
-	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.NoError(t, err, "Initializing FilesystemStore returned unexpected error", err)
 	defer os.RemoveAll(testDir)
 
@@ -112,7 +107,7 @@ func TestGetSetMetadata(t *testing.T) {
 }
 
 func TestRemoveMetadata(t *testing.T) {
-	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.NoError(t, err, "Initializing FilesystemStore returned unexpected error", err)
 	defer os.RemoveAll(testDir)
 
@@ -120,7 +115,7 @@ func TestRemoveMetadata(t *testing.T) {
 }
 
 func TestRemoveAll(t *testing.T) {
-	s, err := NewFilesystemStore(testDir, "metadata", "json", "targets")
+	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	assert.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
 
@@ -129,8 +124,6 @@ func TestRemoveAll(t *testing.T) {
 	// Write some files in metadata and targets dirs
 	metaPath := path.Join(testDir, "metadata", "testMeta.json")
 	ioutil.WriteFile(metaPath, testContent, 0600)
-	targetsPath := path.Join(testDir, "targets", "testTargets.json")
-	ioutil.WriteFile(targetsPath, testContent, 0600)
 
 	// Remove all
 	err = s.RemoveAll()
@@ -138,8 +131,6 @@ func TestRemoveAll(t *testing.T) {
 
 	// Test that files no longer exist
 	_, err = ioutil.ReadFile(metaPath)
-	assert.True(t, os.IsNotExist(err))
-	_, err = ioutil.ReadFile(targetsPath)
 	assert.True(t, os.IsNotExist(err))
 
 	// Removing the empty filestore returns nil

--- a/tuf/store/httpstore.go
+++ b/tuf/store/httpstore.go
@@ -75,13 +75,12 @@ type HTTPStore struct {
 	baseURL       url.URL
 	metaPrefix    string
 	metaExtension string
-	targetsPrefix string
 	keyExtension  string
 	roundTrip     http.RoundTripper
 }
 
 // NewHTTPStore initializes a new store against a URL and a number of configuration options
-func NewHTTPStore(baseURL, metaPrefix, metaExtension, targetsPrefix, keyExtension string, roundTrip http.RoundTripper) (RemoteStore, error) {
+func NewHTTPStore(baseURL, metaPrefix, metaExtension, keyExtension string, roundTrip http.RoundTripper) (RemoteStore, error) {
 	base, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
@@ -96,7 +95,6 @@ func NewHTTPStore(baseURL, metaPrefix, metaExtension, targetsPrefix, keyExtensio
 		baseURL:       *base,
 		metaPrefix:    metaPrefix,
 		metaExtension: metaExtension,
-		targetsPrefix: targetsPrefix,
 		keyExtension:  keyExtension,
 		roundTrip:     roundTrip,
 	}, nil
@@ -258,11 +256,6 @@ func (s HTTPStore) buildMetaURL(name string) (*url.URL, error) {
 	return s.buildURL(uri)
 }
 
-func (s HTTPStore) buildTargetsURL(name string) (*url.URL, error) {
-	uri := path.Join(s.targetsPrefix, name)
-	return s.buildURL(uri)
-}
-
 func (s HTTPStore) buildKeyURL(name string) (*url.URL, error) {
 	filename := fmt.Sprintf("%s.%s", name, s.keyExtension)
 	uri := path.Join(s.metaPrefix, filename)
@@ -275,29 +268,6 @@ func (s HTTPStore) buildURL(uri string) (*url.URL, error) {
 		return nil, err
 	}
 	return s.baseURL.ResolveReference(sub), nil
-}
-
-// GetTarget returns a reader for the desired target or an error.
-// N.B. The caller is responsible for closing the reader.
-func (s HTTPStore) GetTarget(path string) (io.ReadCloser, error) {
-	url, err := s.buildTargetsURL(path)
-	if err != nil {
-		return nil, err
-	}
-	logrus.Debug("Attempting to download target: ", url.String())
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := s.roundTrip.RoundTrip(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if err := translateStatusToError(resp, path); err != nil {
-		return nil, err
-	}
-	return resp.Body, nil
 }
 
 // GetKey retrieves a public key from the remote server

--- a/tuf/store/httpstore_test.go
+++ b/tuf/store/httpstore_test.go
@@ -40,7 +40,6 @@ func TestHTTPStoreGetMeta(t *testing.T) {
 		server.URL,
 		"metadata",
 		"txt",
-		"targets",
 		"key",
 		&http.Transport{},
 	)
@@ -91,7 +90,6 @@ func TestHTTPStoreGetAllMeta(t *testing.T) {
 		server.URL,
 		"metadata",
 		"txt",
-		"targets",
 		"key",
 		&http.Transport{},
 	)
@@ -164,7 +162,7 @@ func TestSetMultiMeta(t *testing.T) {
 	}
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
-	store, err := NewHTTPStore(server.URL, "metadata", "json", "targets", "key", http.DefaultTransport)
+	store, err := NewHTTPStore(server.URL, "metadata", "json", "key", http.DefaultTransport)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +216,6 @@ func testErrorCode(t *testing.T, errorCode int, errType error) {
 		server.URL,
 		"metadata",
 		"txt",
-		"targets",
 		"key",
 		&http.Transport{},
 	)
@@ -302,7 +299,7 @@ func TestHTTPStoreRemoveAll(t *testing.T) {
 	}
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
-	store, err := NewHTTPStore(server.URL, "metadata", "json", "targets", "key", http.DefaultTransport)
+	store, err := NewHTTPStore(server.URL, "metadata", "json", "key", http.DefaultTransport)
 	assert.NoError(t, err)
 
 	// currently unsupported since there is no use case
@@ -312,7 +309,7 @@ func TestHTTPStoreRemoveAll(t *testing.T) {
 }
 
 func TestHTTPOffline(t *testing.T) {
-	s, err := NewHTTPStore("https://localhost/", "", "", "", "", nil)
+	s, err := NewHTTPStore("https://localhost/", "", "", "", nil)
 	assert.NoError(t, err)
 	assert.IsType(t, &OfflineStore{}, s)
 }

--- a/tuf/store/interfaces.go
+++ b/tuf/store/interfaces.go
@@ -1,11 +1,5 @@
 package store
 
-import (
-	"github.com/docker/notary/tuf/data"
-)
-
-type targetsWalkFunc func(path string, meta data.FileMeta) error
-
 // MetadataStore must be implemented by anything that intends to interact
 // with a store of TUF files
 type MetadataStore interface {

--- a/tuf/store/memorystore.go
+++ b/tuf/store/memorystore.go
@@ -11,7 +11,7 @@ import (
 
 // NewMemoryStore returns a MetadataStore that operates entirely in memory.
 // Very useful for testing
-func NewMemoryStore(meta map[string][]byte, files map[string][]byte) *MemoryStore {
+func NewMemoryStore(meta map[string][]byte) *MemoryStore {
 	var consistent = make(map[string][]byte)
 	if meta == nil {
 		meta = make(map[string][]byte)
@@ -23,13 +23,9 @@ func NewMemoryStore(meta map[string][]byte, files map[string][]byte) *MemoryStor
 			consistent[path] = data
 		}
 	}
-	if files == nil {
-		files = make(map[string][]byte)
-	}
 	return &MemoryStore{
 		meta:       meta,
 		consistent: consistent,
-		files:      files,
 		keys:       make(map[string][]data.PrivateKey),
 	}
 }
@@ -39,7 +35,6 @@ func NewMemoryStore(meta map[string][]byte, files map[string][]byte) *MemoryStor
 type MemoryStore struct {
 	meta       map[string][]byte
 	consistent map[string][]byte
-	files      map[string][]byte
 	keys       map[string][]data.PrivateKey
 }
 
@@ -106,6 +101,6 @@ func (m *MemoryStore) GetKey(role string) ([]byte, error) {
 
 // RemoveAll clears the existing memory store by setting this store as new empty one
 func (m *MemoryStore) RemoveAll() error {
-	*m = *NewMemoryStore(nil, nil)
+	*m = *NewMemoryStore(nil)
 	return nil
 }

--- a/tuf/store/memorystore_test.go
+++ b/tuf/store/memorystore_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestMemoryStore(t *testing.T) {
-	s := NewMemoryStore(nil, nil)
+	s := NewMemoryStore(nil)
 	_, err := s.GetMeta("nonexistent", 0)
 	require.Error(t, err)
 	require.IsType(t, ErrMetaNotFound{}, err)

--- a/tuf/store/store_test.go
+++ b/tuf/store/store_test.go
@@ -41,7 +41,7 @@ func testRemoveMeta(t *testing.T, factory storeFactory) {
 
 func TestMemoryStoreMetadata(t *testing.T) {
 	factory := func() MetadataStore {
-		return NewMemoryStore(nil, nil)
+		return NewMemoryStore(nil)
 	}
 
 	testGetSetMeta(t, factory)

--- a/tuf/testutils/corrupt_memorystore.go
+++ b/tuf/testutils/corrupt_memorystore.go
@@ -11,8 +11,8 @@ type CorruptingMemoryStore struct {
 
 // NewCorruptingMemoryStore returns a new instance of memory store that
 // corrupts all data requested from it.
-func NewCorruptingMemoryStore(meta map[string][]byte, files map[string][]byte) *CorruptingMemoryStore {
-	s := store.NewMemoryStore(meta, files)
+func NewCorruptingMemoryStore(meta map[string][]byte) *CorruptingMemoryStore {
+	s := store.NewMemoryStore(meta)
 	return &CorruptingMemoryStore{MemoryStore: *s}
 }
 
@@ -34,8 +34,8 @@ type LongMemoryStore struct {
 
 // NewLongMemoryStore returns a new instance of memory store that
 // returns one byte too much data on any request to GetMeta
-func NewLongMemoryStore(meta map[string][]byte, files map[string][]byte) *LongMemoryStore {
-	s := store.NewMemoryStore(meta, files)
+func NewLongMemoryStore(meta map[string][]byte) *LongMemoryStore {
+	s := store.NewMemoryStore(meta)
 	return &LongMemoryStore{MemoryStore: *s}
 }
 
@@ -56,8 +56,8 @@ type ShortMemoryStore struct {
 
 // NewShortMemoryStore returns a new instance of memory store that
 // returns one byte too little data on any request to GetMeta
-func NewShortMemoryStore(meta map[string][]byte, files map[string][]byte) *ShortMemoryStore {
-	s := store.NewMemoryStore(meta, files)
+func NewShortMemoryStore(meta map[string][]byte) *ShortMemoryStore {
+	s := store.NewMemoryStore(meta)
 	return &ShortMemoryStore{MemoryStore: *s}
 }
 

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -109,7 +109,7 @@ func NewMetadataSwizzler(gun string, initialMetadata map[string][]byte,
 
 	return &MetadataSwizzler{
 		Gun:           gun,
-		MetadataCache: store.NewMemoryStore(initialMetadata, nil),
+		MetadataCache: store.NewMemoryStore(initialMetadata),
 		CryptoService: cryptoService,
 		Roles:         roles,
 	}


### PR DESCRIPTION
Notary does not download actual targets, this removes the last bits of dead code related to that functionality.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)