### PR TITLE
Change the CLI to be able to rotate server managed keys

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/store"
@@ -108,10 +107,8 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	require.NoError(t, repo.fileStore.RemoveMeta(data.CanonicalTimestampRole))
 
 	// rotate the timestamp key, since the server doesn't have that one
-	timestampPubKey, err := getRemoteKey(ts.URL, gun, data.CanonicalTimestampRole, http.DefaultTransport)
+	err = repo.RotateKey(data.CanonicalTimestampRole, true)
 	require.NoError(t, err)
-	require.NoError(
-		t, repo.rootFileKeyChange(data.CanonicalTimestampRole, changelist.ActionCreate, timestampPubKey))
 
 	require.NoError(t, repo.Publish())
 

--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,7 @@ func (err ErrRepoNotInitialized) Error() string {
 }
 
 // ErrInvalidRemoteRole is returned when the server is requested to manage
-// an unsupported key type
+// a key type that is not permitted
 type ErrInvalidRemoteRole struct {
 	Role string
 }
@@ -50,7 +50,7 @@ func (err ErrInvalidRemoteRole) Error() string {
 }
 
 // ErrInvalidLocalRole is returned when the client wants to manage
-// an unsupported key type
+// a key type that is not permitted
 type ErrInvalidLocalRole struct {
 	Role string
 }
