### PR TITLE
adding codecov badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Notary [![Circle CI](https://circleci.com/gh/docker/notary/tree/master.svg?style=shield)](https://circleci.com/gh/docker/notary/tree/master)
+# Notary 
+[![Circle CI](https://circleci.com/gh/docker/notary/tree/master.svg?style=shield)](https://circleci.com/gh/docker/notary/tree/master) [![CodeCov](https://codecov.io/github/docker/notary/coverage.svg?branch=master)](https://codecov.io/github/docker/notary)
 
 The Notary project comprises a [server](cmd/notary-server) and a [client](cmd/notary) for running and interacting
 with trusted collections.


### PR DESCRIPTION
Just because it bugged me we didn't have the codecov badge and it took 30 seconds to add.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)