### PR TITLE
Server generates snapshot and timestamp immediately

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -125,6 +125,13 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	require.Len(t, oldTargetsKeys, 1)
 	require.Len(t, newTargetsKeys, 1)
 	require.NotEqual(t, oldTargetsKeys[0], newTargetsKeys[0])
+
+	// rotate the snapshot key to the server and ensure that the server can re-generate the snapshot
+	// and we can download the snapshot
+	require.NoError(t, repo.RotateKey(data.CanonicalSnapshotRole, true))
+	require.NoError(t, repo.Publish())
+	_, err = repo.Update(false)
+	require.NoError(t, err)
 }
 
 // Ensures that the current client can download metadata that is published from notary 0.1 repos

--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -326,8 +326,8 @@ func TestAtomicUpdateValidationFailurePropagated(t *testing.T) {
 
 	repo, cs, err := testutils.EmptyRepo(gun)
 	assert.NoError(t, err)
-	copyTimestampKey(t, repo, metaStore, gun)
-	state := handlerState{store: metaStore, crypto: cs}
+
+	state := handlerState{store: metaStore, crypto: copyKeys(t, cs, data.CanonicalTimestampRole)}
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	assert.NoError(t, err)
@@ -368,8 +368,8 @@ func TestAtomicUpdateNonValidationFailureNotPropagated(t *testing.T) {
 
 	repo, cs, err := testutils.EmptyRepo(gun)
 	assert.NoError(t, err)
-	copyTimestampKey(t, repo, metaStore, gun)
-	state := handlerState{store: &failStore{*metaStore}, crypto: cs}
+
+	state := handlerState{store: &failStore{*metaStore}, crypto: copyKeys(t, cs, data.CanonicalTimestampRole)}
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	assert.NoError(t, err)
@@ -409,8 +409,9 @@ func TestAtomicUpdateVersionErrorPropagated(t *testing.T) {
 
 	repo, cs, err := testutils.EmptyRepo(gun)
 	assert.NoError(t, err)
-	copyTimestampKey(t, repo, metaStore, gun)
-	state := handlerState{store: &invalidVersionStore{*metaStore}, crypto: cs}
+
+	state := handlerState{
+		store: &invalidVersionStore{*metaStore}, crypto: copyKeys(t, cs, data.CanonicalTimestampRole)}
 
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	assert.NoError(t, err)

--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -107,7 +107,7 @@ func validateUpdate(cs signed.CryptoService, gun string, updates []storage.MetaU
 			}
 		}
 
-		if err := validateSnapshot(snapshotRole, oldSnap, roles[snapshotRole], roles, repo); err != nil {
+		if err := loadAndValidateSnapshot(snapshotRole, oldSnap, roles[snapshotRole], roles, repo); err != nil {
 			logrus.Error("ErrBadSnapshot: ", err.Error())
 			return nil, validation.ErrBadSnapshot{Msg: err.Error()}
 		}
@@ -270,10 +270,9 @@ func generateTimestamp(gun string, repo *tuf.Repo, store storage.MetaStore) (*st
 	return metaUpdate, nil
 }
 
-// validateSnapshot validates that the given snapshot update is valid.  It also sets the new snapshot
+// loadAndValidateSnapshot validates that the given snapshot update is valid.  It also sets the new snapshot
 // on the TUF repo, if it is valid
-func validateSnapshot(role string, oldSnap *data.SignedSnapshot, snapUpdate storage.MetaUpdate, roles map[string]storage.MetaUpdate, repo *tuf.Repo) error {
-
+func loadAndValidateSnapshot(role string, oldSnap *data.SignedSnapshot, snapUpdate storage.MetaUpdate, roles map[string]storage.MetaUpdate, repo *tuf.Repo) error {
 	s := &data.Signed{}
 	err := json.Unmarshal(snapUpdate.Data, s)
 	if err != nil {

--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -216,7 +216,7 @@ func generateSnapshot(gun string, repo *tuf.Repo, store storage.MetaStore) (*sto
 	}
 
 	if _, ok := err.(storage.ErrNotFound); !ok && err != nil {
-		return nil, validation.ErrValidation{Msg: err.Error()}
+		return nil, err
 	}
 
 	metaUpdate, err := snapshot.NewSnapshotUpdate(prev, repo)
@@ -249,7 +249,7 @@ func generateTimestamp(gun string, repo *tuf.Repo, store storage.MetaStore) (*st
 	}
 
 	if _, ok := err.(storage.ErrNotFound); !ok && err != nil {
-		return nil, validation.ErrValidation{Msg: err.Error()}
+		return nil, err
 	}
 
 	metaUpdate, err := timestamp.NewTimestampUpdate(prev, repo)

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -24,7 +24,7 @@ func copyKeys(t *testing.T, from signed.CryptoService, roles ...string) signed.C
 		for _, keyID := range from.ListKeys(role) {
 			key, _, err := from.GetPrivateKey(keyID)
 			assert.NoError(t, err)
-			memKeyStore.AddKey(path.Base(keyID), data.CanonicalTimestampRole, key)
+			memKeyStore.AddKey(path.Base(keyID), role, key)
 		}
 	}
 	return cryptoservice.NewCryptoService("", memKeyStore)

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -40,10 +40,15 @@ func TestValidationErrorFormat(t *testing.T) {
 	assert.NoError(t, err)
 	r, tg, sn, ts, err := testutils.Sign(repo)
 	assert.NoError(t, err)
-	rs, _, _, _, err := testutils.Serialize(r, tg, sn, ts)
+	rs, rt, _, _, err := testutils.Serialize(r, tg, sn, ts)
 	assert.NoError(t, err)
 
-	err = client.SetMultiMeta(map[string][]byte{data.CanonicalRootRole: rs})
+	// No snapshot is passed, and the server doesn't have the snapshot key,
+	// so ErrBadHierarchy
+	err = client.SetMultiMeta(map[string][]byte{
+		data.CanonicalRootRole:    rs,
+		data.CanonicalTargetsRole: rt,
+	})
 	assert.Error(t, err)
-	assert.IsType(t, validation.ErrBadRoot{}, err)
+	assert.IsType(t, validation.ErrBadHierarchy{}, err)
 }

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -105,7 +105,7 @@ func NewSnapshotUpdate(prev *data.SignedSnapshot, repo *tuf.Repo) (*storage.Meta
 	if prev != nil {
 		repo.SetSnapshot(prev) // SetSnapshot never errors
 	} else {
-		// this will only occurr if no snapshot has ever been created for the repository
+		// this will only occur if no snapshot has ever been created for the repository
 		if err := repo.InitSnapshot(); err != nil {
 			return nil, err
 		}

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -3,11 +3,11 @@ package snapshot
 import (
 	"time"
 
-	"github.com/docker/go/canonical/json"
-
 	"github.com/Sirupsen/logrus"
 
+	"github.com/docker/go/canonical/json"
 	"github.com/docker/notary/server/storage"
+	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 )
@@ -50,40 +50,48 @@ func GetOrCreateSnapshotKey(gun string, store storage.KeyStore, crypto signed.Cr
 func GetOrCreateSnapshot(gun string, store storage.MetaStore, cryptoService signed.CryptoService) (
 	*time.Time, []byte, error) {
 
-	lastModified, d, err := store.GetCurrent(gun, data.CanonicalSnapshotRole)
+	lastModified, currentJSON, err := store.GetCurrent(gun, data.CanonicalSnapshotRole)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	sn := &data.SignedSnapshot{}
-	if d != nil {
-		err := json.Unmarshal(d, sn)
-		if err != nil {
-			logrus.Error("Failed to unmarshal existing snapshot")
-			return nil, nil, err
-		}
-
-		if !snapshotExpired(sn) {
-			return lastModified, d, nil
-		}
+	prev := new(data.SignedSnapshot)
+	if err := json.Unmarshal(currentJSON, prev); err != nil {
+		logrus.Error("Failed to unmarshal existing snapshot for GUN ", gun)
+		return nil, nil, err
 	}
 
-	sgnd, version, err := createSnapshot(gun, sn, store, cryptoService)
+	if !snapshotExpired(prev) {
+		return lastModified, currentJSON, nil
+	}
+
+	repo := tuf.NewRepo(cryptoService)
+
+	// load the current root to ensure we use the correct snapshot key.
+	_, rootJSON, err := store.GetCurrent(gun, data.CanonicalRootRole)
+
+	if err != nil {
+		return nil, nil, err
+	}
+	root := &data.SignedRoot{}
+	if err := json.Unmarshal(rootJSON, root); err != nil {
+		logrus.Error("Failed to unmarshal existing root for GUN ", gun)
+		return nil, nil, err
+	}
+	repo.SetRoot(root)
+
+	snapshotUpdate, err := NewSnapshotUpdate(prev, repo)
 	if err != nil {
 		logrus.Error("Failed to create a new snapshot")
 		return nil, nil, err
 	}
-	out, err := json.Marshal(sgnd)
-	if err != nil {
-		logrus.Error("Failed to marshal new snapshot")
-		return nil, nil, err
-	}
-	err = store.UpdateCurrent(gun, storage.MetaUpdate{Role: "snapshot", Version: version, Data: out})
-	if err != nil {
-		return nil, nil, err
-	}
+
 	c := time.Now()
-	return &c, out, nil
+	if err = store.UpdateCurrent(gun, *snapshotUpdate); err != nil {
+		return nil, nil, err
+	}
+
+	return &c, snapshotUpdate.Data, nil
 }
 
 // snapshotExpired simply checks if the snapshot is past its expiry time
@@ -91,33 +99,28 @@ func snapshotExpired(sn *data.SignedSnapshot) bool {
 	return signed.IsExpired(sn.Signed.Expires)
 }
 
-// createSnapshot uses an existing snapshot to create a new one.
-// Important things to be aware of:
-//   - It requires that a snapshot already exists. We create snapshots
-//     on upload so there should always be an existing snapshot if this
-//     gets called.
-//   - It doesn't update what roles are present in the snapshot, as those
-//     were validated during upload.
-func createSnapshot(gun string, sn *data.SignedSnapshot, store storage.MetaStore, cryptoService signed.CryptoService) (*data.Signed, int, error) {
-	algorithm, public, err := store.GetKey(gun, data.CanonicalSnapshotRole)
-	if err != nil {
-		// owner of gun must have generated a snapshot key otherwise
-		// we won't proceed with generating everything.
-		return nil, 0, err
+// NewSnapshotUpdate produces a new snapshot and returns it as a metadata update, given the
+// previous snapshot and the TUF repo.
+func NewSnapshotUpdate(prev *data.SignedSnapshot, repo *tuf.Repo) (*storage.MetaUpdate, error) {
+	if prev != nil {
+		repo.SetSnapshot(prev) // SetSnapshot never errors
+	} else {
+		// this will only occurr if no snapshot has ever been created for the repository
+		if err := repo.InitSnapshot(); err != nil {
+			return nil, err
+		}
 	}
-	key := data.NewPublicKey(algorithm, public)
-
-	// update version and expiry
-	sn.Signed.Version = sn.Signed.Version + 1
-	sn.Signed.Expires = data.DefaultExpires(data.CanonicalSnapshotRole)
-
-	out, err := sn.ToSigned()
+	sgnd, err := repo.SignSnapshot(data.DefaultExpires(data.CanonicalSnapshotRole))
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	err = signed.Sign(cryptoService, out, key)
+	sgndJSON, err := json.Marshal(sgnd)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return out, sn.Signed.Version, nil
+	return &storage.MetaUpdate{
+		Role:    data.CanonicalSnapshotRole,
+		Version: repo.Snapshot.Signed.Version,
+		Data:    sgndJSON,
+	}, nil
 }

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -1,8 +1,9 @@
 package snapshot
 
 import (
-	"encoding/json"
 	"time"
+
+	"github.com/docker/go/canonical/json"
 
 	"github.com/Sirupsen/logrus"
 

--- a/server/snapshot/snapshot_test.go
+++ b/server/snapshot/snapshot_test.go
@@ -138,7 +138,7 @@ func TestGetSnapshotNoPreviousSnapshot(t *testing.T) {
 		}
 
 		// create a key to be used by GetOrCreateSnapshot
-		key, err := crypto.Create(data.CanonicalSnapshotRole, data.ECDSAKey)
+		key, err := crypto.Create(data.CanonicalSnapshotRole, "gun", data.ECDSAKey)
 		assert.NoError(t, err)
 		assert.NoError(t, store.SetKey("gun", data.CanonicalSnapshotRole, key.Algorithm(), key.Public()))
 

--- a/server/snapshot/snapshot_test.go
+++ b/server/snapshot/snapshot_test.go
@@ -2,9 +2,10 @@ package snapshot
 
 import (
 	"bytes"
-	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/docker/go/canonical/json"
 
 	"github.com/stretchr/testify/assert"
 

--- a/server/snapshot/snapshot_test.go
+++ b/server/snapshot/snapshot_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go/canonical/json"
-
 	"github.com/stretchr/testify/assert"
 
+	"github.com/docker/go/canonical/json"
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
+	"github.com/docker/notary/tuf/testutils"
 )
 
 func TestSnapshotExpired(t *testing.T) {
@@ -115,102 +115,151 @@ func TestGetSnapshotKeyExistsOnSet(t *testing.T) {
 	assert.NotNil(t, k2, "Key should not be nil")
 }
 
-func TestGetSnapshotNotExists(t *testing.T) {
-	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
-
-	_, _, err := GetOrCreateSnapshot("gun", store, crypto)
-	assert.Error(t, err)
-}
-
-func TestGetSnapshotCurrValid(t *testing.T) {
-	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
-
-	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
-
-	newData := []byte{2}
-	currMeta, err := data.NewFileMeta(bytes.NewReader(newData), "sha256")
+// If there is no previous snapshot or the previous snapshot is corrupt, then
+// even if everything else is in place, getting the snapshot fails
+func TestGetSnapshotNoPreviousSnapshot(t *testing.T) {
+	repo, crypto, err := testutils.EmptyRepo("gun")
 	assert.NoError(t, err)
 
-	snapshot := &data.SignedSnapshot{
-		Signed: data.Snapshot{
-			Expires: data.DefaultExpires(data.CanonicalSnapshotRole),
-			Meta: data.Files{
-				data.CanonicalRootRole: currMeta,
-			},
-		},
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
+
+	for _, snapshotJSON := range [][]byte{nil, []byte("invalid JSON")} {
+		store := storage.NewMemStorage()
+
+		// so we know it's not a failure in getting root
+		assert.NoError(t,
+			store.UpdateCurrent("gun", storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+
+		if snapshotJSON != nil {
+			assert.NoError(t,
+				store.UpdateCurrent("gun",
+					storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapshotJSON}))
+		}
+
+		// create a key to be used by GetOrCreateSnapshot
+		key, err := crypto.Create(data.CanonicalSnapshotRole, data.ECDSAKey)
+		assert.NoError(t, err)
+		assert.NoError(t, store.SetKey("gun", data.CanonicalSnapshotRole, key.Algorithm(), key.Public()))
+
+		_, _, err = GetOrCreateSnapshot("gun", store, crypto)
+		assert.Error(t, err, "GetSnapshot should have failed")
+		if snapshotJSON == nil {
+			assert.IsType(t, storage.ErrNotFound{}, err)
+		} else {
+			assert.IsType(t, &json.SyntaxError{}, err)
+		}
 	}
-	snapJSON, _ := json.Marshal(snapshot)
-
-	// test when db is missing the role data
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
-	c1, result, err := GetOrCreateSnapshot("gun", store, crypto)
-	assert.NoError(t, err)
-	assert.True(t, bytes.Equal(snapJSON, result))
-
-	// test when db has the role data
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 0, Data: newData})
-	c2, result, err := GetOrCreateSnapshot("gun", store, crypto)
-	assert.NoError(t, err)
-	assert.True(t, bytes.Equal(snapJSON, result))
-	assert.True(t, c1.Equal(*c2))
-
-	// test when db role data is corrupt
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 1, Data: []byte{3}})
-	c2, result, err = GetOrCreateSnapshot("gun", store, crypto)
-	assert.NoError(t, err)
-	assert.True(t, bytes.Equal(snapJSON, result))
-	assert.True(t, c1.Equal(*c2))
 }
 
-func TestGetSnapshotCurrExpired(t *testing.T) {
+// If there WAS a pre-existing snapshot, and it is not expired, then just return it (it doesn't
+// load any other metadata that it doesn't need)
+func TestGetSnapshotReturnsPreviousSnapshotIfUnexpired(t *testing.T) {
 	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
-
-	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
-
-	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.Marshal(snapshot)
-
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
-	c1, newJSON, err := GetOrCreateSnapshot("gun", store, crypto)
+	repo, crypto, err := testutils.EmptyRepo("gun")
 	assert.NoError(t, err)
-	assert.False(t, bytes.Equal(snapJSON, newJSON))
-	assert.True(t, c1.After(time.Now().Add(-1*time.Minute)))
+
+	snapshotJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
+
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapshotJSON}))
+
+	// test when db is missing the role data (no root)
+	_, gottenSnapshot, err := GetOrCreateSnapshot("gun", store, crypto)
+	assert.NoError(t, err, "GetSnapshot should not have failed")
+	assert.True(t, bytes.Equal(snapshotJSON, gottenSnapshot))
 }
 
-func TestGetSnapshotCurrCorrupt(t *testing.T) {
+func TestGetSnapshotOldSnapshotExpired(t *testing.T) {
 	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
+	repo, crypto, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
 
-	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
 
-	snapshot := &data.SignedSnapshot{}
-	snapJSON, _ := json.Marshal(snapshot)
+	// create an expired snapshot
+	_, err = repo.SignSnapshot(time.Now().AddDate(-1, -1, -1))
+	assert.True(t, repo.Snapshot.Signed.Expires.Before(time.Now()))
+	assert.NoError(t, err)
+	snapshotJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
 
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON[1:]})
-	_, _, err = GetOrCreateSnapshot("gun", store, crypto)
-	assert.Error(t, err)
+	// set all the metadata
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapshotJSON}))
+
+	_, gottenSnapshot, err := GetOrCreateSnapshot("gun", store, crypto)
+	assert.NoError(t, err, "GetSnapshot errored")
+
+	assert.False(t, bytes.Equal(snapshotJSON, gottenSnapshot),
+		"Snapshot was not regenerated when old one was expired")
+
+	signedMeta := &data.SignedMeta{}
+	assert.NoError(t, json.Unmarshal(gottenSnapshot, signedMeta))
+	// the new metadata is not expired
+	assert.True(t, signedMeta.Signed.Expires.After(time.Now()))
 }
 
-func TestCreateSnapshotNoKeyInStorage(t *testing.T) {
-	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
+// If the root is missing or corrupt, no snapshot can be generated
+func TestCannotMakeNewSnapshotIfNoRoot(t *testing.T) {
+	repo, crypto, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
 
-	_, _, err := createSnapshot("gun", nil, store, crypto)
-	assert.Error(t, err)
+	// create an expired snapshot
+	_, err = repo.SignSnapshot(time.Now().AddDate(-1, -1, -1))
+	assert.True(t, repo.Snapshot.Signed.Expires.Before(time.Now()))
+	assert.NoError(t, err)
+	snapshotJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
+
+	for _, rootJSON := range [][]byte{nil, []byte("invalid JSON")} {
+		store := storage.NewMemStorage()
+
+		if rootJSON != nil {
+			assert.NoError(t, store.UpdateCurrent("gun",
+				storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+		}
+		assert.NoError(t, store.UpdateCurrent("gun",
+			storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 1, Data: snapshotJSON}))
+
+		_, _, err := GetOrCreateSnapshot("gun", store, crypto)
+		assert.Error(t, err, "GetSnapshot errored")
+
+		if rootJSON == nil { // missing metadata
+			assert.IsType(t, storage.ErrNotFound{}, err)
+		} else {
+			assert.IsType(t, &json.SyntaxError{}, err)
+		}
+	}
 }
 
 func TestCreateSnapshotNoKeyInCrypto(t *testing.T) {
 	store := storage.NewMemStorage()
-	crypto := signed.NewEd25519()
+	repo, _, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
 
-	_, err := GetOrCreateSnapshotKey("gun", store, crypto, data.ED25519Key)
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
 
-	// reset crypto so the store has the key but crypto doesn't
-	crypto = signed.NewEd25519()
+	// create an expired snapshot
+	_, err = repo.SignSnapshot(time.Now().AddDate(-1, -1, -1))
+	assert.True(t, repo.Snapshot.Signed.Expires.Before(time.Now()))
+	assert.NoError(t, err)
+	snapshotJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
 
-	_, _, err = createSnapshot("gun", &data.SignedSnapshot{}, store, crypto)
+	// set all the metadata so we know the failure to sign is just because of the key
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapshotJSON}))
+
+	// pass it a new cryptoservice without the key
+	_, _, err = GetOrCreateSnapshot("gun", store, signed.NewEd25519())
 	assert.Error(t, err)
+	assert.IsType(t, signed.ErrNoKeys{}, err)
 }

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -4,7 +4,9 @@ import (
 	"time"
 
 	"github.com/docker/go/canonical/json"
+	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
 
 	"github.com/Sirupsen/logrus"
@@ -64,8 +66,9 @@ func GetOrCreateTimestamp(gun string, store storage.MetaStore, cryptoService sig
 		}
 		logrus.Debug("No timestamp found, will proceed to create first timestamp")
 	}
-	ts := &data.SignedTimestamp{}
+	var ts *data.SignedTimestamp
 	if d != nil {
+		ts = &data.SignedTimestamp{}
 		err := json.Unmarshal(d, ts)
 		if err != nil {
 			logrus.Error("Failed to unmarshal existing timestamp")
@@ -110,38 +113,42 @@ func snapshotExpired(ts *data.SignedTimestamp, snapshot []byte) bool {
 // version number one higher than prev. The store is used to lookup the current
 // snapshot, this function does not save the newly generated timestamp.
 func CreateTimestamp(gun string, prev *data.SignedTimestamp, snapshot []byte, store storage.MetaStore, cryptoService signed.CryptoService) (*data.Signed, int, error) {
-	algorithm, public, err := store.GetKey(gun, data.CanonicalTimestampRole)
+	kdb := keys.NewDB()
+	repo := tuf.NewRepo(kdb, cryptoService)
+
+	// load the current root to ensure we use the correct timestamp key.
+	root, err := store.GetCurrent(gun, data.CanonicalRootRole)
+	r := &data.SignedRoot{}
+	err = json.Unmarshal(root, r)
 	if err != nil {
-		// owner of gun must have generated a timestamp key otherwise
-		// we won't proceed with generating everything.
+		// couldn't parse root
 		return nil, 0, err
 	}
-	key := data.NewPublicKey(algorithm, public)
-	sn := &data.Signed{}
+	repo.SetRoot(r)
+
+	// load snapshot so we can include it in timestamp
+	sn := &data.SignedSnapshot{}
 	err = json.Unmarshal(snapshot, sn)
 	if err != nil {
 		// couldn't parse snapshot
 		return nil, 0, err
 	}
-	ts, err := data.NewTimestamp(sn)
+	repo.SetSnapshot(sn)
+
+	if prev == nil {
+		// no previous timestamp: generate first timestamp
+		repo.InitTimestamp()
+	} else {
+		// set repo timestamp to previous timestamp to use as base for
+		// generating new one
+		repo.SetTimestamp(prev)
+	}
+
+	out, err := repo.SignTimestamp(
+		data.DefaultExpires(data.CanonicalTimestampRole),
+	)
 	if err != nil {
 		return nil, 0, err
 	}
-	if prev != nil {
-		ts.Signed.Version = prev.Signed.Version + 1
-	}
-	var sgndTs json.RawMessage
-	sgndTs, err = json.MarshalCanonical(ts.Signed)
-	if err != nil {
-		return nil, 0, err
-	}
-	out := &data.Signed{
-		Signatures: ts.Signatures,
-		Signed:     &sgndTs,
-	}
-	err = signed.Sign(cryptoService, out, key)
-	if err != nil {
-		return nil, 0, err
-	}
-	return out, ts.Signed.Version, nil
+	return out, repo.Timestamp.Signed.Version, nil
 }

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -1,10 +1,11 @@
 package timestamp
 
 import (
-	"encoding/json"
+	"bytes"
 	"testing"
 	"time"
 
+	"github.com/docker/go/canonical/json"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/testutils"
@@ -49,9 +50,10 @@ func TestGetTimestampKey(t *testing.T) {
 	assert.NotNil(t, k2, "Key should not be nil")
 }
 
-func TestGetTimestamp(t *testing.T) {
-	store := storage.NewMemStorage()
-	_, repo, crypto, err := testutils.EmptyRepo("gun")
+// If there is no previous timestamp or the previous timestamp is corrupt, then
+// even if everything else is in place, getting the timestamp fails
+func TestGetTimestampNoPreviousTimestamp(t *testing.T) {
+	repo, crypto, err := testutils.EmptyRepo("gun")
 	assert.NoError(t, err)
 
 	rootJSON, err := json.Marshal(repo.Root)
@@ -59,21 +61,61 @@ func TestGetTimestamp(t *testing.T) {
 	snapJSON, err := json.Marshal(repo.Snapshot)
 	assert.NoError(t, err)
 
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 0, Data: rootJSON})
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
+	for _, timestampJSON := range [][]byte{nil, []byte("invalid JSON")} {
+		store := storage.NewMemStorage()
 
-	// create a key to be used by GetTimestamp
-	key, err := crypto.Create(data.CanonicalTimestampRole, data.ECDSAKey)
-	assert.NoError(t, err)
-	assert.NoError(t, store.SetKey("gun", data.CanonicalTimestampRole, key.Algorithm(), key.Public()))
+		// so we know it's not a failure in getting root or snapshot
+		assert.NoError(t,
+			store.UpdateCurrent("gun", storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+		assert.NoError(t,
+			store.UpdateCurrent("gun", storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapJSON}))
 
-	_, _, err = GetOrCreateTimestamp("gun", store, crypto)
-	assert.Nil(t, err, "GetTimestamp errored")
+		if timestampJSON != nil {
+			assert.NoError(t,
+				store.UpdateCurrent("gun",
+					storage.MetaUpdate{Role: data.CanonicalTimestampRole, Version: 0, Data: timestampJSON}))
+		}
+
+		// create a key to be used by GetOrCreateTimestamp
+		key, err := crypto.Create(data.CanonicalTimestampRole, data.ECDSAKey)
+		assert.NoError(t, err)
+		assert.NoError(t, store.SetKey("gun", data.CanonicalTimestampRole, key.Algorithm(), key.Public()))
+
+		_, _, err = GetOrCreateTimestamp("gun", store, crypto)
+		assert.Error(t, err, "GetTimestamp should have failed")
+		if timestampJSON == nil {
+			assert.IsType(t, storage.ErrNotFound{}, err)
+		} else {
+			assert.IsType(t, &json.SyntaxError{}, err)
+		}
+	}
 }
 
-func TestGetTimestampNewSnapshot(t *testing.T) {
+// If there WAS a pre-existing timestamp, and it is not expired, then just return it (it doesn't
+// load any other metadata that it doesn't need, like root)
+func TestGetTimestampReturnsPreviousTimestampIfUnexpired(t *testing.T) {
 	store := storage.NewMemStorage()
-	_, repo, crypto, err := testutils.EmptyRepo("gun")
+	repo, crypto, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
+
+	snapJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
+	timestampJSON, err := json.Marshal(repo.Timestamp)
+	assert.NoError(t, err)
+
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalTimestampRole, Version: 0, Data: timestampJSON}))
+
+	_, gottenTimestamp, err := GetOrCreateTimestamp("gun", store, crypto)
+	assert.NoError(t, err, "GetTimestamp should not have failed")
+	assert.True(t, bytes.Equal(timestampJSON, gottenTimestamp))
+}
+
+func TestGetTimestampOldTimestampExpired(t *testing.T) {
+	store := storage.NewMemStorage()
+	repo, crypto, err := testutils.EmptyRepo("gun")
 	assert.NoError(t, err)
 
 	rootJSON, err := json.Marshal(repo.Root)
@@ -81,29 +123,140 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 	snapJSON, err := json.Marshal(repo.Snapshot)
 	assert.NoError(t, err)
 
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "root", Version: 0, Data: rootJSON})
-	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
-
-	// create a key to be used by GetTimestamp
-	key, err := crypto.Create(data.CanonicalTimestampRole, data.ECDSAKey)
+	// create an expired timestamp
+	_, err = repo.SignTimestamp(time.Now().AddDate(-1, -1, -1))
+	assert.True(t, repo.Timestamp.Signed.Expires.Before(time.Now()))
 	assert.NoError(t, err)
-	assert.NoError(t, store.SetKey("gun", data.CanonicalTimestampRole, key.Algorithm(), key.Public()))
+	timestampJSON, err := json.Marshal(repo.Timestamp)
+	assert.NoError(t, err)
+
+	// set all the metadata
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalTimestampRole, Version: 1, Data: timestampJSON}))
+
+	_, gottenTimestamp, err := GetOrCreateTimestamp("gun", store, crypto)
+	assert.NoError(t, err, "GetTimestamp errored")
+
+	assert.False(t, bytes.Equal(timestampJSON, gottenTimestamp),
+		"Timestamp was not regenerated when old one was expired")
+
+	signedMeta := &data.SignedMeta{}
+	assert.NoError(t, json.Unmarshal(gottenTimestamp, signedMeta))
+	// the new metadata is not expired
+	assert.True(t, signedMeta.Signed.Expires.After(time.Now()))
+}
+
+// In practice this might happen if the snapshot is expired, for instance, and
+// is re-signed.
+func TestGetTimestampIfNewSnapshot(t *testing.T) {
+	store := storage.NewMemStorage()
+	repo, crypto, err := testutils.EmptyRepo("gun")
+
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
+	timestampJSON, err := json.Marshal(repo.Timestamp)
+	assert.NoError(t, err)
+	snapJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
+
+	// set all the metadata
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalTimestampRole, Version: 0, Data: timestampJSON}))
 
 	c1, ts1, err := GetOrCreateTimestamp("gun", store, crypto)
 	assert.Nil(t, err, "GetTimestamp errored")
 
-	snapshot = &data.SignedSnapshot{
-		Signed: data.Snapshot{
-			Expires: data.DefaultExpires(data.CanonicalSnapshotRole),
-			Version: 1,
-		},
-	}
-	snapJSON, _ = json.Marshal(snapshot)
-
+	// update the snapshot to a new version
+	repo.Snapshot.Signed.Version++
+	snapJSON, err = json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 1, Data: snapJSON})
 
 	c2, ts2, err := GetOrCreateTimestamp("gun", store, crypto)
 	assert.NoError(t, err, "GetTimestamp errored")
 	assert.NotEqual(t, ts1, ts2, "Timestamp was not regenerated when snapshot changed")
 	assert.True(t, c1.Before(*c2), "Timestamp modification time incorrect")
