### PR TITLE
WalkTargets on tuf repo for targets and delegations

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -443,7 +443,7 @@ func (r *NotaryRepository) GetTargetByName(name string, roles ...string) (*Targe
 			if tgt == nil {
 				return tuf.ErrContinueWalk{}
 			}
-			// We found the target and validated path compatiblity in our walk,
+			// We found the target and validated path compatibility in our walk,
 			// so we should stop our walk and set the resultMeta and resultRoleName variables
 			if resultMeta, ok = tgt.Signed.Targets[name]; ok {
 				resultRoleName = validRole.Name

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1237,7 +1237,9 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	// setup delegated targets/level1 role
 	k, err := repo.CryptoService.Create("targets/level1", rootType)
 	assert.NoError(t, err)
-	err = repo.tufRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 	delegatedTarget := addTarget(t, repo, "current", "../fixtures/root-ca.crt", "targets/level1")
 	otherTarget := addTarget(t, repo, "other", "../fixtures/root-ca.crt", "targets/level1")
@@ -1245,7 +1247,9 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	// setup delegated targets/level2 role
 	k, err = repo.CryptoService.Create("targets/level2", rootType)
 	assert.NoError(t, err)
-	err = repo.tufRepo.UpdateDelegations("targets/level2", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level2", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level2", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 	// this target should not show up as the one in targets/level1 takes higher priority
 	_ = addTarget(t, repo, "current", "../fixtures/notary-server.crt", "targets/level2")
@@ -1275,7 +1279,9 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	// This is done separately due to target shadowing
 	k, err = repo.CryptoService.Create("targets/level1/level2", rootType)
 	assert.NoError(t, err)
-	err = repo.tufRepo.UpdateDelegations("targets/level1/level2", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{"level2"}, NewThreshold: 1})
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level1/level2", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1/level2", []string{"level2"}, []string{}, false)
 	assert.NoError(t, err)
 	nestedTarget := addTarget(t, repo, "level2", "../fixtures/notary-signer.crt", "targets/level1/level2")
 	// load the changelist for this repo
@@ -1385,13 +1391,17 @@ func TestListTargetRestrictsDelegationPaths(t *testing.T) {
 	// setup delegated targets/level1 role
 	k, err := repo.CryptoService.Create("targets/level1", data.ECDSAKey)
 	assert.NoError(t, err)
-	err = repo.tufRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 	addTarget(t, repo, "level1-target", "../fixtures/root-ca.crt", "targets/level1")
 	addTarget(t, repo, "incorrectly-named-target", "../fixtures/root-ca.crt", "targets/level1")
 
 	// setup delegated targets/level2 role
-	err = repo.tufRepo.UpdateDelegations("targets/level1/level2", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level1/level2", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1/level2", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 	addTarget(t, repo, "level2-target", "../fixtures/notary-server.crt", "targets/level1/level2")
 	addTarget(t, repo, "level1-level2-target", "../fixtures/notary-server.crt", "targets/level1/level2")
@@ -1410,14 +1420,14 @@ func TestListTargetRestrictsDelegationPaths(t *testing.T) {
 	assert.NoError(t, cl.Clear(""))
 
 	// Now restrict the paths
-	err = repo.tufRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddPaths: []string{"level1"}})
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1", []string{"level1"}, []string{}, false)
 	assert.NoError(t, err)
-	err = repo.tufRepo.UpdateDelegations("targets/level1/level2", changelist.TufDelegation{AddPaths: []string{"level1-level2", "level2"}})
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1/level2", []string{"level1-level2", "level2"}, []string{}, false)
 	assert.NoError(t, err)
 
-	err = repo.tufRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{RemovePaths: []string{""}})
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1", []string{}, []string{""}, false)
 	assert.NoError(t, err)
-	err = repo.tufRepo.UpdateDelegations("targets/level1/level2", changelist.TufDelegation{RemovePaths: []string{""}})
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1/level2", []string{}, []string{""}, false)
 	assert.NoError(t, err)
 
 	// load the changelist for this repo

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1218,18 +1218,16 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	// setup delegated targets/level1 role
 	k, err := repo.CryptoService.Create("targets/level1", rootType)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""})
+	err = repo.tufRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
 	assert.NoError(t, err)
