### PR TITLE
Fix server signed snapshot expiry/regeneration

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,13 +27,7 @@ import (
 )
 
 func init() {
-	data.SetDefaultExpiryTimes(
-		map[string]int{
-			"root":     3650,
-			"targets":  1095,
-			"snapshot": 1095,
-		},
-	)
+	data.SetDefaultExpiryTimes(notary.NotaryDefaultExpiries)
 }
 
 // ErrRepoNotInitialized is returned when trying to publish an uninitialized

--- a/const.go
+++ b/const.go
@@ -1,5 +1,9 @@
 package notary
 
+import (
+	"time"
+)
+
 // application wide constants
 const (
 	// MaxDownloadSize is the maximum size we'll download for metadata if no limit is given
@@ -24,4 +28,23 @@ const (
 	RootKeysSubdir = "root_keys"
 	// NonRootKeysSubdir is the subdirectory under PrivDir where non-root private keys are stored
 	NonRootKeysSubdir = "tuf_keys"
+
+	// Day is a duration of one day
+	Day  = 24 * time.Hour
+	Year = 365 * Day
+
+	// NotaryRootExpiry is the duration representing the expiry time of the Root role
+	NotaryRootExpiry      = 10 * Year
+	NotaryTargetsExpiry   = 3 * Year
+	NotarySnapshotExpiry  = 3 * Year
+	NotaryTimestampExpiry = 14 * Day
 )
+
+// NotaryDefaultExpiries is the construct used to configure the default expiry times of
+// the various role files.
+var NotaryDefaultExpiries = map[string]time.Duration{
+	"root":      NotaryRootExpiry,
+	"targets":   NotaryTargetsExpiry,
+	"snapshot":  NotarySnapshotExpiry,
+	"timestamp": NotaryTimestampExpiry,
+}

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/health"
 	"github.com/docker/distribution/registry/auth"
+	"github.com/docker/notary"
 	"github.com/docker/notary/server/handlers"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
@@ -19,11 +20,7 @@ import (
 )
 
 func init() {
-	data.SetDefaultExpiryTimes(
-		map[string]int{
-			"timestamp": 14,
-		},
-	)
+	data.SetDefaultExpiryTimes(notary.NotaryDefaultExpiries)
 }
 
 func prometheusOpts(operation string) prometheus.SummaryOpts {

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/notary/tuf/signed"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/notary/server/snapshot"
 	"github.com/docker/notary/server/storage"
 )
 
@@ -49,7 +50,7 @@ func GetOrCreateTimestampKey(gun string, store storage.MetaStore, crypto signed.
 // a new timestamp is generated either because none exists, or because the current
 // one has expired. Once generated, the timestamp is saved in the store.
 func GetOrCreateTimestamp(gun string, store storage.MetaStore, cryptoService signed.CryptoService) ([]byte, error) {
-	snapshot, err := store.GetCurrent(gun, "snapshot")
+	snapshot, err := snapshot.GetOrCreateSnapshot(gun, store, cryptoService)
 	if err != nil {
 		return nil, err
 	}

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -52,7 +52,11 @@ func TestGetTimestamp(t *testing.T) {
 	store := storage.NewMemStorage()
 	crypto := signed.NewEd25519()
 
-	snapshot := &data.SignedSnapshot{}
+	snapshot := &data.SignedSnapshot{
+		Signed: data.Snapshot{
+			Expires: data.DefaultExpires(data.CanonicalSnapshotRole),
+		},
+	}
 	snapJSON, _ := json.Marshal(snapshot)
 
 	store.UpdateCurrent("gun", storage.MetaUpdate{Role: "snapshot", Version: 0, Data: snapJSON})
@@ -68,7 +72,11 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 	store := storage.NewMemStorage()
 	crypto := signed.NewEd25519()
 
-	snapshot := data.SignedSnapshot{}
+	snapshot := &data.SignedSnapshot{
+		Signed: data.Snapshot{
+			Expires: data.DefaultExpires(data.CanonicalSnapshotRole),
+		},
+	}
 	snapshot.Signed.Version = 0
 	snapJSON, _ := json.Marshal(snapshot)
 
@@ -80,7 +88,11 @@ func TestGetTimestampNewSnapshot(t *testing.T) {
 	ts1, err := GetOrCreateTimestamp("gun", store, crypto)
 	assert.Nil(t, err, "GetTimestamp errored")
 
-	snapshot = data.SignedSnapshot{}
+	snapshot = &data.SignedSnapshot{
+		Signed: data.Snapshot{
+			Expires: data.DefaultExpires(data.CanonicalSnapshotRole),
+		},
+	}
 	snapshot.Signed.Version = 1
 	snapJSON, _ = json.Marshal(snapshot)
 


### PR DESCRIPTION
Two related fixes:

- The server was not setting the longer snapshot expiry time consistent with the client. 
- When generating a timestamp it was also retrieving the snapshot directly from the database and only validating the checksum still matched what was in the timestamp. Due to the addition of consistent downloads, this mean a new snapshot never got generated (when the server was responsible for this). It is necessary for `GetOrCreateTimestamp` to call `GetOrCreateSnapshot` to ensure a new snapshot is generated as and when required

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)