### PR TITLE
check validity of children during download

### DIFF
--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"path"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary"
@@ -428,7 +429,11 @@ func (c *Client) downloadTargets(role string) error {
 
 		// push delegated roles contained in the targets file onto the stack
 		for _, r := range t.Signed.Delegations.Roles {
-			stack.Push(r.Name)
+			if path.Dir(r.Name) == role {
+				// only load children that are direct 1st generation descendants
+				// of the role we've just downloaded
+				stack.Push(r.Name)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
I originally also added a check to prevent overwriting of targets objects in tuf.Repo.SetTargets but this broke operation as we current re-use the repo object. Adding the check during download should be sufficient to ensure we never write an incorrect child as a second call to SetTargets with an existing delegation will set a validated object.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)