-	repo.tufRepo.UpdateDelegations(r, []data.PublicKey{k})
 	delegatedTarget := addTarget(t, repo, "current", "../fixtures/root-ca.crt", "targets/level1")
 	otherTarget := addTarget(t, repo, "other", "../fixtures/root-ca.crt", "targets/level1")
 
 	// setup delegated targets/level2 role
 	k, err = repo.CryptoService.Create("targets/level2", rootType)
 	assert.NoError(t, err)
-	r, err = data.NewRole("targets/level2", 1, []string{k.ID()}, []string{""})
+	err = repo.tufRepo.UpdateDelegations("targets/level2", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
 	assert.NoError(t, err)
-	repo.tufRepo.UpdateDelegations(r, []data.PublicKey{k})
 	// this target should not show up as the one in targets/level1 takes higher priority
 	_ = addTarget(t, repo, "current", "../fixtures/notary-server.crt", "targets/level2")
 	// this target should show up as the name doesn't exist elsewhere

--- a/client/delegations.go
+++ b/client/delegations.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary"
 	"github.com/docker/notary/client/changelist"
-	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/store"
 	"github.com/docker/notary/tuf/utils"
@@ -255,10 +254,7 @@ func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
 	allDelegations := []*data.Role{}
 
 	// Define a visitor function to populate the delegations list and translate their key IDs to canonical IDs
-	delegationCanonicalListVisitor := func(tgt *data.SignedTargets, validRole data.DelegationRole) error {
-		if tgt == nil {
-			return tuf.ErrContinueWalk{}
-		}
+	delegationCanonicalListVisitor := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
 		// For the return list, update with a copy that includes canonicalKeyIDs
 		// These aren't validated by the validRole
 		canonicalDelegations, err := translateDelegationsToCanonicalIDs(tgt.Signed.Delegations)
@@ -266,7 +262,7 @@ func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
 			return err
 		}
 		allDelegations = append(allDelegations, canonicalDelegations...)
-		return tuf.ErrContinueWalk{}
+		return nil
 	}
 	err := r.tufRepo.WalkTargets("", "", delegationCanonicalListVisitor)
 	if err != nil {

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -80,18 +80,8 @@ func changeTargetsDelegation(repo *tuf.Repo, c changelist.Change) error {
 		if err != nil {
 			return err
 		}
-		_, err = repo.GetDelegationRole(c.Scope())
-		if _, ok := err.(data.ErrInvalidRole); err != nil && !ok {
-			// error that wasn't ErrInvalidRole
-			return err
-		}
 
-		if err == nil {
-			// role existed, merge paths and keys to this copy of the delegation role
-			addTD := changelist.TufDelegation{AddPaths: td.AddPaths, AddKeys: td.AddKeys}
-			return repo.UpdateDelegations(c.Scope(), addTD)
-		}
-		// try to create brand new role
+		// try to create brand new role or update one
 		createTD := changelist.TufDelegation{AddPaths: td.AddPaths, AddKeys: td.AddKeys, NewThreshold: notary.MinThreshold}
 		return repo.UpdateDelegations(c.Scope(), createTD)
 	case changelist.ActionUpdate:

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -782,8 +782,9 @@ func TestApplyChangelistCreatesDelegation(t *testing.T) {
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{newKey}, AddPaths: []string{""}, NewThreshold: 1})
+	err = repo.UpdateDelegationKeys("targets/level1", []data.PublicKey{newKey}, []string{}, 1)
 	assert.NoError(t, err)
+	err = repo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
 	delete(repo.Targets, "targets/level1")
 
 	hash := sha256.Sum256([]byte{})
@@ -820,10 +821,14 @@ func TestApplyChangelistTargetsToMultipleRoles(t *testing.T) {
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{newKey}, AddPaths: []string{""}, NewThreshold: 1})
+	err = repo.UpdateDelegationKeys("targets/level1", []data.PublicKey{newKey}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations("targets/level2", changelist.TufDelegation{AddKeys: []data.PublicKey{newKey}, AddPaths: []string{""}, NewThreshold: 1})
+	err = repo.UpdateDelegationKeys("targets/level2", []data.PublicKey{newKey}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.UpdateDelegationPaths("targets/level2", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 
 	hash := sha256.Sum256([]byte{})
@@ -936,7 +941,9 @@ func TestChangeTargetMetaDoesntFallbackIfPrefixError(t *testing.T) {
 	newKey, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
 
-	err = repo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{newKey}, AddPaths: []string{"pathprefix"}, NewThreshold: 1})
+	err = repo.UpdateDelegationKeys("targets/level1", []data.PublicKey{newKey}, []string{}, 1)
+	assert.NoError(t, err)
+	err = repo.UpdateDelegationPaths("targets/level1", []string{"pathprefix"}, []string{}, false)
 	assert.NoError(t, err)
 
 	hash := sha256.Sum256([]byte{})

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -445,7 +445,7 @@ func TestApplyTargetsDelegationEditNonExisting(t *testing.T) {
 
 	err = applyTargetsChange(repo, ch)
 	assert.Error(t, err)
-	assert.IsType(t, data.ErrNoSuchRole{}, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
 }
 
 func TestApplyTargetsDelegationCreateAlreadyExisting(t *testing.T) {

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf"
@@ -860,7 +859,9 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
 
-	err = baseRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	err = baseRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = baseRepo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 
 	// no targets file is created for the new delegations, so force one
@@ -909,7 +910,9 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
 
-	err = baseRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	err = baseRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = baseRepo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 
 	// no targets file is created for the new delegations, so force one
@@ -965,7 +968,9 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
 
-	err = baseRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	err = baseRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
+	assert.NoError(t, err)
+	err = baseRepo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
 	assert.NoError(t, err)
 
 	// no targets file is created for the new delegations, so force one

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/notary/client/changelist"
+	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
@@ -14,8 +16,6 @@ import (
 	"github.com/docker/notary/tuf/testutils"
 	"github.com/docker/notary/tuf/validation"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/docker/notary/server/storage"
 )
 
 func copyTimestampKey(t *testing.T, fromRepo *tuf.Repo,
@@ -859,10 +859,8 @@ func TestValidateTargetsLoadParent(t *testing.T) {
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""})
-	assert.NoError(t, err)
 
-	err = baseRepo.UpdateDelegations(r, []data.PublicKey{k})
+	err = baseRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
 	assert.NoError(t, err)
 
 	// no targets file is created for the new delegations, so force one
@@ -910,10 +908,9 @@ func TestValidateTargetsParentInUpdate(t *testing.T) {
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""})
-	assert.NoError(t, err)
 
-	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
+	err = baseRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	assert.NoError(t, err)
 
 	// no targets file is created for the new delegations, so force one
 	baseRepo.InitTargets("targets/level1")
@@ -967,10 +964,9 @@ func TestValidateTargetsParentNotFound(t *testing.T) {
 
 	k, err := cs.Create("targets/level1", data.ED25519Key)
 	assert.NoError(t, err)
-	r, err := data.NewRole("targets/level1", 1, []string{k.ID()}, []string{""})
-	assert.NoError(t, err)
 
-	baseRepo.UpdateDelegations(r, []data.PublicKey{k})
+	err = baseRepo.UpdateDelegations("targets/level1", changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+	assert.NoError(t, err)
 
 	// no targets file is created for the new delegations, so force one
 	baseRepo.InitTargets("targets/level1")

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -536,37 +536,3 @@ func (c Client) getTargetsFile(role string, snapshotMeta data.Files, consistent 
 	}
 	return s, nil
 }
-
-// TargetMeta ensures the repo is up to date. It assumes downloadTargets
-// has already downloaded all delegated roles
-func (c Client) TargetMeta(role, path string, excludeRoles ...string) (*data.FileMeta, string) {
-	excl := make(map[string]bool)
-	for _, r := range excludeRoles {
-		excl[r] = true
-	}
-
-	// FIFO list of targets delegations to inspect for target
-	roles := []string{role}
-	var (
-		meta *data.FileMeta
-		curr string
-	)
-	for len(roles) > 0 {
-		// have to do these lines here because of order of execution in for statement
-		curr = roles[0]
-		roles = roles[1:]
-
-		meta = c.local.TargetMeta(curr, path)
-		if meta != nil {
-			// we found the target!
-			return meta, curr
-		}
-		delegations := c.local.TargetDelegations(curr, path)
-		for _, d := range delegations {
-			if !excl[d.Name] {
-				roles = append(roles, d.Name)
-			}
-		}
-	}
-	return meta, ""
-}

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/notary/tuf/testutils"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
@@ -411,7 +410,9 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 		assert.NoError(t, err)
 
 		// add role to repo
-		err = repo.UpdateDelegations(r, changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+		err = repo.UpdateDelegationKeys(r, []data.PublicKey{k}, []string{}, 1)
+		assert.NoError(t, err)
+		err = repo.UpdateDelegationPaths(r, []string{""}, []string{}, false)
 		assert.NoError(t, err)
 		repo.InitTargets(r)
 	}

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/notary/tuf/testutils"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
@@ -408,11 +409,10 @@ func TestDownloadTargetsDeepHappy(t *testing.T) {
 		// create role
 		k, err := cs.Create(r, data.ED25519Key)
 		assert.NoError(t, err)
-		role, err := data.NewRole(r, 1, []string{k.ID()}, []string{""})
-		assert.NoError(t, err)
 
 		// add role to repo
-		repo.UpdateDelegations(role, []data.PublicKey{k})
+		err = repo.UpdateDelegations(r, changelist.TufDelegation{AddKeys: []data.PublicKey{k}, AddPaths: []string{""}, NewThreshold: 1})
+		assert.NoError(t, err)
 		repo.InitTargets(r)
 	}
 

--- a/tuf/data/root.go
+++ b/tuf/data/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"fmt"
 	"github.com/docker/go/canonical/json"
 )
 

--- a/tuf/data/root.go
+++ b/tuf/data/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"fmt"
 	"github.com/docker/go/canonical/json"
 )
 
@@ -83,6 +84,34 @@ func NewRoot(keys map[string]PublicKey, roles map[string]*RootRole, consistent b
 	}
 
 	return signedRoot, nil
+}
+
+// BuildBaseRole returns a copy of a BaseRole using the information in this SignedRoot for the specified role name.
+// Will error for invalid role name or key metadata within this SignedRoot
+func (r SignedRoot) BuildBaseRole(roleName string) (BaseRole, error) {
+	roleData, ok := r.Signed.Roles[roleName]
+	if !ok {
+		return BaseRole{}, ErrInvalidRole{Role: roleName, Reason: "role not found in root file"}
+	}
+	// Get all public keys for the base role from TUF metadata
+	keyIDs := roleData.KeyIDs
+	pubKeys := make(map[string]PublicKey)
+	for _, keyID := range keyIDs {
+		pubKey, ok := r.Signed.Keys[keyID]
+		if !ok {
+			return BaseRole{}, ErrInvalidRole{
+				Role:   roleName,
+				Reason: fmt.Sprintf("key with ID %s was not found in root metadata", keyID),
+			}
+		}
+		pubKeys[keyID] = pubKey
+	}
+
+	return BaseRole{
+		Name:      roleName,
+		Keys:      pubKeys,
+		Threshold: roleData.Threshold,
+	}, nil
 }
 
 // ToSigned partially serializes a SignedRoot for further signing

--- a/tuf/data/targets.go
+++ b/tuf/data/targets.go
@@ -93,29 +93,43 @@ func (t SignedTargets) GetValidDelegations(parent DelegationRole) []DelegationRo
 	return result
 }
 
