### PR TITLE
Misspell in Makefile and circleci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,10 @@ lint:
 #
 # be run first
 
-# misspell target, don't include Godeps, binaries, or python test files
+# misspell target, don't include Godeps, binaries, python tests, or git files
 misspell:
 	@echo "+ $@"
-	@test -z "$$(find . -name '*' | grep -v Godeps/_workspace/src/ | grep -v bin/ | grep -v misc/ | xargs misspell | tee /dev/stderr)"
+	@test -z "$$(find . -name '*' | grep -v Godeps/_workspace/src/ | grep -v bin/ | grep -v misc/ | grep -v .git/ | xargs misspell | tee /dev/stderr)"
 
 build: go_version
 	@echo "+ $@"

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,16 @@ lint:
 	@echo "+ $@"
 	@test -z "$$(golint ./... | grep -v .pb. | grep -v Godeps/_workspace/src/ | tee /dev/stderr)"
 
+# Requires that the following:
+# go get -u github.com/client9/misspell/cmd/misspell
+#
+# be run first
+
+# misspell target, don't include Godeps, binaries, or python test files
+misspell:
+	@echo "+ $@"
+	@test -z "$$(find . -name '*' | grep -v Godeps/_workspace/src/ | grep -v bin/ | grep -v misc/ | xargs misspell | tee /dev/stderr)"
+
 build: go_version
 	@echo "+ $@"
 	@go build -tags "${NOTARY_BUILDTAGS}" -v ${GO_LDFLAGS} ./...

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -195,7 +195,7 @@ func TestValidateRoot(t *testing.T) {
 	}
 
 	//
-	// This call to ValidateRoot will suceed in getting to the TUF validation, since
+	// This call to ValidateRoot will succeed in getting to the TUF validation, since
 	// we are using a valid PEM encoded certificate chain of intermediate + leaf cert
 	// that are signed by a trusted root authority and the leaf cert has a correct CN.
 	// It will, however, fail to validate, because it has an invalid TUF signature

--- a/circle.yml
+++ b/circle.yml
@@ -37,10 +37,11 @@ dependencies:
         pwd: $BASE_STABLE
 
   post:
-  # For the stable go version, additionally install linting tools
+  # For the stable go version, additionally install linting and misspell tools
     - >
       gvm use stable &&
-      go get github.com/golang/lint/golint
+      go get github.com/golang/lint/golint &&
+      go get -u github.com/client9/misspell/cmd/misspell
 test:
   pre:
   # Output the go versions we are going to test
@@ -60,6 +61,10 @@ test:
 
   # LINT
     - gvm use stable && make lint:
+        pwd: $BASE_STABLE
+
+  # MISSPELL
+    - gvm use stable && make misspell:
         pwd: $BASE_STABLE
 
   override:

--- a/client/changelist/change.go
+++ b/client/changelist/change.go
@@ -17,7 +17,7 @@ const (
 // Types for TufChanges are namespaced by the Role they
 // are relevant for. The Root and Targets roles are the
 // only ones for which user action can cause a change, as
-// all changes in Snapshot and Timestamp are programatically
+// all changes in Snapshot and Timestamp are programmatically
 // generated base on Root and Targets changes.
 const (
 	TypeRootRole          = "role"

--- a/client/client.go
+++ b/client/client.go
@@ -572,7 +572,7 @@ func (r *NotaryRepository) Publish() error {
 		r.tufRepo, data.CanonicalSnapshotRole)
 
 	if err == nil {
-		// Only update the snapshot if we've sucessfully signed it.
+		// Only update the snapshot if we've successfully signed it.
 		updatedFiles[data.CanonicalSnapshotRole] = snapshotJSON
 	} else if _, ok := err.(signed.ErrNoKeys); ok {
 		// If signing fails due to us not having the snapshot key, then

--- a/tuf/README.md
+++ b/tuf/README.md
@@ -29,7 +29,7 @@ however in attempting to add delegations I found I was making such
 significant changes that I could not maintain backwards compatibility
 without the code becoming overly convoluted.
 
-Some features such as pluggable verifiers have alreayd been merged upstream to flynn/go-tuf
+Some features such as pluggable verifiers have already been merged upstream to flynn/go-tuf
 and we are in discussion with [titanous](https://github.com/titanous) about working to merge the 2 implementations.
 
 This implementation retains the same 3 Clause BSD license present on 

--- a/tuf/encrypted/encrypted.go
+++ b/tuf/encrypted/encrypted.go
@@ -25,7 +25,7 @@ const (
 
 const (
 	// N parameter was chosen to be ~100ms of work using the default implementation
-	// on the 2.3GHz Core i7 Haswell processor in a late-2013 Apple Retina Macbook
+	// on the 2.3GHz Core i7 processor in a late-2013 Apple Retina Macbook
 	// Pro (it takes ~113ms).
 	scryptN = 32768
 	scryptR = 8

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -484,7 +484,7 @@ func TestDeleteDelegationsRoleNotExist(t *testing.T) {
 	repo := initRepo(t, ed25519, keyDB)
 
 	// initRepo leaves all the roles as Dirty. Set to false
-	// to test removing a non-existant role doesn't mark
+	// to test removing a non-existent role doesn't mark
 	// a role as dirty
 	repo.Targets[data.CanonicalTargetsRole].Dirty = false
 


### PR DESCRIPTION
Fixes current typos and adds `misspell` as a target to the Makefile and as a step in circle ci