### PR TITLE
Move yubikey import role check to avoid excessive passphrase prompting

### DIFF
--- a/trustmanager/yubikey/yubikeystore.go
+++ b/trustmanager/yubikey/yubikeystore.go
@@ -765,14 +765,14 @@ func (s *YubiKeyStore) ExportKey(keyID string) ([]byte, error) {
 // ImportKey imports a root key into a Yubikey
 func (s *YubiKeyStore) ImportKey(pemBytes []byte, keyPath string) error {
 	logrus.Debugf("Attempting to import: %s key inside of YubiKeyStore", keyPath)
+	if keyPath != data.CanonicalRootRole {
+		return fmt.Errorf("yubikey only supports storing root keys")
+	}
 	privKey, _, err := trustmanager.GetPasswdDecryptBytes(
 		s.passRetriever, pemBytes, "", "imported root")
 	if err != nil {
 		logrus.Debugf("Failed to get and retrieve a key from: %s", keyPath)
 		return err
-	}
-	if keyPath != data.CanonicalRootRole {
-		return fmt.Errorf("yubikey only supports storing root keys")
 	}
 	_, err = s.addKey(privKey.ID(), "root", privKey)
 	return err


### PR DESCRIPTION
When importing to a yubikeystore, we should reject non-root keys upfront before prompting for passphrases or attempting to read key bytes.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>