+// BuildDelegationRole returns a copy of a DelegationRole using the information in this SignedTargets for the specified role name.
+// Will error for invalid role name or key metadata within this SignedTargets.  Path data is not validated.
+func (t *SignedTargets) BuildDelegationRole(roleName string) (DelegationRole, error) {
+	for _, role := range t.Signed.Delegations.Roles {
+		if role.Name == roleName {
+			pubKeys := make(map[string]PublicKey)
+			for _, keyID := range role.KeyIDs {
+				pubKey, ok := t.Signed.Delegations.Keys[keyID]
+				if !ok {
+					// Couldn't retrieve all keys, so stop walking and return invalid role
+					return DelegationRole{}, ErrInvalidRole{Role: roleName, Reason: "delegation does not exist with all specified keys"}
+				}
+				pubKeys[keyID] = pubKey
+			}
+			return DelegationRole{
+				BaseRole: BaseRole{
+					Name:      role.Name,
+					Keys:      pubKeys,
+					Threshold: role.Threshold,
+				},
+				Paths: role.Paths,
+			}, nil
+		}
+	}
+	return DelegationRole{}, ErrNoSuchRole{Role: roleName}
+}
+
 // helper function to create DelegationRole structures from all delegations in a SignedTargets,
 // these delegations are read directly from the SignedTargets and not modified or validated
 func (t SignedTargets) buildDelegationRoles() []DelegationRole {
 	var roles []DelegationRole
 	for _, roleData := range t.Signed.Delegations.Roles {
-		keyIDs := roleData.KeyIDs
-		pubKeys := make(map[string]PublicKey)
-		for _, keyID := range keyIDs {
-			pubKey, ok := t.Signed.Delegations.Keys[keyID]
-			if !ok {
-				continue
-			}
-			pubKeys[keyID] = pubKey
+		delgRole, err := t.BuildDelegationRole(roleData.Name)
+		if err != nil {
+			continue
 		}
-
-		roles = append(roles, DelegationRole{
-			BaseRole: BaseRole{
-				Name:      roleData.Name,
-				Keys:      pubKeys,
-				Threshold: roleData.Threshold,
-			},
-			Paths: roleData.Paths,
-		})
+		roles = append(roles, delgRole)
 	}
 	return roles
 }

--- a/tuf/data/targets.go
+++ b/tuf/data/targets.go
@@ -93,7 +93,8 @@ func (t SignedTargets) GetValidDelegations(parent DelegationRole) []DelegationRo
 	return result
 }
 