@@ -869,17 +869,18 @@ func (r *NotaryRepository) validateRoot(rootJSON []byte) (*data.SignedRoot, erro
 // These changes are staged in a changelist until publish is called.
 func (r *NotaryRepository) RotateKey(role string, serverManagesKey bool) error {
 	switch {
-	// We currently support locally managing targets keys, remotely managing
-	// timestamp keys, and locally or remotely managing snapshot keys.
+	// We currently support locally or remotely managing snapshot keys...
+	case role == data.CanonicalSnapshotRole:
+	// locally managing targets keys only
 	case role == data.CanonicalTargetsRole:
 		if serverManagesKey {
 			return ErrInvalidRemoteRole{Role: data.CanonicalTargetsRole}
 		}
+	// and remotely managing timestamp keys only
 	case role == data.CanonicalTimestampRole:
 		if !serverManagesKey {
 			return ErrInvalidLocalRole{Role: data.CanonicalTimestampRole}
 		}
-	case role == data.CanonicalSnapshotRole:
 	default:
 		return fmt.Errorf("notary does not currently permit rotating the %s key", role)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2554,7 +2554,7 @@ func TestRotateKeyInvalidRole(t *testing.T) {
 	repo, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary", ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 
-	// the equivalent of: remotely remotely rotating the root key
+	// the equivalent of: remotely rotating the root key
 	// (RotateKey("root", true)), locally rotating the root key (RotateKey("root", false)),
 	// locally rotating the timestamp key (RotateKey("timestamp", false)),
 	// and remotely rotating the targets key (RotateKey(targets, true)), all of which should

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2554,7 +2554,11 @@ func TestRotateKeyInvalidRole(t *testing.T) {
 	repo, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary", ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 
-	// the equivalent of: (root, true), (root, false), (timestamp, false), (targets, true)
+	// the equivalent of: remotely remotely rotating the root key
+	// (RotateKey("root", true)), locally rotating the root key (RotateKey("root", false)),
+	// locally rotating the timestamp key (RotateKey("timestamp", false)),
+	// and remotely rotating the targets key (RotateKey(targets, true)), all of which should
+	// fail
 	for _, role := range data.BaseRoles {
 		if role == data.CanonicalSnapshotRole {
 			continue

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -871,28 +871,13 @@ func TestClientKeyGenerationRotation(t *testing.T) {
 	assertSuccessfullyPublish(t, tempDir, server.URL, "gun", target, tempfiles[0])
 
 	// rotate the signing keys
-	_, err = runCommand(t, tempDir, "key", "rotate", "gun", data.CanonicalSnapshotRole)
+	_, err = runCommand(t, tempDir, "-s", server.URL, "key", "rotate", "gun", data.CanonicalSnapshotRole)
 	assert.NoError(t, err)
-	_, err = runCommand(t, tempDir, "key", "rotate", "gun", data.CanonicalTargetsRole)
+	_, err = runCommand(t, tempDir, "-s", server.URL, "key", "rotate", "gun", data.CanonicalTargetsRole)
 	assert.NoError(t, err)
-	root, sign := assertNumKeys(t, tempDir, 1, 4, true)
+	root, sign := assertNumKeys(t, tempDir, 1, 2, true)
 	assert.Equal(t, origRoot[0], root[0])
-	// there should be the new keys and the old keys
-	for _, origKey := range origSign {
-		found := false
-		for _, key := range sign {
-			if key == origKey {
-				found = true
-			}
-		}
-		assert.True(t, found, "Old key not found in list of old and new keys")
-	}
 
-	// publish the key rotation
-	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
-	root, sign = assertNumKeys(t, tempDir, 1, 2, true)
-	assert.Equal(t, origRoot[0], root[0])
 	// just do a cursory rotation check that the keys aren't equal anymore
 	for _, origKey := range origSign {
 		for _, key := range sign {

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -589,7 +589,7 @@ func TestClientDelegationsPublishing(t *testing.T) {
 	assertNumKeys(t, tempDir, 1, 2, true)
 
 	// rotate the snapshot key to server
-	output, err = runCommand(t, tempDir, "-s", server.URL, "key", "rotate", "gun", "-r", "--key-type", "snapshot")
+	output, err = runCommand(t, tempDir, "-s", server.URL, "key", "rotate", "gun", "snapshot", "-r")
 	assert.NoError(t, err)
 
 	// publish repo
@@ -871,7 +871,9 @@ func TestClientKeyGenerationRotation(t *testing.T) {
 	assertSuccessfullyPublish(t, tempDir, server.URL, "gun", target, tempfiles[0])
 
 	// rotate the signing keys
-	_, err = runCommand(t, tempDir, "key", "rotate", "gun")
+	_, err = runCommand(t, tempDir, "key", "rotate", "gun", data.CanonicalSnapshotRole)
+	assert.NoError(t, err)
+	_, err = runCommand(t, tempDir, "key", "rotate", "gun", data.CanonicalTargetsRole)
 	assert.NoError(t, err)
 	root, sign := assertNumKeys(t, tempDir, 1, 4, true)
 	assert.Equal(t, origRoot[0], root[0])

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -430,11 +430,7 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = nRepo.RotateKey(rotateKeyRole, k.rotateKeyServerManaged)
-	if err == nil && k.rotateKeyServerManaged {
-		err = nRepo.Publish()
-	}
-	return err
+	return nRepo.RotateKey(rotateKeyRole, k.rotateKeyServerManaged)
 }
 
 func removeKeyInteractively(keyStores []trustmanager.KeyStore, keyID string,

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -430,7 +430,11 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return nRepo.RotateKey(rotateKeyRole, k.rotateKeyServerManaged)
+	err = nRepo.RotateKey(rotateKeyRole, k.rotateKeyServerManaged)
+	if err == nil && k.rotateKeyServerManaged {
+		err = nRepo.Publish()
+	}
+	return err
 }
 
 func removeKeyInteractively(keyStores []trustmanager.KeyStore, keyID string,

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -38,7 +38,7 @@ var cmdKeyListTemplate = usageTemplate{
 var cmdRotateKeyTemplate = usageTemplate{
 	Use:   "rotate [ GUN ]",
 	Short: "Rotate the signing (non-root) keys for the given Globally Unique Name.",
-	Long:  "Removes all the old signing (non-root) keys for the given Globally Unique Name, and generates new ones.  This only makes local changes - please use then `notary publish` to push the key rotation changes to the remote server.",
+	Long:  "Removes old signing (non-root) keys for the given Globally Unique Name, and generates new ones.  If rotating to a server-managed key, the key rotation is automatically published.  If rotating to locally-managed key(s), only local, non-online changes are made - please use then `notary publish` to push the key rotation changes to the remote server.",
 }
 
 var cmdKeyGenerateRootKeyTemplate = usageTemplate{
@@ -420,12 +420,10 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 		rolesToRotate = []string{data.CanonicalSnapshotRole}
 	case data.CanonicalTargetsRole:
 		rolesToRotate = []string{data.CanonicalTargetsRole}
+	case data.CanonicalTimestampRole:
+		rolesToRotate = []string{data.CanonicalTimestampRole}
 	default:
 		return fmt.Errorf("key rotation not supported for %s keys", k.rotateKeyRole)
-	}
-	if k.rotateKeyServerManaged && rotateKeyRole != data.CanonicalSnapshotRole {
-		return fmt.Errorf(
-			"remote signing/key management is only supported for the snapshot key")
 	}
 
 	config, err := k.configGetter()

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -366,9 +366,7 @@ func TestRotateKeyRemoteServerManagesKey(t *testing.T) {
 
 		cl, err := repo.GetChangelist()
 		assert.NoError(t, err, "unable to get changelist: %v", err)
-		assert.Len(t, cl.List(), 1, "expected a single key rotation change")
-
-		assert.NoError(t, repo.Publish())
+		assert.Len(t, cl.List(), 0, "expected the changes to have been published")
 
 		finalKeys := repo.CryptoService.ListAllKeys()
 		assert.Len(t, initialKeys, 3)

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -106,7 +106,7 @@ var exampleValidCommands = []string{
 	"add repo v1 somefile",
 	"verify repo v1",
 	"key list",
-	"key rotate repo",
+	"key rotate repo snapshot",
 	"key generate rsa",
 	"key backup tempfile.zip",
 	"key export e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 backup.pem",

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -90,13 +90,15 @@ subsection.
 In case of potential compromise, notary provides a CLI command for rotating keys. Currently, you can use the `notary key rotate` command to rotate the targets or snapshot keys.
 
 While the snapshot key is managed by the notary client by default, use the `notary key
-rotate -r` command to rotate the snapshot key to the server, such that the
+rotate snapshot -r` command to rotate the snapshot key to the server, such that the
 notary server will then sign snapshots. This is particularly useful when using
 delegations with a trusted collection, so that delegates will never need access to the
 snapshot key to push their updates to the collection.
 
 Note that new collections created by a Docker 1.11 Engine client will have the server manage the snapshot key by default.
 To reclaim control of the snapshot key on the client, use the `notary key rotate` command without the `-r` flag.
+
+The targets key must be locally managed - to rotate the targets key, for instance in case of compromise, use the `notary key rotate targets` command without the `-r` flag.s
 
 ### Use a Yubikey
 
@@ -129,11 +131,10 @@ their own targets to the collection, since the server can publish the valid
 snapshot with the delegation targets:
 
 ```
-$ notary key rotate example.com/collection -r --key-type=snapshot
+$ notary key rotate example.com/collection snapshot -r
 ```
 
-Here, `-r` specifies to rotate the key to the remote server, and `--key-type` (shorthand `-t`)
-specifies the role.
+Here, `-r` specifies to rotate the key to the remote server.
 
 When adding a delegation, your must acquire a x509 certificate with the public
 key of the user you wish to delegate to. The user who will assume this
@@ -205,7 +206,7 @@ In the preceding example, you add the target `delegation/path/target` to
 collection `example/collections` staged for next publish. The file
 `delegation_file.txt` is a target `delegation/path/target` using the delegation
 role `targets/releases`. This target's path is valid because it is prefixed by
-the delegation role's valid path.  
+the delegation role's valid path.
 
 The `notary list` and `notary remove` commands can also take the `--roles` flag
 to specify roles to list or remove targets from.  By default, this operates over


### PR DESCRIPTION
This includes some minor changes from #553.

Fixes #554 