### PR TITLE
print IDs instead of key itself

### DIFF
--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -270,7 +270,7 @@ func (d *delegationCommander) delegationAdd(cmd *cobra.Command, args []string) e
 	cmd.Println("")
 	addingItems := ""
 	if len(pubKeyIDs) > 0 {
-		addingItems = addingItems + fmt.Sprintf("with keys %s, ", pubKeys)
+		addingItems = addingItems + fmt.Sprintf("with keys %s, ", pubKeyIDs)
 	}
 	if d.paths != nil || d.allPaths {
 		addingItems = addingItems + fmt.Sprintf("with paths [%s], ", prettyPrintPaths(d.paths))

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -203,6 +203,7 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", tempFile.Name())
 	assert.NoError(t, err)
 	assert.Contains(t, output, "Addition of delegation role")
+	assert.Contains(t, output, keyID)
 	assert.NotContains(t, output, "path")
 
 	// check status - see delegation
@@ -274,6 +275,7 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", tempFile2.Name(), "--paths", "path")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "Addition of delegation role")
+	assert.Contains(t, output, keyID2)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
@@ -320,6 +322,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", tempFile.Name(), tempFile2.Name(), "--paths", "path1,path2")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "Addition of delegation role")
+	assert.Contains(t, output, keyID)
+	assert.Contains(t, output, keyID2)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
@@ -600,6 +604,7 @@ func TestClientDelegationsPublishing(t *testing.T) {
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/releases", tempFile.Name(), "--paths", "\"\"")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "Addition of delegation role")
+	assert.Contains(t, output, canonicalKeyID)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")


### PR DESCRIPTION
Changes to print the canonical key IDs when adding a delegation, instead of the public key bytes.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>