+}
+
+// If the root or snapshot is missing or corrupt, no timestamp can be generated
+func TestCannotMakeNewTimestampIfNoRootOrSnapshot(t *testing.T) {
+	repo, crypto, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
+
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
+	snapJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
+
+	// create an expired timestamp
+	_, err = repo.SignTimestamp(time.Now().AddDate(-1, -1, -1))
+	assert.True(t, repo.Timestamp.Signed.Expires.Before(time.Now()))
+	assert.NoError(t, err)
+	timestampJSON, err := json.Marshal(repo.Timestamp)
+	assert.NoError(t, err)
+
+	invalids := []map[string][]byte{
+		{data.CanonicalRootRole: rootJSON, data.CanonicalSnapshotRole: []byte("invalid JSON")},
+		{data.CanonicalRootRole: []byte("invalid JSON"), data.CanonicalSnapshotRole: snapJSON},
+		{data.CanonicalRootRole: rootJSON},
+		{data.CanonicalSnapshotRole: snapJSON},
+	}
+
+	for _, dataToSet := range invalids {
+		store := storage.NewMemStorage()
+		for roleName, jsonBytes := range dataToSet {
+			assert.NoError(t, store.UpdateCurrent("gun",
+				storage.MetaUpdate{Role: roleName, Version: 0, Data: jsonBytes}))
+		}
+		assert.NoError(t, store.UpdateCurrent("gun",
+			storage.MetaUpdate{Role: data.CanonicalTimestampRole, Version: 1, Data: timestampJSON}))
+
+		_, _, err := GetOrCreateTimestamp("gun", store, crypto)
+		assert.Error(t, err, "GetTimestamp errored")
+
+		if len(dataToSet) == 1 { // missing metadata
+			assert.IsType(t, storage.ErrNotFound{}, err)
+		} else {
+			assert.IsType(t, &json.SyntaxError{}, err)
+		}
+	}
+}
+
+func TestCreateTimestampNoKeyInCrypto(t *testing.T) {
+	store := storage.NewMemStorage()
+	repo, _, err := testutils.EmptyRepo("gun")
+	assert.NoError(t, err)
+
+	rootJSON, err := json.Marshal(repo.Root)
+	assert.NoError(t, err)
+	snapJSON, err := json.Marshal(repo.Snapshot)
+	assert.NoError(t, err)
+
+	// create an expired timestamp
+	_, err = repo.SignTimestamp(time.Now().AddDate(-1, -1, -1))
+	assert.True(t, repo.Timestamp.Signed.Expires.Before(time.Now()))
+	assert.NoError(t, err)
+	timestampJSON, err := json.Marshal(repo.Timestamp)
+	assert.NoError(t, err)
+
+	// set all the metadata so we know the failure to sign is just because of the key
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalRootRole, Version: 0, Data: rootJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalSnapshotRole, Version: 0, Data: snapJSON}))
+	assert.NoError(t, store.UpdateCurrent("gun",
+		storage.MetaUpdate{Role: data.CanonicalTimestampRole, Version: 1, Data: timestampJSON}))
+
+	// pass it a new cryptoservice without the key
+	_, _, err = GetOrCreateTimestamp("gun", store, signed.NewEd25519())
+	assert.Error(t, err)
+	assert.IsType(t, signed.ErrNoKeys{}, err)
 }

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -77,7 +77,7 @@ func TestGetTimestampNoPreviousTimestamp(t *testing.T) {
 		}
 
 		// create a key to be used by GetOrCreateTimestamp
