### PR TITLE
Add script that "vendors" notary into docker and runs trust integration tests

### DIFF
--- a/misc/docker-integration-test.py
+++ b/misc/docker-integration-test.py
@@ -4,91 +4,111 @@ docker client binary with an API version compatible with the existing
 daemon
 
 Usage:
-python docker-integration-test.py <directory to build notary>
+python docker-integration-test.py
+
+This assumes that your docker directory is in $GOPATH/src/github.com/docker/docker
+and your notary directory, irrespective of where this script is located, is
+at $GOPATH/src/github.com/docker/notary.
 """
 from __future__ import print_function
-import inspect
 import os
 import re
 import shutil
 import subprocess
 import sys
 
-def this_script_location():
+def from_gopath(gopkg):
     """
-    Returns the absolute path to directory where this script lives, so that
-    we don't depend on the CWD for looking for things.
+    Gets the location of the go source given go package, based on the $GOPATH.
     """
-    script_filename = inspect.getfile(inspect.currentframe())
-    return os.path.dirname(os.path.abspath(script_filename))
+    gopaths = os.getenv("GOPATH")
+    for path in gopaths.split(":"):
+        maybe_path = os.path.abspath(os.path.expanduser(os.path.join(
+            path, "src", *gopkg.split("/"))))
+        if os.path.isdir(maybe_path):
+            return maybe_path
+    return ""
 
-def fake_vendor(docker_dir="docker"):
+
+DOCKER_DIR = from_gopath("github.com/docker/docker")
+NOTARY_DIR = from_gopath("github.com/docker/notary")
+
+
+def fake_vendor():
     """
     "vendors" notary into docker by copying all of notary into the docker
     vendor directory - also appending several lines into the Dockerfile because
     it pulls down notary from github and builds the binaries
     """
-    docker_dir = os.path.abspath(os.path.expanduser(docker_dir))
     docker_notary_relpath = "vendor/src/github.com/docker/notary"
-    notary_loc = os.path.dirname(this_script_location())  # this script is in misc
-    docker_notary_abspath = os.path.join(docker_dir, docker_notary_relpath)
+    docker_notary_abspath = os.path.join(DOCKER_DIR, docker_notary_relpath)
 
-    print("copying notary ({0}) into {1}".format(notary_loc, docker_notary_abspath))
+    print("copying notary ({0}) into {1}".format(NOTARY_DIR, docker_notary_abspath))
 
     def ignore_dirs(walked_dir, _):
         """
         Don't vendor everything, particularly not the docker directory
         recursively, if it happened to be in the notary directory
         """
-        if walked_dir == notary_loc:
+        if walked_dir == NOTARY_DIR:
             return [".git", ".cover", "docs", "bin"]
-        elif walked_dir == os.path.join(notary_loc, "fixtures"):
+        elif walked_dir == os.path.join(NOTARY_DIR, "fixtures"):
             return ["compatibility"]
-        elif walked_dir == os.path.dirname(docker_dir):  # don't recursively copy!
-            return [os.path.basename(docker_dir)]
         return []
 
     if os.path.exists(docker_notary_abspath):
         shutil.rmtree(docker_notary_abspath)
     shutil.copytree(
-        notary_loc, docker_notary_abspath, symlinks=True, ignore=ignore_dirs)
+        NOTARY_DIR, docker_notary_abspath, symlinks=True, ignore=ignore_dirs)
 
     # hack this because docker/docker's Dockerfile checks out a particular version of notary
     # based on a tag or SHA, and we want to build based on what was vendored in
-    with open(os.path.join(docker_dir, "Dockerfile"), 'a+') as dockerfile:
-        dockerfile.write(
-            "\n"
-            "RUN set -x && "
-            "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
-            "go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server &&"
-            "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
-            "go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary")
+    dockerfile_addition = ("\n"
+        "RUN set -x && "
+        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
+        "go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server &&"
+        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
+        "go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary")
+
+    with open(os.path.join(DOCKER_DIR, "Dockerfile")) as dockerfile:
+        text = dockerfile.read()
+
+    if not text.endswith(dockerfile_addition):
+        with open(os.path.join(DOCKER_DIR, "Dockerfile"), 'a+') as dockerfile:
+            dockerfile.write(dockerfile_addition)
 
     # hack the makefile so that we tag the built image as something else so we
     # don't interfere with any other docker test builds
-    with open(os.path.join(docker_dir, "Makefile"), 'r') as makefile:
+    with open(os.path.join(DOCKER_DIR, "Makefile"), 'r') as makefile:
         makefiletext = makefile.read()
 
-    with open(os.path.join(docker_dir, "Makefile"), 'wb') as makefile:
+    with open(os.path.join(DOCKER_DIR, "Makefile"), 'wb') as makefile:
         image_name = os.getenv("DOCKER_TEST_IMAGE_NAME", "notary-docker-vendor-test")
         text = re.sub("^DOCKER_IMAGE := .+$", "DOCKER_IMAGE := {0}".format(image_name),
                       makefiletext, 1, flags=re.M)
         makefile.write(text)
 
-def run_integration_test(docker_dir="docker"):
+def run_integration_test():
     """
     Presumes that the fake vendoring has already happened - this runs the
     integration tests.
     """
-    docker_dir = os.path.abspath(os.path.expanduser(docker_dir))
     env = os.environ.copy()
     env["TESTFLAGS"] = '-check.f DockerTrustSuite*'
     subprocess.check_call(
-        "make test-integration-cli".split(), cwd=docker_dir, env=env)
+        "make test-integration-cli".split(), cwd=DOCKER_DIR, env=env)
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("\nUsage: python {0} <docker source directory>\n".format(sys.argv[0]))
+    if len(sys.argv) > 1:
+        print("\nWarning: Ignoring all extra arguments: {0}".format(" ".join(sys.argv[1:])))
+        print("\nUsage: python {0}\n\n".format(sys.argv[0]))
+    if DOCKER_DIR == "":
+        print("ERROR: Could not find github.com/docker/docker in your GOPATH='{0}'"
+              .format(os.getenv("GOPATH")))
         sys.exit(1)
-    fake_vendor(sys.argv[1])
-    run_integration_test(sys.argv[1])
+    if NOTARY_DIR == "":
+        print("ERROR: Could not find github.com/docker/notary in your GOPATH='{0}'"
+              .format(os.getenv("GOPATH")))
+        sys.exit(1)
+    fake_vendor()
+    run_integration_test()

--- a/misc/docker-integration-test.py
+++ b/misc/docker-integration-test.py
@@ -1,0 +1,94 @@
+"""
+"vendors" notary into docker and runs integration tests - then builds the
+docker client binary with an API version compatible with the existing
+daemon
+
+Usage:
+python docker-integration-test.py <directory to build notary>
+"""
+from __future__ import print_function
+import inspect
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+def this_script_location():
+    """
+    Returns the absolute path to directory where this script lives, so that
+    we don't depend on the CWD for looking for things.
+    """
+    script_filename = inspect.getfile(inspect.currentframe())
+    return os.path.dirname(os.path.abspath(script_filename))
+
+def fake_vendor(docker_dir="docker"):
+    """
+    "vendors" notary into docker by copying all of notary into the docker
+    vendor directory - also appending several lines into the Dockerfile because
+    it pulls down notary from github and builds the binaries
+    """
+    docker_dir = os.path.abspath(os.path.expanduser(docker_dir))
+    docker_notary_relpath = "vendor/src/github.com/docker/notary"
+    notary_loc = os.path.dirname(this_script_location())  # this script is in misc
+    docker_notary_abspath = os.path.join(docker_dir, docker_notary_relpath)
+
+    print("copying notary ({0}) into {1}".format(notary_loc, docker_notary_abspath))
+
+    def ignore_dirs(walked_dir, _):
+        """
+        Don't vendor everything, particularly not the docker directory
+        recursively, if it happened to be in the notary directory
+        """
+        if walked_dir == notary_loc:
+            return [".git", ".cover", "docs", "bin"]
+        elif walked_dir == os.path.join(notary_loc, "fixtures"):
+            return ["compatibility"]
+        elif walked_dir == os.path.dirname(docker_dir):  # don't recursively copy!
+            return [os.path.basename(docker_dir)]
+        return []
+
+    if os.path.exists(docker_notary_abspath):
+        shutil.rmtree(docker_notary_abspath)
+    shutil.copytree(
+        notary_loc, docker_notary_abspath, symlinks=True, ignore=ignore_dirs)
+
+    # hack this because docker/docker's Dockerfile checks out a particular version of notary
+    # based on a tag or SHA, and we want to build based on what was vendored in
+    with open(os.path.join(docker_dir, "Dockerfile"), 'a+') as dockerfile:
+        dockerfile.write(
+            "\n"
+            "RUN set -x && "
+            "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
+            "go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server &&"
+            "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
+            "go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary")
+
+    # hack the makefile so that we tag the built image as something else so we
+    # don't interfere with any other docker test builds
+    with open(os.path.join(docker_dir, "Makefile"), 'r') as makefile:
+        makefiletext = makefile.read()
+
+    with open(os.path.join(docker_dir, "Makefile"), 'wb') as makefile:
+        image_name = os.getenv("DOCKER_TEST_IMAGE_NAME", "notary-docker-vendor-test")
+        text = re.sub("^DOCKER_IMAGE := .+$", "DOCKER_IMAGE := {0}".format(image_name),
+                      makefiletext, 1, flags=re.M)
+        makefile.write(text)
+
+def run_integration_test(docker_dir="docker"):
+    """
+    Presumes that the fake vendoring has already happened - this runs the
+    integration tests.
+    """
+    docker_dir = os.path.abspath(os.path.expanduser(docker_dir))
+    env = os.environ.copy()
+    env["TESTFLAGS"] = '-check.f DockerTrustSuite*'
+    subprocess.check_call(
+        "make test-integration-cli".split(), cwd=docker_dir, env=env)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("\nUsage: python {0} <docker source directory>\n".format(sys.argv[0]))
+        sys.exit(1)
+    fake_vendor(sys.argv[1])
+    run_integration_test(sys.argv[1])


### PR DESCRIPTION
This could be more clever and actually call the vendor script instead of just copying in the whole notary directory, if the SHA we are on is actually available on origin/remote, but I was hoping this would be a way to get the combo script into the docker-in-docker image as well so we can hopefully run a container that contains that script (I haven't figured out how to do that yet)