-// helper function to create DelegationRole structures from all delegations in a SignedTargets
+// helper function to create DelegationRole structures from all delegations in a SignedTargets,
+// these delegations are read directly from the SignedTargets and not modified or validated
 func (t SignedTargets) buildDelegationRoles() []DelegationRole {
 	var roles []DelegationRole
 	for _, roleData := range t.Signed.Delegations.Roles {

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/notary/tuf/utils"
 	fuzz "github.com/google/gofuzz"
 
+	"github.com/docker/notary/client/changelist"
 	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/signed"
 )
@@ -80,11 +81,7 @@ func EmptyRepo(gun string, delegationRoles ...string) (*tuf.Repo, signed.CryptoS
 		if err != nil {
 			return nil, nil, err
 		}
-		role, err := data.NewRole(delgName, 1, []string{}, []string{""})
-		if err != nil {
-			return nil, nil, err
-		}
-		if err := r.UpdateDelegations(role, []data.PublicKey{delgKey}); err != nil {
+		if err := r.UpdateDelegations(delgName, changelist.TufDelegation{AddKeys: []data.PublicKey{delgKey}, AddPaths: []string{""}, NewThreshold: 1, NewName: delgName}); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/notary/tuf/utils"
 	fuzz "github.com/google/gofuzz"
 
-	"github.com/docker/notary/client/changelist"
 	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/signed"
 )
@@ -81,7 +80,10 @@ func EmptyRepo(gun string, delegationRoles ...string) (*tuf.Repo, signed.CryptoS
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := r.UpdateDelegations(delgName, changelist.TufDelegation{AddKeys: []data.PublicKey{delgKey}, AddPaths: []string{""}, NewThreshold: 1}); err != nil {
+		if err := r.UpdateDelegationKeys(delgName, []data.PublicKey{delgKey}, []string{}, 1); err != nil {
+			return nil, nil, err
+		}
+		if err := r.UpdateDelegationPaths(delgName, []string{""}, []string{}, false); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -81,7 +81,7 @@ func EmptyRepo(gun string, delegationRoles ...string) (*tuf.Repo, signed.CryptoS
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := r.UpdateDelegations(delgName, changelist.TufDelegation{AddKeys: []data.PublicKey{delgKey}, AddPaths: []string{""}, NewThreshold: 1, NewName: delgName}); err != nil {
+		if err := r.UpdateDelegations(delgName, changelist.TufDelegation{AddKeys: []data.PublicKey{delgKey}, AddPaths: []string{""}, NewThreshold: 1}); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -390,7 +390,7 @@ func TestDeleteDelegations(t *testing.T) {
 	_, ok = repo.Snapshot.Signed.Meta["targets/test"]
 	assert.True(t, ok)
 
-	assert.NoError(t, repo.DeleteDelegation(*role))
+	assert.NoError(t, repo.DeleteDelegation(role.Name))
 	assert.Len(t, r.Signed.Delegations.Roles, 0)
 	assert.Len(t, r.Signed.Delegations.Keys, 0)
 	assert.True(t, r.Dirty)
@@ -420,7 +420,7 @@ func TestDeleteDelegationsRoleNotExistBecauseNoParentMeta(t *testing.T) {
 
 	delRole, err := data.NewRole("targets/test/a", 1, []string{testKey.ID()}, []string{"test"})
 
-	err = repo.DeleteDelegation(*delRole)
+	err = repo.DeleteDelegation(delRole.Name)
 	assert.NoError(t, err)
 	// still no metadata
 	_, ok = repo.Targets["targets/test"]
@@ -439,7 +439,7 @@ func TestDeleteDelegationsRoleNotExist(t *testing.T) {
 	role, err := data.NewRole("targets/test", 1, []string{}, []string{""})
 	assert.NoError(t, err)
 
-	err = repo.DeleteDelegation(*role)
+	err = repo.DeleteDelegation(role.Name)
 	assert.NoError(t, err)
 	r, ok := repo.Targets[data.CanonicalTargetsRole]
 	assert.True(t, ok)
@@ -457,7 +457,7 @@ func TestDeleteDelegationsInvalidRole(t *testing.T) {
 	invalidRole, err := data.NewRole("root", 1, []string{}, []string{""})
 	assert.NoError(t, err)
 
-	err = repo.DeleteDelegation(*invalidRole)
+	err = repo.DeleteDelegation(invalidRole.Name)
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
 
@@ -473,7 +473,7 @@ func TestDeleteDelegationsParentMissing(t *testing.T) {
 	testRole, err := data.NewRole("targets/test/deep", 1, []string{}, []string{""})
 	assert.NoError(t, err)
 
-	err = repo.DeleteDelegation(*testRole)
+	err = repo.DeleteDelegation(testRole.Name)
 	assert.Error(t, err)
 	assert.IsType(t, data.ErrInvalidRole{}, err)
 
@@ -514,7 +514,7 @@ func TestDeleteDelegationsMissingParentSigningKey(t *testing.T) {
 
 	// delete all signing keys
 	repo.cryptoService = signed.NewEd25519()
-	err = repo.DeleteDelegation(*role)
+	err = repo.DeleteDelegation(role.Name)
 	assert.Error(t, err)
 	assert.IsType(t, signed.ErrNoKeys{}, err)
 
@@ -553,7 +553,7 @@ func TestDeleteDelegationsMidSliceRole(t *testing.T) {
 	err = repo.UpdateDelegations(role3, data.KeyList{testKey})
 	assert.NoError(t, err)
 
-	err = repo.DeleteDelegation(*role2)
+	err = repo.DeleteDelegation(role2.Name)
 	assert.NoError(t, err)
 
 	r, ok := repo.Targets[data.CanonicalTargetsRole]

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -874,16 +874,12 @@ func TestGetDelegationRolesInvalidPaths(t *testing.T) {
 
 	testKey2, err := ed25519.Create("targets/test/b", data.ED25519Key)
 	assert.NoError(t, err)
-	// Now we add a delegation with a path that is not prefixed by its parent delegation, the invalid path won't be added
+	// Now we add a delegation with a path that is not prefixed by its parent delegation, the invalid path can't be added so there is an error
 	err = repo.UpdateDelegations("targets/test/b", changelist.TufDelegation{AddKeys: []data.PublicKey{testKey2}, AddPaths: []string{"invalidpath"}, NewThreshold: 1})
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	assert.IsType(t, data.ErrInvalidRole{}, err)
 
-	// Updating the delegation will restrict paths
-	delgRole, err := repo.GetDelegationRole("targets/test/b")
-	assert.NoError(t, err)
-	assert.NotContains(t, delgRole.Paths, "invalidpath")
-
-	delgRole, err = repo.GetDelegationRole("targets/test")
+	delgRole, err := repo.GetDelegationRole("targets/test")
 	assert.NoError(t, err)
 	assert.Contains(t, delgRole.Paths, "path")
 	assert.Contains(t, delgRole.Paths, "anotherpath")

--- a/tuf/utils/utils.go
+++ b/tuf/utils/utils.go
@@ -62,6 +62,17 @@ func StrSliceContains(ss []string, s string) bool {
 	return false
 }
 
+// StrSliceRemove removes the the given string from the slice, returning a new slice
+func StrSliceRemove(ss []string, s string) []string {
+	res := []string{}
+	for _, v := range ss {
+		if v != s {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
 // StrSliceContainsI checks if the given string appears in the slice
 // in a case insensitive manner
 func StrSliceContainsI(ss []string, s string) bool {


### PR DESCRIPTION
Defines a `WalkTargets` that walks the targets and delegations structure in a uniform way, and we can pass closures to perform special visit functions to list targets, get targets by name, and get delegation roles.  Also used for adding/removing targets and delegation roles.

This PR also removes unused code that would also find targets or get target meta by walking the targets structure.

Closes #560

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>