### PR TITLE
Non-root key import and export CLI

### DIFF
--- a/cmd/notary/integration_nonpkcs11_test.go
+++ b/cmd/notary/integration_nonpkcs11_test.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	NewNotaryCommand = func() *cobra.Command {
 		commander := &notaryCommander{
-			getRetriever: func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+			getRetriever: func() passphrase.Retriever { return passphrase.ConstantRetriever(testPassphrase) },
 		}
 		return commander.GetCommand()
 	}

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -52,10 +52,10 @@ var cmdKeysBackupTemplate = usageTemplate{
 	Long:  "Backs up all of your accessible of keys. The keys are reencrypted with a new passphrase. The output is a ZIP file.  If the --gun option is passed, only signing keys and no root keys will be backed up.  Does not work on keys that are only in hardware (e.g. Yubikeys).",
 }
 
-var cmdKeyExportRootTemplate = usageTemplate{
+var cmdKeyExportTemplate = usageTemplate{
 	Use:   "export [ keyID ] [ pemfilename ]",
-	Short: "Export a root key on disk to a PEM file.",
-	Long:  "Exports a single root key on disk, without reencrypting. The output is a PEM file. Does not work on keys that are only in hardware (e.g. Yubikeys).",
+	Short: "Export a private key on disk to a PEM file.",
+	Long:  "Exports a single private key on disk, without reencrypting. The output is a PEM file. Does not work on keys that are only in hardware (e.g. Yubikeys).",
 }
 
 var cmdKeysRestoreTemplate = usageTemplate{
@@ -64,10 +64,10 @@ var cmdKeysRestoreTemplate = usageTemplate{
 	Long:  "Restores one or more keys from a ZIP file. If hardware key storage (e.g. a Yubikey) is available, root keys will be imported into the hardware, but not backed up to disk in the same location as the other, non-root keys.",
 }
 
-var cmdKeyImportRootTemplate = usageTemplate{
+var cmdKeyImportTemplate = usageTemplate{
 	Use:   "import [ pemfilename ]",
-	Short: "Imports a root key from a PEM file.",
-	Long:  "Imports a single root key from a PEM file. If a hardware key storage (e.g. Yubikey) is available, the root key will be imported into the hardware but not backed up on disk again.",
+	Short: "Imports a key from a PEM file.",
+	Long:  "Imports a single key from a PEM file. If a hardware key storage (e.g. Yubikey) is available, the root key will be imported into the hardware but not backed up on disk again.",
 }
 
 var cmdKeyRemoveTemplate = usageTemplate{
@@ -88,7 +88,7 @@ type keyCommander struct {
 	getRetriever func() passphrase.Retriever
 
 	// these are for command line parsing - no need to set
-	keysExportRootChangePassphrase bool
+	keysExportChangePassphrase     bool
 	keysExportGUN                  string
 	rotateKeyRole                  string
 	rotateKeyServerManaged         bool
@@ -99,7 +99,8 @@ func (k *keyCommander) GetCommand() *cobra.Command {
 	cmd.AddCommand(cmdKeyListTemplate.ToCommand(k.keysList))
 	cmd.AddCommand(cmdKeyGenerateRootKeyTemplate.ToCommand(k.keysGenerateRootKey))
 	cmd.AddCommand(cmdKeysRestoreTemplate.ToCommand(k.keysRestore))
-	cmd.AddCommand(cmdKeyImportRootTemplate.ToCommand(k.keysImportRoot))
+	cmd.AddCommand(cmdKeyImportTemplate.ToCommand(k.keysImportRoot))
+
 	cmd.AddCommand(cmdKeyRemoveTemplate.ToCommand(k.keyRemove))
 	cmd.AddCommand(cmdKeyPasswdTemplate.ToCommand(k.keyPassphraseChange))
 
@@ -108,11 +109,11 @@ func (k *keyCommander) GetCommand() *cobra.Command {
 		&k.keysExportGUN, "gun", "g", "", "Globally Unique Name to export keys for")
 	cmd.AddCommand(cmdKeysBackup)
 
-	cmdKeyExportRoot := cmdKeyExportRootTemplate.ToCommand(k.keysExportRoot)
-	cmdKeyExportRoot.Flags().BoolVarP(
-		&k.keysExportRootChangePassphrase, "change-passphrase", "p", false,
+	cmdKeyExport := cmdKeyExportTemplate.ToCommand(k.keysExport)
+	cmdKeyExport.Flags().BoolVarP(
+		&k.keysExportChangePassphrase, "change-passphrase", "p", false,
 		"Set a new passphrase for the key being exported")
-	cmd.AddCommand(cmdKeyExportRoot)
+	cmd.AddCommand(cmdKeyExport)
 
 	cmdRotateKey := cmdRotateKeyTemplate.ToCommand(k.keysRotate)
 	cmdRotateKey.Flags().BoolVarP(&k.rotateKeyServerManaged, "server-managed", "r",
@@ -236,8 +237,8 @@ func (k *keyCommander) keysBackup(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// keysExportRoot exports a root key by ID to a PEM file
-func (k *keyCommander) keysExportRoot(cmd *cobra.Command, args []string) error {
+// keysExport exports a key by ID to a PEM file
+func (k *keyCommander) keysExport(cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		cmd.Usage()
 		return fmt.Errorf("Must specify key ID and output filename for export")
@@ -247,7 +248,7 @@ func (k *keyCommander) keysExportRoot(cmd *cobra.Command, args []string) error {
 	exportFilename := args[1]
 
 	if len(keyID) != notary.Sha256HexSize {
-		return fmt.Errorf("Please specify a valid root key ID")
+		return fmt.Errorf("Please specify a valid key ID")
 	}
 
 	config, err := k.configGetter()
@@ -258,24 +259,43 @@ func (k *keyCommander) keysExportRoot(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cs := cryptoservice.NewCryptoService("", ks...)
+
+	// Search for this key, determine whether this key has a GUN
+	keyGun := ""
+	keyRole := ""
+	for _, store := range ks {
+		for keypath, role := range store.ListKeys() {
+			if filepath.Base(keypath) == keyID {
+				keyRole = role
+				if role != data.CanonicalRootRole {
+					dirPath := filepath.Dir(keypath)
+					if dirPath != "." { // no gun
+						keyGun = dirPath
+					}
+				}
+				break
+			}
+		}
+	}
+
+	cs := cryptoservice.NewCryptoService(keyGun, ks...)
 
 	exportFile, err := os.Create(exportFilename)
 	if err != nil {
 		return fmt.Errorf("Error creating output file: %v", err)
 	}
-	if k.keysExportRootChangePassphrase {
+	if k.keysExportChangePassphrase {
 		// Must use a different passphrase retriever to avoid caching the
 		// unlocking passphrase and reusing that.
 		exportRetriever := k.getRetriever()
-		err = cs.ExportRootKeyReencrypt(exportFile, keyID, exportRetriever)
+		err = cs.ExportKeyReencrypt(exportFile, keyID, exportRetriever)
 	} else {
-		err = cs.ExportRootKey(exportFile, keyID)
+		err = cs.ExportKey(exportFile, keyID, keyRole)
 	}
 	exportFile.Close()
 	if err != nil {
 		os.Remove(exportFilename)
-		return fmt.Errorf("Error exporting root key: %v", err)
+		return fmt.Errorf("Error exporting %s key: %v", keyRole, err)
 	}
 	return nil
 }

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -103,7 +103,7 @@ func (k *keyCommander) GetCommand() *cobra.Command {
 	cmd.AddCommand(cmdKeysRestoreTemplate.ToCommand(k.keysRestore))
 	cmdKeysImport := cmdKeyImportTemplate.ToCommand(k.keysImport)
 	cmdKeysImport.Flags().StringVarP(
-		&k.keysExportGUN, "gun", "g", "", "Globally Unique Name to import key to")
+		&k.keysImportGUN, "gun", "g", "", "Globally Unique Name to import key to")
 	cmdKeysImport.Flags().StringVarP(
 		&k.keysImportRole, "role", "r", data.CanonicalRootRole, "Role to import key to")
 	cmd.AddCommand(cmdKeysImport)
@@ -267,7 +267,7 @@ func (k *keyCommander) keysExport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Search for this key, determine whether this key has a GUN
+	// Search for this key in all of our keystores, determine whether this key has a GUN
 	keyGun := ""
 	keyRole := ""
 	for _, store := range ks {
@@ -340,7 +340,7 @@ func (k *keyCommander) keysRestore(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// keysImport imports a private key from a PEM file
+// keysImport imports a private key from a PEM file for a role
 func (k *keyCommander) keysImport(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		cmd.Usage()
@@ -368,7 +368,7 @@ func (k *keyCommander) keysImport(cmd *cobra.Command, args []string) error {
 	if k.keysImportRole == data.CanonicalRootRole {
 		err = cs.ImportRootKey(importFile)
 	} else {
-		err = cs.ImportRoleKey(importFile, k.keysImportRole)
+		err = cs.ImportRoleKey(importFile, k.keysImportRole, k.retriever)
 	}
 
 	if err != nil {

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -433,3 +433,130 @@ func TestChangeKeyPassphraseNonexistentID(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not retrieve local key for key ID provided")
 }
+
+func TestKeyImportInvalidFlagRole(t *testing.T) {
+	k := &keyCommander{
+		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+		keysImportRole: "invalid",
+	}
+	tempFileName := generateTempTestKeyFile(t, "invalid")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid role specified for key:")
+}
+
+func TestKeyImportInvalidPEMRole(t *testing.T) {
+	k := &keyCommander{
+		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+		keysImportRole: "targets",
+	}
+	tempFileName := generateTempTestKeyFile(t, "invalid")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid role specified for key:")
+}
+
+func TestKeyImportMismatchingRoles(t *testing.T) {
+	k := &keyCommander{
+		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+		keysImportRole: "targets",
+	}
+	tempFileName := generateTempTestKeyFile(t, "snapshot")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match role")
+}
+
+func TestKeyImportNoGUNForTargetsPEM(t *testing.T) {
+	k := &keyCommander{
+		configGetter: func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever: func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+	}
+	tempFileName := generateTempTestKeyFile(t, "targets")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Must specify GUN")
+}
+
+func TestKeyImportNoGUNForSnapshotPEM(t *testing.T) {
+	k := &keyCommander{
+		configGetter: func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever: func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+	}
+	tempFileName := generateTempTestKeyFile(t, "snapshot")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Must specify GUN")
+}
+
+func TestKeyImportNoGUNForTargetsFlag(t *testing.T) {
+	k := &keyCommander{
+		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+		keysImportRole: "targets",
+	}
+	tempFileName := generateTempTestKeyFile(t, "")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Must specify GUN")
+}
+
+func TestKeyImportNoGUNForSnapshotFlag(t *testing.T) {
+	k := &keyCommander{
+		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+		keysImportRole: "snapshot",
+	}
+	tempFileName := generateTempTestKeyFile(t, "")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Must specify GUN")
+}
+
+func TestKeyImportNoRole(t *testing.T) {
+	k := &keyCommander{
+		configGetter: func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever: func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
+	}
+	tempFileName := generateTempTestKeyFile(t, "")
+	defer os.Remove(tempFileName)
+
+	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Could not infer role, and no role was specified for key")
+}
+
+func generateTempTestKeyFile(t *testing.T, role string) string {
+	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
+	if err != nil {
+		return ""
+	}
+	keyBytes, err := trustmanager.KeyToPEM(privKey, role)
+	assert.NoError(t, err)
+
+	tempPrivFile, err := ioutil.TempFile("/tmp", "privfile")
+	assert.NoError(t, err)
+
+	// Write the private key to a file so we can import it
+	_, err = tempPrivFile.Write(keyBytes)
+	assert.NoError(t, err)
+	tempPrivFile.Close()
+	return tempPrivFile.Name()
+}

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -434,33 +434,6 @@ func TestChangeKeyPassphraseNonexistentID(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not retrieve local key for key ID provided")
 }
 
-func TestKeyImportInvalidFlagRole(t *testing.T) {
-	k := &keyCommander{
-		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },
-		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
-		keysImportRole: "invalid",
-	}
-	tempFileName := generateTempTestKeyFile(t, "")
-	defer os.Remove(tempFileName)
-
-	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Invalid role specified for key:")
-}
-
-func TestKeyImportInvalidPEMRole(t *testing.T) {
-	k := &keyCommander{
-		configGetter: func() (*viper.Viper, error) { return viper.New(), nil },
-		getRetriever: func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
-	}
-	tempFileName := generateTempTestKeyFile(t, "invalid")
-	defer os.Remove(tempFileName)
-
-	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Invalid role specified for key:")
-}
-
 func TestKeyImportMismatchingRoles(t *testing.T) {
 	k := &keyCommander{
 		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -440,7 +440,7 @@ func TestKeyImportInvalidFlagRole(t *testing.T) {
 		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
 		keysImportRole: "invalid",
 	}
-	tempFileName := generateTempTestKeyFile(t, "invalid")
+	tempFileName := generateTempTestKeyFile(t, "")
 	defer os.Remove(tempFileName)
 
 	err := k.keysImport(&cobra.Command{}, []string{tempFileName})
@@ -450,9 +450,8 @@ func TestKeyImportInvalidFlagRole(t *testing.T) {
 
 func TestKeyImportInvalidPEMRole(t *testing.T) {
 	k := &keyCommander{
-		configGetter:   func() (*viper.Viper, error) { return viper.New(), nil },
-		getRetriever:   func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
-		keysImportRole: "targets",
+		configGetter: func() (*viper.Viper, error) { return viper.New(), nil },
+		getRetriever: func() passphrase.Retriever { return passphrase.ConstantRetriever("pass") },
 	}
 	tempFileName := generateTempTestKeyFile(t, "invalid")
 	defer os.Remove(tempFileName)

--- a/const.go
+++ b/const.go
@@ -18,4 +18,10 @@ const (
 	Sha256HexSize = 64
 	// TrustedCertsDir is the directory, under the notary repo base directory, where trusted certs are stored
 	TrustedCertsDir = "trusted_certificates"
+	// PrivDir is the directory, under the notary repo base directory, where private keys are stored
+	PrivDir = "private"
+	// RootKeysSubdir is the subdirectory under PrivDir where root private keys are stored
+	RootKeysSubdir = "root_keys"
+	// NonRootKeysSubdir is the subdirectory under PrivDir where non-root private keys are stored
+	NonRootKeysSubdir = "tuf_keys"
 )

--- a/cryptoservice/import_export.go
+++ b/cryptoservice/import_export.go
@@ -104,19 +104,19 @@ func (cs *CryptoService) ExportKeyReencrypt(dest io.Writer, keyID string, newPas
 // It prompts for the key's passphrase to verify the data and to determine
 // the key ID.
 func (cs *CryptoService) ImportRootKey(source io.Reader) error {
-	return cs.ImportRoleKey(source, data.CanonicalRootRole, nil)
-}
-
-// ImportRoleKey imports a private key in PEM format key from an io.Reader
-// It prompts for the key's passphrase to verify the data and to determine
-// the key ID.
-func (cs *CryptoService) ImportRoleKey(source io.Reader, role string, newPassphraseRetriever passphrase.Retriever) error {
 	pemBytes, err := ioutil.ReadAll(source)
-
 	if err != nil {
 		return err
 	}
+	return cs.ImportRoleKey(pemBytes, data.CanonicalRootRole, nil)
+}
+
+// ImportRoleKey imports a private key in PEM format key from a byte array
+// It prompts for the key's passphrase to verify the data and to determine
+// the key ID.
+func (cs *CryptoService) ImportRoleKey(pemBytes []byte, role string, newPassphraseRetriever passphrase.Retriever) error {
 	var alias string
+	var err error
 	if role == data.CanonicalRootRole {
 		alias = role
 		if err = checkRootKeyIsEncrypted(pemBytes); err != nil {

--- a/cryptoservice/import_export.go
+++ b/cryptoservice/import_export.go
@@ -112,6 +112,7 @@ func (cs *CryptoService) ImportRootKey(source io.Reader) error {
 // the key ID.
 func (cs *CryptoService) ImportRoleKey(source io.Reader, role string, newPassphraseRetriever passphrase.Retriever) error {
 	pemBytes, err := ioutil.ReadAll(source)
+
 	if err != nil {
 		return err
 	}

--- a/cryptoservice/import_export.go
+++ b/cryptoservice/import_export.go
@@ -41,10 +41,10 @@ func (cs *CryptoService) ExportKey(dest io.Writer, keyID, role string) error {
 		err      error
 	)
 
+	if role != data.CanonicalRootRole {
+		keyID = filepath.Join(cs.gun, keyID)
+	}
 	for _, ks := range cs.keyStores {
-		if role != data.CanonicalRootRole {
-			keyID = filepath.Join(cs.gun, keyID)
-		}
 		pemBytes, err = ks.ExportKey(keyID)
 		if err != nil {
 			continue

--- a/cryptoservice/import_export.go
+++ b/cryptoservice/import_export.go
@@ -103,18 +103,27 @@ func (cs *CryptoService) ExportKeyReencrypt(dest io.Writer, keyID string, newPas
 // It prompts for the key's passphrase to verify the data and to determine
 // the key ID.
 func (cs *CryptoService) ImportRootKey(source io.Reader) error {
+	return cs.ImportRoleKey(source, data.CanonicalRootRole)
+}
+
+// ImportRoleKey imports a private key in PEM format key from an io.Reader
+// It prompts for the key's passphrase to verify the data and to determine
+// the key ID.
+func (cs *CryptoService) ImportRoleKey(source io.Reader, role string) error {
 	pemBytes, err := ioutil.ReadAll(source)
 	if err != nil {
 		return err
 	}
 
-	if err = checkRootKeyIsEncrypted(pemBytes); err != nil {
-		return err
+	if role == data.CanonicalRootRole {
+		if err = checkRootKeyIsEncrypted(pemBytes); err != nil {
+			return err
+		}
 	}
 
 	for _, ks := range cs.keyStores {
 		// don't redeclare err, we want the value carried out of the loop
-		if err = ks.ImportKey(pemBytes, data.CanonicalRootRole); err == nil {
+		if err = ks.ImportKey(pemBytes, role); err == nil {
 			return nil //bail on the first keystore we import to
 		}
 	}

--- a/cryptoservice/import_export_test.go
+++ b/cryptoservice/import_export_test.go
@@ -77,7 +77,7 @@ func TestImportExportZip(t *testing.T) {
 		_, alias, err := cs.GetPrivateKey(privKeyName)
 		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
 
-		if alias == "root" {
+		if alias == data.CanonicalRootRole {
 			continue
 		}
 		relKeyPath := filepath.Join("tuf_keys", privKeyName+".key")
@@ -138,7 +138,7 @@ func TestImportExportZip(t *testing.T) {
 		_, alias, err := cs2.GetPrivateKey(privKeyName)
 		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
 
-		if alias == "root" {
+		if alias == data.CanonicalRootRole {
 			continue
 		}
 		relKeyPath := filepath.Join("tuf_keys", privKeyName+".key")
@@ -196,7 +196,7 @@ func TestImportExportGUN(t *testing.T) {
 	for privKeyName := range privKeyMap {
 		_, alias, err := cs.GetPrivateKey(privKeyName)
 		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
-		if alias == "root" {
+		if alias == data.CanonicalRootRole {
 			continue
 		}
 		relKeyPath := filepath.Join("tuf_keys", privKeyName+".key")
@@ -250,12 +250,12 @@ func TestImportExportGUN(t *testing.T) {
 	// Look for keys in private. The filenames should match the key IDs
 	// in the repo's private key store.
 	for privKeyName, role := range privKeyMap {
-		if role == "root" {
+		if role == data.CanonicalRootRole {
 			continue
 		}
 		_, alias, err := cs2.GetPrivateKey(privKeyName)
 		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
-		if alias == "root" {
+		if alias == data.CanonicalRootRole {
 			continue
 		}
 		relKeyPath := filepath.Join("tuf_keys", privKeyName+".key")
@@ -329,7 +329,7 @@ func TestImportExportRootKey(t *testing.T) {
 	// Should be able to unlock the root key with the old password
 	key, alias, err := cs2.GetPrivateKey(rootKeyID)
 	assert.NoError(t, err, "could not unlock root key")
-	assert.Equal(t, "root", alias)
+	assert.Equal(t, data.CanonicalRootRole, alias)
 	assert.Equal(t, rootKeyID, key.ID())
 }
 
@@ -381,7 +381,7 @@ func TestImportExportRootKeyReencrypt(t *testing.T) {
 	// Should be able to unlock the root key with the new password
 	key, alias, err := cs2.GetPrivateKey(rootKeyID)
 	assert.NoError(t, err, "could not unlock root key")
-	assert.Equal(t, "root", alias)
+	assert.Equal(t, data.CanonicalRootRole, alias)
 	assert.Equal(t, rootKeyID, key.ID())
 }
 
@@ -419,7 +419,10 @@ func TestImportExportNonRootKey(t *testing.T) {
 	keyReader, err := os.Open(tempKeyFilePath)
 	assert.NoError(t, err, "could not open key file")
 
-	err = cs2.ImportRoleKey(keyReader, data.CanonicalTargetsRole, oldPassphraseRetriever)
+	pemBytes, err := ioutil.ReadAll(keyReader)
+	assert.NoError(t, err, "could not read key file")
+
+	err = cs2.ImportRoleKey(pemBytes, data.CanonicalTargetsRole, oldPassphraseRetriever)
 	assert.NoError(t, err)
 	keyReader.Close()
 
@@ -433,7 +436,7 @@ func TestImportExportNonRootKey(t *testing.T) {
 	// Check that the key is the same
 	key, alias, err := cs2.GetPrivateKey(targetsKeyID)
 	assert.NoError(t, err, "could not unlock targets key")
-	assert.Equal(t, "targets", alias)
+	assert.Equal(t, data.CanonicalTargetsRole, alias)
 	assert.Equal(t, targetsKeyID, key.ID())
 }
 
@@ -471,7 +474,10 @@ func TestImportExportNonRootKeyReencrypt(t *testing.T) {
 	keyReader, err := os.Open(tempKeyFilePath)
 	assert.NoError(t, err, "could not open key file")
 
-	err = cs2.ImportRoleKey(keyReader, "snapshot", newPassphraseRetriever)
+	pemBytes, err := ioutil.ReadAll(keyReader)
+	assert.NoError(t, err, "could not read key file")
+
+	err = cs2.ImportRoleKey(pemBytes, data.CanonicalSnapshotRole, newPassphraseRetriever)
 	assert.NoError(t, err)
 	keyReader.Close()
 
@@ -485,6 +491,6 @@ func TestImportExportNonRootKeyReencrypt(t *testing.T) {
 	// Should be able to unlock the root key with the new password
 	key, alias, err := cs2.GetPrivateKey(snapshotKeyID)
 	assert.NoError(t, err, "could not unlock snapshot key")
-	assert.Equal(t, "snapshot", alias)
+	assert.Equal(t, data.CanonicalSnapshotRole, alias)
 	assert.Equal(t, snapshotKeyID, key.ID())
 }

--- a/cryptoservice/import_export_test.go
+++ b/cryptoservice/import_export_test.go
@@ -284,7 +284,7 @@ func TestImportExportRootKey(t *testing.T) {
 	tempKeyFilePath := tempKeyFile.Name()
 	defer os.Remove(tempKeyFilePath)
 
-	err = cs.ExportRootKey(tempKeyFile, rootKeyID)
+	err = cs.ExportKey(tempKeyFile, rootKeyID, data.CanonicalRootRole)
 	assert.NoError(t, err)
 	tempKeyFile.Close()
 
@@ -352,7 +352,7 @@ func TestImportExportRootKeyReencrypt(t *testing.T) {
 	tempKeyFilePath := tempKeyFile.Name()
 	defer os.Remove(tempKeyFilePath)
 
-	err = cs.ExportRootKeyReencrypt(tempKeyFile, rootKeyID, newPassphraseRetriever)
+	err = cs.ExportKeyReencrypt(tempKeyFile, rootKeyID, newPassphraseRetriever)
 	assert.NoError(t, err)
 	tempKeyFile.Close()
 

--- a/cryptoservice/import_export_test.go
+++ b/cryptoservice/import_export_test.go
@@ -390,8 +390,7 @@ func TestImportExportNonRootKey(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	fmt.Println(tempBaseDir)
-	//defer os.RemoveAll(tempBaseDir)
+	defer os.RemoveAll(tempBaseDir)
 	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore, err := trustmanager.NewKeyFileStore(tempBaseDir, oldPassphraseRetriever)
@@ -411,8 +410,7 @@ func TestImportExportNonRootKey(t *testing.T) {
 
 	// Create new repo to test import
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
-	fmt.Println(tempBaseDir2)
-	//defer os.RemoveAll(tempBaseDir2)
+	defer os.RemoveAll(tempBaseDir2)
 	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore2, err := trustmanager.NewKeyFileStore(tempBaseDir2, oldPassphraseRetriever)

--- a/trustmanager/x509utils.go
+++ b/trustmanager/x509utils.go
@@ -515,7 +515,6 @@ func EncryptPrivateKey(key data.PrivateKey, role, passphrase string) ([]byte, er
 }
 
 // ReadRoleFromPEM returns the value from the role PEM header, if it exists
-// If it doesn't exist, returns nil
 func ReadRoleFromPEM(pemBytes []byte) string {
 	pemBlock, _ := pem.Decode(pemBytes)
 	if pemBlock.Headers == nil {

--- a/trustmanager/x509utils.go
+++ b/trustmanager/x509utils.go
@@ -514,6 +514,20 @@ func EncryptPrivateKey(key data.PrivateKey, role, passphrase string) ([]byte, er
 	return pem.EncodeToMemory(encryptedPEMBlock), nil
 }
 
+// ReadRoleFromPEM returns the value from the role PEM header, if it exists
+// If it doesn't exist, returns nil
+func ReadRoleFromPEM(pemBytes []byte) string {
+	pemBlock, _ := pem.Decode(pemBytes)
+	if pemBlock.Headers == nil {
+		return ""
+	}
+	role, ok := pemBlock.Headers["role"]
+	if !ok {
+		return ""
+	}
+	return role
+}
+
 // CertToKey transforms a single input certificate into its corresponding
 // PublicKey
 func CertToKey(cert *x509.Certificate) data.PublicKey {


### PR DESCRIPTION
Allows for importing and exporting non-root keys via notary CLI.  This also works for importing delegation keys:

`notary key import <file> --role <ROLE> --gun <GUN>`

The default role is root, so that the behavior of `notary key import <file>` remains unchanged.

export is the same but now also can export non-root keys by ID:

`notary key export <keyID> <file>`

I also made "private", "tuf_keys", and "root_keys" constants in `const.go`

Partially addresses #483 (`passwd` can be a separate PR, along with changes to passphrase retriever)