### PR TITLE
remove path hash prefix from TargetsDelegations

### DIFF
--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -539,9 +538,6 @@ func (c Client) TargetMeta(role, path string, excludeRoles ...string) (*data.Fil
 		excl[r] = true
 	}
 
-	pathDigest := sha256.Sum256([]byte(path))
-	pathHex := hex.EncodeToString(pathDigest[:])
-
 	// FIFO list of targets delegations to inspect for target
 	roles := []string{role}
 	var (
@@ -558,7 +554,7 @@ func (c Client) TargetMeta(role, path string, excludeRoles ...string) (*data.Fil
 			// we found the target!
 			return meta, curr
 		}
-		delegations := c.local.TargetDelegations(curr, path, pathHex)
+		delegations := c.local.TargetDelegations(curr, path)
 		for _, d := range delegations {
 			if !excl[d.Name] {
 				roles = append(roles, d.Name)

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -3,8 +3,6 @@ package tuf
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -548,11 +546,7 @@ func (tr Repo) TargetMeta(role, path string) *data.FileMeta {
 
 // TargetDelegations returns a slice of Roles that are valid publishers
 // for the target path provided.
-func (tr Repo) TargetDelegations(role, path, pathHex string) []*data.Role {
-	if pathHex == "" {
-		pathDigest := sha256.Sum256([]byte(path))
-		pathHex = hex.EncodeToString(pathDigest[:])
-	}
+func (tr Repo) TargetDelegations(role, path string) []*data.Role {
 	var roles []*data.Role
 	if t, ok := tr.Targets[role]; ok {
 		for _, r := range t.Signed.Delegations.Roles {
@@ -571,8 +565,6 @@ func (tr Repo) TargetDelegations(role, path, pathHex string) []*data.Role {
 // N.B. Multiple entries may exist in different delegated roles
 //      for the same target. Only the first one encountered is returned.
 func (tr Repo) FindTarget(path string) *data.FileMeta {
-	pathDigest := sha256.Sum256([]byte(path))
-	pathHex := hex.EncodeToString(pathDigest[:])
 
 	var walkTargets func(role string) *data.FileMeta
 	walkTargets = func(role string) *data.FileMeta {
@@ -581,7 +573,7 @@ func (tr Repo) FindTarget(path string) *data.FileMeta {
 		}
 		// Depth first search of delegations based on order
 		// as presented in current targets file for role:
-		for _, r := range tr.TargetDelegations(role, path, pathHex) {
+		for _, r := range tr.TargetDelegations(role, path) {
 			if m := walkTargets(r.Name); m != nil {
 				return m
 			}


### PR DESCRIPTION
I noticed a stray and unused `pathHex` that we should remove, since we no longer support path hash prefixes

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>