### PR TITLE
add non-root passwd functionality

### DIFF
--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -431,5 +431,5 @@ func TestChangeKeyPassphraseNonexistentID(t *testing.T) {
 	// Valid ID size, but does not exist as a key ID
 	err := k.keyPassphraseChange(&cobra.Command{}, []string{strings.Repeat("x", notary.Sha256HexSize)})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "could not retrieve local root key for key ID provided")
+	assert.Contains(t, err.Error(), "could not retrieve local key for key ID provided")
 }


### PR DESCRIPTION
Allows notary CLI to change passphrases for non-root keys, including delegation keys.

There might be some weird behavior with the passphrase retriever on targets/snapshot key if you only change the passphrase for one individually -- #541 would fix this.

Partially addresses #483

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>