### PR TITLE
Update integration test to exclude yubikeys from importing/exporting non-root keys

### DIFF
--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -1087,6 +1087,10 @@ func getKeySubdir(role, gun string) string {
 
 // Tests importing and exporting keys for all different roles and GUNs
 func TestClientKeyImportExportAllRoles(t *testing.T) {
+	if rootOnHardware() {
+		t.Log("Cannot import or export a non-root key from hardware. Will skip test.")
+		return
+	}
 	// -- setup --
 	setUp(t)
 


### PR DESCRIPTION
It seems like jenkins got into a weird state and didn't actually test this code with yubikeys until now. Without this PR, this test will fail when using a yubikey because it cannot export keys, nor can it import non-root keys.  `TestClientKeyImportExportRootOnly` still tests that importing a root key on a yubikey functions as expected.

@cyli and I investigated the jenkins build configuration, and we've fixed it to ensure it pulls the latest commit off master.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>