### PR TITLE
Remove keyDB from signed.Verify

### DIFF
--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -194,7 +194,7 @@ func loadTargetsFromStore(gun, role string, repo *tuf.Repo, store storage.MetaSt
 }
 
 func generateSnapshot(gun string, repo *tuf.Repo, store storage.MetaStore) (*storage.MetaUpdate, error) {
-	role, err := repo.GetRole(data.CanonicalSnapshotRole)
+	role, err := repo.GetRoleWithKeys(data.CanonicalSnapshotRole)
 	if err != nil {
 		return nil, validation.ErrBadRoot{Msg: "root did not include snapshot role"}
 	}
@@ -265,7 +265,7 @@ func validateSnapshot(role string, oldSnap *data.SignedSnapshot, snapUpdate stor
 	}
 	// version specifically gets validated when writing to store to
 	// better handle race conditions there.
-	snapshotRole, err := repo.GetRole(role)
+	snapshotRole, err := repo.GetRoleWithKeys(role)
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func validateTargets(role string, roles map[string]storage.MetaUpdate, repo *tuf
 	}
 	// version specifically gets validated when writing to store to
 	// better handle race conditions there.
-	targetsRole, err := repo.GetRole(role)
+	targetsRole, err := repo.GetRoleWithKeys(role)
 	if err != nil {
 		return nil, err
 	}

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -270,7 +270,7 @@ func TestValidateSnapshotGenerateWithPrev(t *testing.T) {
 	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
-	snapRole, err := repo.GetRole(data.CanonicalSnapshotRole)
+	snapRole, err := repo.GetRoleWithKeys(data.CanonicalSnapshotRole)
 	assert.NoError(t, err)
 
 	for _, k := range snapRole.Keys {
@@ -310,7 +310,7 @@ func TestValidateSnapshotGeneratePrevCorrupt(t *testing.T) {
 	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
-	snapRole, err := repo.GetRole(data.CanonicalSnapshotRole)
+	snapRole, err := repo.GetRoleWithKeys(data.CanonicalSnapshotRole)
 	assert.NoError(t, err)
 
 	for _, k := range snapRole.Keys {
@@ -340,7 +340,7 @@ func TestValidateSnapshotGenerateNoTargets(t *testing.T) {
 	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
-	snapRole, err := repo.GetRole(data.CanonicalSnapshotRole)
+	snapRole, err := repo.GetRoleWithKeys(data.CanonicalSnapshotRole)
 	assert.NoError(t, err)
 
 	for _, k := range snapRole.Keys {
@@ -364,7 +364,7 @@ func TestValidateSnapshotGenerate(t *testing.T) {
 	kdb, repo, cs, err := testutils.EmptyRepo("docker.com/notary")
 	assert.NoError(t, err)
 	store := storage.NewMemStorage()
-	snapRole, err := repo.GetRole(data.CanonicalSnapshotRole)
+	snapRole, err := repo.GetRoleWithKeys(data.CanonicalSnapshotRole)
 	assert.NoError(t, err)
 
 	for _, k := range snapRole.Keys {

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -200,11 +200,11 @@ func (c *Client) downloadRoot() error {
 
 func (c Client) verifyRoot(role string, s *data.Signed, minVersion int) error {
 	// this will confirm that the root has been signed by the old root role
-	// as c.keysDB contains the root keys we bootstrapped with.
+	// with the root keys we bootstrapped with.
 	// Still need to determine if there has been a root key update and
 	// confirm signature with new root key
 	logrus.Debug("verifying root with existing keys")
-	rootRole, err := c.local.GetRole(role)
+	rootRole, err := c.local.GetRoleWithKeys(role)
 	if err != nil {
 		logrus.Debug("no previous root role loaded")
 		return err
@@ -231,7 +231,7 @@ func (c Client) verifyRoot(role string, s *data.Signed, minVersion int) error {
 	// TODO(endophage): be more intelligent and only re-verify if we detect
 	//                  there has been a change in root keys
 	logrus.Debug("verifying root with updated keys")
-	rootRole, err = c.local.GetRole(role)
+	rootRole, err = c.local.GetRoleWithKeys(role)
 	if err != nil {
 		logrus.Debug("root role with new keys not loaded")
 		return err
@@ -302,7 +302,7 @@ func (c *Client) downloadTimestamp() error {
 
 // verifies that a timestamp is valid, and returned the SignedTimestamp object to add to the tuf repo
 func (c *Client) verifyTimestamp(s *data.Signed, minVersion int) (*data.SignedTimestamp, error) {
-	timestampRole, err := c.local.GetRole(data.CanonicalTimestampRole)
+	timestampRole, err := c.local.GetRoleWithKeys(data.CanonicalTimestampRole)
 	if err != nil {
 		logrus.Debug("no timestamp role loaded")
 		return nil, err
@@ -365,7 +365,7 @@ func (c *Client) downloadSnapshot() error {
 		s = old
 	}
 
-	snapshotRole, err := c.local.GetRole(role)
+	snapshotRole, err := c.local.GetRoleWithKeys(role)
 	if err != nil {
 		logrus.Debug("no snapshot role loaded")
 		return err
@@ -508,7 +508,7 @@ func (c Client) getTargetsFile(role string, keyIDs []string, snapshotMeta data.F
 		s = old
 	}
 
-	targetsRole, err := c.local.GetRole(role)
+	targetsRole, err := c.local.GetRoleWithKeys(role)
 	if err != nil {
 		logrus.Debugf("no %s role loaded", role)
 		return nil, err

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -2,10 +2,11 @@ package data
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
 	"path"
 	"regexp"
 	"strings"
+
+	"github.com/Sirupsen/logrus"
 )
 
 // Canonical base role names
@@ -243,4 +244,10 @@ func subtractStrSlices(orig, remove []string) []string {
 		}
 	}
 	return keep
+}
+
+// RoleWithKeys is a role that has the signing keys for the role embedded
+type RoleWithKeys struct {
+	Role
+	Keys map[string]PublicKey
 }

--- a/tuf/data/roles.go
+++ b/tuf/data/roles.go
@@ -249,5 +249,5 @@ func subtractStrSlices(orig, remove []string) []string {
 // RoleWithKeys is a role that has the signing keys for the role embedded
 type RoleWithKeys struct {
 	Role
-	Keys map[string]PublicKey
+	Keys Keys
 }

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/go/canonical/json"
 	"github.com/docker/notary/tuf/data"
-	"github.com/docker/notary/tuf/keys"
 )
 
 // Various basic signing errors
@@ -57,18 +56,18 @@ func VerifyRoot(s *data.Signed, minVersion int, keys map[string]data.PublicKey) 
 			continue
 		}
 		// threshold of 1 so return on first success
-		return verifyMeta(s, "root", minVersion)
+		return verifyMeta(s, data.CanonicalRootRole, minVersion)
 	}
 	return ErrRoleThreshold{}
 }
 
 // Verify checks the signatures and metadata (expiry, version) for the signed role
 // data
-func Verify(s *data.Signed, role string, minVersion int, db *keys.KeyDB) error {
-	if err := verifyMeta(s, role, minVersion); err != nil {
+func Verify(s *data.Signed, role *data.RoleWithKeys, minVersion int) error {
+	if err := verifyMeta(s, role.Name, minVersion); err != nil {
 		return err
 	}
-	return VerifySignatures(s, role, db)
+	return VerifySignatures(s, role)
 }
 
 func verifyMeta(s *data.Signed, role string, minVersion int) error {
@@ -96,21 +95,18 @@ func IsExpired(t time.Time) bool {
 }
 
 // VerifySignatures checks the we have sufficient valid signatures for the given role
-func VerifySignatures(s *data.Signed, role string, db *keys.KeyDB) error {
+func VerifySignatures(s *data.Signed, roleData *data.RoleWithKeys) error {
 	if len(s.Signatures) == 0 {
 		return ErrNoSignatures
-	}
-
-	roleData := db.GetRole(role)
-	if roleData == nil {
-		return ErrUnknownRole
 	}
 
 	if roleData.Threshold < 1 {
 		return ErrRoleThreshold{}
 	}
-	logrus.Debugf("%s role has key IDs: %s", role, strings.Join(roleData.KeyIDs, ","))
+	logrus.Debugf("%s role has key IDs: %s", roleData.Name, strings.Join(roleData.KeyIDs, ","))
 
+	// remarshal the signed part so we can verify the signature, since the signature has
+	// to be of a canonically marshalled signed object
 	var decoded map[string]interface{}
 	if err := json.Unmarshal(s.Signed, &decoded); err != nil {
 		return err
@@ -127,8 +123,8 @@ func VerifySignatures(s *data.Signed, role string, db *keys.KeyDB) error {
 			logrus.Debugf("continuing b/c keyid was invalid: %s for roledata %s\n", sig.KeyID, roleData)
 			continue
 		}
-		key := db.GetKey(sig.KeyID)
-		if key == nil {
+		key, ok := roleData.Keys[sig.KeyID]
+		if !ok {
 			logrus.Debugf("continuing b/c keyid lookup was nil: %s\n", sig.KeyID)
 			continue
 		}
@@ -152,29 +148,4 @@ func VerifySignatures(s *data.Signed, role string, db *keys.KeyDB) error {
 	}
 
 	return nil
-}
-
-// Unmarshal unmarshals and verifys the raw bytes for a given role's metadata
-func Unmarshal(b []byte, v interface{}, role string, minVersion int, db *keys.KeyDB) error {
-	s := &data.Signed{}
-	if err := json.Unmarshal(b, s); err != nil {
-		return err
-	}
-	if err := Verify(s, role, minVersion, db); err != nil {
-		return err
-	}
-	return json.Unmarshal(s.Signed, v)
-}
-
-// UnmarshalTrusted unmarshals and verifies signatures only, not metadata, for a
-// given role's metadata
-func UnmarshalTrusted(b []byte, v interface{}, role string, db *keys.KeyDB) error {
-	s := &data.Signed{}
-	if err := json.Unmarshal(b, s); err != nil {
-		return err
-	}
-	if err := VerifySignatures(s, role, db); err != nil {
-		return err
-	}
-	return json.Unmarshal(s.Signed, v)
 }

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -23,7 +23,7 @@ func TestRoleNoKeys(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: data.Keys{k.ID(): k}}
 
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
@@ -47,7 +47,7 @@ func TestNotEnoughSigs(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: data.Keys{k.ID(): k}}
 
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
@@ -73,7 +73,7 @@ func TestMoreThanEnoughSigs(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k1.ID(): k1, k2.ID(): k2}}
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: data.Keys{k1.ID(): k1, k2.ID(): k2}}
 
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
@@ -98,7 +98,7 @@ func TestDuplicateSigs(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: data.Keys{k.ID(): k}}
 
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
@@ -125,7 +125,7 @@ func TestUnknownKeyBelowThreshold(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k, unknown.ID(): unknown}}
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: data.Keys{k.ID(): k, unknown.ID(): unknown}}
 
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
@@ -209,7 +209,7 @@ func Test(t *testing.T) {
 				nil,
 			)
 			assert.NoError(t, err)
-			run.roleData = &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
+			run.roleData = &data.RoleWithKeys{Role: *r, Keys: data.Keys{k.ID(): k}}
 			meta := &data.SignedCommon{Type: run.typ, Version: run.ver, Expires: *run.exp}
 
 			b, err := json.MarshalCanonical(meta)

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/notary/tuf/data"
-	"github.com/docker/notary/tuf/keys"
 )
 
 func TestRoleNoKeys(t *testing.T) {
@@ -24,17 +23,15 @@ func TestRoleNoKeys(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	db := keys.NewDB()
-	assert.NoError(t, err)
-	err = db.AddRole(r)
-	assert.NoError(t, err)
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
+
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
 	b, err := json.MarshalCanonical(meta)
 	assert.NoError(t, err)
 	s := &data.Signed{Signed: b}
 	Sign(cs, s, k)
-	err = Verify(s, "root", 1, db)
+	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
 }
 
@@ -50,18 +47,15 @@ func TestNotEnoughSigs(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	db := keys.NewDB()
-	assert.NoError(t, err)
-	db.AddKey(k)
-	err = db.AddRole(r)
-	assert.NoError(t, err)
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
+
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
 	b, err := json.MarshalCanonical(meta)
 	assert.NoError(t, err)
 	s := &data.Signed{Signed: b}
 	Sign(cs, s, k)
-	err = Verify(s, "root", 1, db)
+	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
 }
 
@@ -79,12 +73,8 @@ func TestMoreThanEnoughSigs(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	db := keys.NewDB()
-	assert.NoError(t, err)
-	db.AddKey(k1)
-	db.AddKey(k2)
-	err = db.AddRole(r)
-	assert.NoError(t, err)
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k1.ID(): k1, k2.ID(): k2}}
+
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
 	b, err := json.MarshalCanonical(meta)
@@ -92,7 +82,7 @@ func TestMoreThanEnoughSigs(t *testing.T) {
 	s := &data.Signed{Signed: b}
 	Sign(cs, s, k1, k2)
 	assert.Equal(t, 2, len(s.Signatures))
-	err = Verify(s, "root", 1, db)
+	err = Verify(s, roleWithKeys, 1)
 	assert.NoError(t, err)
 }
 
@@ -108,11 +98,8 @@ func TestDuplicateSigs(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	db := keys.NewDB()
-	assert.NoError(t, err)
-	db.AddKey(k)
-	err = db.AddRole(r)
-	assert.NoError(t, err)
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
+
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
 	b, err := json.MarshalCanonical(meta)
@@ -120,7 +107,7 @@ func TestDuplicateSigs(t *testing.T) {
 	s := &data.Signed{Signed: b}
 	Sign(cs, s, k)
 	s.Signatures = append(s.Signatures, s.Signatures[0])
-	err = Verify(s, "root", 1, db)
+	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
 }
 
@@ -138,12 +125,8 @@ func TestUnknownKeyBelowThreshold(t *testing.T) {
 		nil,
 	)
 	assert.NoError(t, err)
-	db := keys.NewDB()
-	assert.NoError(t, err)
-	db.AddKey(k)
-	db.AddKey(unknown)
-	err = db.AddRole(r)
-	assert.NoError(t, err)
+	roleWithKeys := &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k, unknown.ID(): unknown}}
+
 	meta := &data.SignedCommon{Type: "Root", Version: 1, Expires: data.DefaultExpires("root")}
 
 	b, err := json.MarshalCanonical(meta)
@@ -151,23 +134,22 @@ func TestUnknownKeyBelowThreshold(t *testing.T) {
 	s := &data.Signed{Signed: b}
 	Sign(cs, s, k, unknown)
 	s.Signatures = append(s.Signatures)
-	err = Verify(s, "root", 1, db)
+	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
 }
 
 func Test(t *testing.T) {
 	cryptoService := NewEd25519()
 	type test struct {
-		name  string
-		keys  []data.PublicKey
-		roles map[string]*data.Role
-		s     *data.Signed
-		ver   int
-		exp   *time.Time
-		typ   string
-		role  string
-		err   error
-		mut   func(*test)
+		name     string
+		roleData *data.RoleWithKeys
+		s        *data.Signed
+		ver      int
+		exp      *time.Time
+		typ      string
+		role     string
+		err      error
+		mut      func(*test)
 	}
 
 	expiredTime := time.Now().Add(-time.Hour)
@@ -204,7 +186,6 @@ func Test(t *testing.T) {
 		},
 	}
 	for _, run := range tests {
-		db := keys.NewDB()
 		if run.role == "" {
 			run.role = "root"
 		}
@@ -218,9 +199,8 @@ func Test(t *testing.T) {
 		if run.typ == "" {
 			run.typ = data.TUFTypes[run.role]
 		}
-		if run.keys == nil && run.s == nil {
+		if run.s == nil {
 			k, _ := cryptoService.Create("root", data.ED25519Key)
-			db.AddKey(k)
 			r, err := data.NewRole(
 				"root",
 				1,
@@ -229,7 +209,7 @@ func Test(t *testing.T) {
 				nil,
 			)
 			assert.NoError(t, err)
-			db.AddRole(r)
+			run.roleData = &data.RoleWithKeys{Role: *r, Keys: map[string]data.PublicKey{k.ID(): k}}
 			meta := &data.SignedCommon{Type: run.typ, Version: run.ver, Expires: *run.exp}
 
 			b, err := json.MarshalCanonical(meta)
@@ -242,7 +222,7 @@ func Test(t *testing.T) {
 			run.mut(&run)
 		}
 
-		err := Verify(run.s, run.role, minVer, db)
+		err := Verify(run.s, run.roleData, minVer)
 		if e, ok := run.err.(ErrExpired); ok {
 			assertErrExpired(t, err, e)
 		} else {

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -772,13 +772,13 @@ func (tr Repo) sign(signedData *data.Signed, role data.Role) (*data.Signed, erro
 	return signedData, nil
 }
 
-// GetRole returns a RoleWithKeys object, given a role name.
-func (tr Repo) GetRole(role string) (*data.RoleWithKeys, error) {
+// GetRoleWithKeys returns a RoleWithKeys object, given a role name.
+func (tr Repo) GetRoleWithKeys(role string) (*data.RoleWithKeys, error) {
 	roleData := tr.keysDB.GetRole(role)
 	if roleData == nil {
 		return nil, ErrNotLoaded{role: role}
 	}
-	keysInRole := make(map[string]data.PublicKey)
+	keysInRole := make(data.Keys)
 	for _, keyID := range roleData.KeyIDs {
 		k := tr.keysDB.GetKey(keyID)
 		if k != nil {

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -771,3 +771,19 @@ func (tr Repo) sign(signedData *data.Signed, role data.Role) (*data.Signed, erro
 	}
 	return signedData, nil
 }
+
+// GetRole returns a RoleWithKeys object, given a role name.
+func (tr Repo) GetRole(role string) (*data.RoleWithKeys, error) {
+	roleData := tr.keysDB.GetRole(role)
+	if roleData == nil {
+		return nil, ErrNotLoaded{role: role}
+	}
+	keysInRole := make(map[string]data.PublicKey)
+	for _, keyID := range roleData.KeyIDs {
+		k := tr.keysDB.GetKey(keyID)
+		if k != nil {
+			keysInRole[keyID] = k
+		}
+	}
+	return &data.RoleWithKeys{Role: *roleData, Keys: keysInRole}, nil
+}


### PR DESCRIPTION
The start of removing KeyDB.  This introduces a `RoleWithKeys` object, which `Verify` uses to verify signatures, instead of a `KeyDB`.

Part of #556