### PR TITLE
Per metadata type mutation tests

### DIFF
--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -919,12 +919,8 @@ func waysToMessUpServerNonRootPerRole(t *testing.T) map[string][]swizzleExpectat
 		perRoleSwizzling[data.CanonicalSnapshotRole] = append(
 			perRoleSwizzling[data.CanonicalSnapshotRole],
 			swizzleExpectations{
-				desc: fmt.Sprintf("snapshot missing root meta checksum"),
-				// TODO: this should probably be always client.ErrMissingMeta
-				// or some kind of snapshot validation failure - please see
-				// https://github.com/docker/notary/pull/572#discussion_r53093988 for an explanation
-				// of the JSON syntax error
-				expectErrs: []interface{}{&json.SyntaxError{}, client.ErrMissingMeta{}},
+				desc:       fmt.Sprintf("snapshot missing root meta checksum"),
+				expectErrs: []interface{}{client.ErrMissingMeta{}},
 				swizzle: func(s *testutils.MetadataSwizzler, role string) error {
 					return s.MutateSnapshot(func(sn *data.Snapshot) {
 						delete(sn.Meta, missing)

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -813,8 +813,8 @@ var waysToMessUpServer = []swizzleExpectations{
 
 var _waysToMessUpServerRoot []swizzleExpectations
 
-// A getter that also sets once through - we can just add these, but it's very easier to do it
-// programmatically
+// We also want to remove a every role from root once, or remove the role's keys.
+// This function generates once and caches the result for later re-use.
 func waysToMessUpServerRoot() []swizzleExpectations {
 	if _waysToMessUpServerRoot == nil {
 		_waysToMessUpServerRoot = waysToMessUpServer

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -129,8 +129,10 @@ func (c *Client) downloadRoot() error {
 	var size int64 = -1
 	var expectedSha256 []byte
 	if c.local.Snapshot != nil {
-		size = c.local.Snapshot.Signed.Meta[role].Length
-		expectedSha256 = c.local.Snapshot.Signed.Meta[role].Hashes["sha256"]
+		if prevRootMeta, ok := c.local.Snapshot.Signed.Meta[role]; ok {
+			size = prevRootMeta.Length
+			expectedSha256 = prevRootMeta.Hashes["sha256"]
+		}
 	}
 
 	// if we're bootstrapping we may not have a cached root, an

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -559,11 +559,10 @@ func (m *MetadataSwizzler) MutateRoot(mutate func(*data.Root)) error {
 
 	mutate(&root)
 
-	rootBytes, err := json.MarshalCanonical(root)
+	signedThing, err = data.SignedRoot{Signed: root, Signatures: signedThing.Signatures}.ToSigned()
 	if err != nil {
 		return err
 	}
-	signedThing.Signed = json.RawMessage(rootBytes)
 
 	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalRootRole)
 	if err != nil || len(pubKeys) == 0 { // we have to sign it somehow - might as well use the old keys
@@ -592,11 +591,10 @@ func (m *MetadataSwizzler) MutateTimestamp(mutate func(*data.Timestamp)) error {
 
 	mutate(&timestamp)
 
-	timestampBytes, err := json.MarshalCanonical(timestamp)
+	signedThing, err = data.SignedTimestamp{Signed: timestamp, Signatures: signedThing.Signatures}.ToSigned()
 	if err != nil {
 		return err
 	}
-	signedThing.Signed = json.RawMessage(timestampBytes)
 
 	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalTimestampRole)
 	if err != nil {
@@ -625,11 +623,10 @@ func (m *MetadataSwizzler) MutateSnapshot(mutate func(*data.Snapshot)) error {
 
 	mutate(&snapshot)
 
-	snapshotBytes, err := json.MarshalCanonical(snapshot)
+	signedThing, err = data.SignedSnapshot{Signed: snapshot, Signatures: signedThing.Signatures}.ToSigned()
 	if err != nil {
 		return err
 	}
-	signedThing.Signed = json.RawMessage(snapshotBytes)
 
 	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalSnapshotRole)
 	if err != nil {
@@ -658,11 +655,10 @@ func (m *MetadataSwizzler) MutateTargets(mutate func(*data.Targets)) error {
 
 	mutate(&targets)
 
-	targetsBytes, err := json.MarshalCanonical(targets)
+	signedThing, err = data.SignedTargets{Signed: targets, Signatures: signedThing.Signatures}.ToSigned()
 	if err != nil {
 		return err
 	}
-	signedThing.Signed = json.RawMessage(targetsBytes)
 
 	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalTargetsRole)
 	if err != nil {

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -532,3 +532,135 @@ func (m *MetadataSwizzler) UpdateTimestampHash() error {
 	}
 	return m.MetadataCache.SetMeta(data.CanonicalTimestampRole, metaBytes)
 }
+
+// MutateRoot takes a function that mutates the root metadata - once done, it
+// serializes the root again
+func (m *MetadataSwizzler) MutateRoot(mutate func(*data.Root)) error {
+	signedThing, err := signedFromStore(m.MetadataCache, data.CanonicalRootRole)
+	if err != nil {
+		return err
+	}
+
+	var root data.Root
+	if err := json.Unmarshal(signedThing.Signed, &root); err != nil {
+		return err
+	}
+
+	mutate(&root)
+
+	rootBytes, err := json.MarshalCanonical(root)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(rootBytes)
+
+	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalRootRole)
+	if err != nil {
+		return err
+	}
+
+	metaBytes, err := serializeMetadata(m.CryptoService, signedThing, data.CanonicalRootRole, pubKeys...)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(data.CanonicalRootRole, metaBytes)
+}
+
+// MutateTimestamp takes a function that mutates the timestamp metadata - once done, it
+// serializes the timestamp again
+func (m *MetadataSwizzler) MutateTimestamp(mutate func(*data.Timestamp)) error {
+	signedThing, err := signedFromStore(m.MetadataCache, data.CanonicalTimestampRole)
+	if err != nil {
+		return err
+	}
+
+	var timestamp data.Timestamp
+	if err := json.Unmarshal(signedThing.Signed, &timestamp); err != nil {
+		return err
+	}
+
+	mutate(&timestamp)
+
+	timestampBytes, err := json.MarshalCanonical(timestamp)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(timestampBytes)
+
+	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalTimestampRole)
+	if err != nil {
+		return err
+	}
+
+	metaBytes, err := serializeMetadata(m.CryptoService, signedThing, data.CanonicalTimestampRole, pubKeys...)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(data.CanonicalTimestampRole, metaBytes)
+}
+
+// MutateSnapshot takes a function that mutates the snapshot metadata - once done, it
+// serializes the snapshot again
+func (m *MetadataSwizzler) MutateSnapshot(mutate func(*data.Snapshot)) error {
+	signedThing, err := signedFromStore(m.MetadataCache, data.CanonicalSnapshotRole)
+	if err != nil {
+		return err
+	}
+
+	var snapshot data.Snapshot
+	if err := json.Unmarshal(signedThing.Signed, &snapshot); err != nil {
+		return err
+	}
+
+	mutate(&snapshot)
+
+	snapshotBytes, err := json.MarshalCanonical(snapshot)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(snapshotBytes)
+
+	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalSnapshotRole)
+	if err != nil {
+		return err
+	}
+
+	metaBytes, err := serializeMetadata(m.CryptoService, signedThing, data.CanonicalSnapshotRole, pubKeys...)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(data.CanonicalSnapshotRole, metaBytes)
+}
+
+// MutateTargets takes a function that mutates the targets metadata - once done, it
+// serializes the targets again
+func (m *MetadataSwizzler) MutateTargets(mutate func(*data.Targets)) error {
+	signedThing, err := signedFromStore(m.MetadataCache, data.CanonicalTargetsRole)
+	if err != nil {
+		return err
+	}
+
+	var targets data.Targets
+	if err := json.Unmarshal(signedThing.Signed, &targets); err != nil {
+		return err
+	}
+
+	mutate(&targets)
+
+	targetsBytes, err := json.MarshalCanonical(targets)
+	if err != nil {
+		return err
+	}
+	signedThing.Signed = json.RawMessage(targetsBytes)
+
+	pubKeys, err := getPubKeys(m.CryptoService, signedThing, data.CanonicalTargetsRole)
+	if err != nil {
+		return err
+	}
+
+	metaBytes, err := serializeMetadata(m.CryptoService, signedThing, data.CanonicalTargetsRole, pubKeys...)
+	if err != nil {
+		return err
+	}
+	return m.MetadataCache.SetMeta(data.CanonicalTargetsRole, metaBytes)
+}


### PR DESCRIPTION
This completes a lot of the per-metadata-type tests listed in #361