-		key, err := crypto.Create(data.CanonicalTimestampRole, data.ECDSAKey)
+		key, err := crypto.Create(data.CanonicalTimestampRole, "gun", data.ECDSAKey)
 		assert.NoError(t, err)
 		assert.NoError(t, store.SetKey("gun", data.CanonicalTimestampRole, key.Algorithm(), key.Public()))
 

--- a/tuf/data/root.go
+++ b/tuf/data/root.go
@@ -146,6 +146,12 @@ func (r SignedRoot) MarshalJSON() ([]byte, error) {
 // that it is a valid SignedRoot
 func RootFromSigned(s *Signed) (*SignedRoot, error) {
 	r := Root{}
+	if s.Signed == nil {
+		return nil, ErrInvalidMetadata{
+			role: CanonicalRootRole,
+			msg:  "root file contained an empty payload",
+		}
+	}
 	if err := defaultSerializer.Unmarshal(*s.Signed, &r); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Sorry for the largish change.

This changes the timestamp and snapshot code generation to just try to sign a generated timestamp and snapshot, and if there aren't enough signatures, to then fail on server-managed keys, which will help us with eliminating the `timestamp_keys` table and allowing us to have multiple signing keys for a gun and role on the signer, which is part of #347.

It also changes timestamp generation to automatically generate a timestamp when an update is sent, which fixes #563.