### PR TITLE
Separately ask for snapshot password with passphrase retriever

### DIFF
--- a/passphrase/passphrase.go
+++ b/passphrase/passphrase.go
@@ -61,10 +61,12 @@ func PromptRetriever() Retriever {
 // aliasMap can be used to specify display names for TUF key aliases. If aliasMap
 // is nil, a sensible default will be used.
 func PromptRetrieverWithInOut(in io.Reader, out io.Writer, aliasMap map[string]string) Retriever {
-	userEnteredTargetsSnapshotsPass := false
-	targetsSnapshotsPass := ""
-	userEnteredRootsPass := false
-	rootsPass := ""
+	userEnteredTargetsPass := false
+	targetsPass := ""
+	userEnteredSnapshotPass := false
+	snapshotPass := ""
+	userEnteredRootPass := false
+	rootPass := ""
 
 	return func(keyName string, alias string, createNew bool, numAttempts int) (string, bool, error) {
 		if alias == tufRootAlias && createNew && numAttempts == 0 {
@@ -87,11 +89,19 @@ func PromptRetrieverWithInOut(in io.Reader, out io.Writer, aliasMap map[string]s
 
 		// First, check if we have a password cached for this alias.
 		if numAttempts == 0 {
-			if userEnteredTargetsSnapshotsPass && (alias == tufSnapshotAlias || alias == tufTargetsAlias) {
-				return targetsSnapshotsPass, false, nil
-			}
-			if userEnteredRootsPass && (alias == "root") {
-				return rootsPass, false, nil
+			switch alias {
+			case tufTargetsAlias:
+				if userEnteredTargetsPass {
+					return targetsPass, false, nil
+				}
+			case tufSnapshotAlias:
+				if userEnteredSnapshotPass {
+					return snapshotPass, false, nil
+				}
+			case tufRootAlias:
+				if userEnteredRootPass {
+					return rootPass, false, nil
+				}
 			}
 		}
 
@@ -150,13 +160,16 @@ func PromptRetrieverWithInOut(in io.Reader, out io.Writer, aliasMap map[string]s
 		retPass := strings.TrimSpace(string(passphrase))
 
 		if !createNew {
-			if alias == tufSnapshotAlias || alias == tufTargetsAlias {
-				userEnteredTargetsSnapshotsPass = true
-				targetsSnapshotsPass = retPass
-			}
-			if alias == tufRootAlias {
-				userEnteredRootsPass = true
-				rootsPass = retPass
+			switch alias {
+			case tufTargetsAlias:
+				userEnteredTargetsPass = true
+				targetsPass = retPass
+			case tufSnapshotAlias:
+				userEnteredSnapshotPass = true
+				snapshotPass = retPass
+			case tufRootAlias:
+				userEnteredRootPass = true
+				rootPass = retPass
 			}
 			return retPass, false, nil
 		}
@@ -179,13 +192,16 @@ func PromptRetrieverWithInOut(in io.Reader, out io.Writer, aliasMap map[string]s
 			return "", false, ErrDontMatch
 		}
 
-		if alias == tufSnapshotAlias || alias == tufTargetsAlias {
-			userEnteredTargetsSnapshotsPass = true
-			targetsSnapshotsPass = retPass
-		}
-		if alias == tufRootAlias {
-			userEnteredRootsPass = true
-			rootsPass = retPass
+		switch alias {
+		case tufTargetsAlias:
+			userEnteredTargetsPass = true
+			targetsPass = retPass
+		case tufSnapshotAlias:
+			userEnteredSnapshotPass = true
+			snapshotPass = retPass
+		case tufRootAlias:
+			userEnteredRootPass = true
+			rootPass = retPass
 		}
 
 		return retPass, false, nil

--- a/passphrase/passphrase_test.go
+++ b/passphrase/passphrase_test.go
@@ -68,11 +68,9 @@ func TestGetPassphraseForCreatingDelegationKey(t *testing.T) {
 	require.Equal(t, expectedText, lines)
 }
 
-// PromptRetrieverWithInOut, if asked for root, targets, delegation, and
-// snapshot passphrases in that order will only prompt for root, targets, and
-// delegation passphrases because it caches the targets password and uses it
-// for snapshot.
-func TestGetRootTargetsDelegation(t *testing.T) {
+// PromptRetrieverWithInOut, if asked for root, targets, snapshot, and delegation
+// passphrases in that order will cache each of the keys except for the delegation key
+func TestRolePromptingAndCaching(t *testing.T) {
 	var in bytes.Buffer
 	var out bytes.Buffer
 
@@ -80,16 +78,38 @@ func TestGetRootTargetsDelegation(t *testing.T) {
 
 	assertAskOnceForKey(t, &in, &out, retriever, "rootpassword", data.CanonicalRootRole)
 	assertAskOnceForKey(t, &in, &out, retriever, "targetspassword", data.CanonicalTargetsRole)
+	assertAskOnceForKey(t, &in, &out, retriever, "snapshotpassword", data.CanonicalSnapshotRole)
 	assertAskOnceForKey(t, &in, &out, retriever, "delegationpass", "targets/delegation")
 
-	// now ask for snapshot password, but it should already be cached, it
-	// won't ask and  no input necessary.
-	pass, giveUp, err := retriever("repo/0123456789abcdef", data.CanonicalSnapshotRole, false, 0)
+	// ask for root password, but it should already be cached
+	pass, giveUp, err := retriever("repo/0123456789abcdef", data.CanonicalRootRole, false, 0)
+	require.NoError(t, err)
+	require.False(t, giveUp)
+	require.Equal(t, "rootpassword", pass)
+
+	// ask for targets password, but it should already be cached
+	pass, giveUp, err = retriever("repo/0123456789abcdef", data.CanonicalTargetsRole, false, 0)
 	require.NoError(t, err)
 	require.False(t, giveUp)
 	require.Equal(t, "targetspassword", pass)
 
+	// ask for snapshot password, but it should already be cached
+	pass, giveUp, err = retriever("repo/0123456789abcdef", data.CanonicalSnapshotRole, false, 0)
+	require.NoError(t, err)
+	require.False(t, giveUp)
+	require.Equal(t, "snapshotpassword", pass)
+
+	// ask for targets/delegation password, but it should already be cached
+	pass, giveUp, err = retriever("repo/0123456789abcdef", "targets/delegation", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveUp)
+	require.Equal(t, "delegationpass", pass)
+
+	// ask for targets/newdelegation password, which should not be cached
+	pass, giveUp, err = retriever("repo/0123456789abcdef", "targets/newdelegation", false, 0)
+	require.Error(t, err)
+
 	text, err := ioutil.ReadAll(&out)
 	require.NoError(t, err)
-	require.Empty(t, text)
+	require.Contains(t, string(text), "Enter passphrase for targets/newdelegation key with ID 0123456 (repo):")
 }

--- a/passphrase/passphrase_test.go
+++ b/passphrase/passphrase_test.go
@@ -105,11 +105,10 @@ func TestRolePromptingAndCaching(t *testing.T) {
 	require.False(t, giveUp)
 	require.Equal(t, "delegationpass", pass)
 
-	// ask for targets/newdelegation password, which should not be cached
-	pass, giveUp, err = retriever("repo/0123456789abcdef", "targets/newdelegation", false, 0)
+	// ask for different delegation password, which should not be cached
+	_, _, err = retriever("repo/0123456789abcdef", "targets/delegation/new", false, 0)
 	require.Error(t, err)
-
 	text, err := ioutil.ReadAll(&out)
 	require.NoError(t, err)
-	require.Contains(t, string(text), "Enter passphrase for targets/newdelegation key with ID 0123456 (repo):")
+	require.Contains(t, string(text), "Enter passphrase for targets/delegation/new key with ID 0123456 (repo):")
 }


### PR DESCRIPTION
Marking as PoC because this deviates from the behavior vendored into docker/docker.

This changes the passphrase retriever to separate the cached passwords for the `targets` and `snapshot` role, such that we cache all passwords (including for delegations) individually.  I think we should move in this direction, especially because we can enable remote snapshot key management.

However, I'm still trying to wrap my head around the consequences against pre-existing notary integrations, like in docker -- because the old passphrase retriever is being used and the environment variable `DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE` is [shared](https://github.com/docker/docker/blob/master/api/client/trust.go#L200) between targets and snapshot.  If this environment variable is set, it will be used without calling the passphrase retriever, which could be an issue if the user picks different a passphrase for targets and snapshot on init.

Closes #524.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>