### PR TITLE
Remove delegation role fallback when applying targets changes

### DIFF
--- a/client/helpers.go
+++ b/client/helpers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path"
 	"strings"
 	"time"
 
@@ -130,22 +129,6 @@ func changeTargetsDelegation(repo *tuf.Repo, c changelist.Change) error {
 
 }
 
-// applies a function repeatedly, falling back on the parent role, until it no
-// longer can
-func doWithRoleFallback(role string, doFunc func(string) error) error {
-	for role == data.CanonicalTargetsRole || data.IsDelegation(role) {
-		err := doFunc(role)
-		if err == nil {
-			return nil
-		}
-		if _, ok := err.(data.ErrInvalidRole); !ok {
-			return err
-		}
-		role = path.Dir(role)
-	}
-	return data.ErrInvalidRole{Role: role}
-}
-
 func changeTargetMeta(repo *tuf.Repo, c changelist.Change) error {
 	var err error
 	switch c.Action() {
@@ -158,21 +141,16 @@ func changeTargetMeta(repo *tuf.Repo, c changelist.Change) error {
 		}
 		files := data.Files{c.Path(): *meta}
 
-		err = doWithRoleFallback(c.Scope(), func(role string) error {
-			_, e := repo.AddTargets(role, files)
-			return e
-		})
-		if err != nil {
+		// Attempt to add the target to this role, with no fallback
+		if _, err = repo.AddTargets(c.Scope(), files); err != nil {
 			logrus.Errorf("couldn't add target to %s: %s", c.Scope(), err.Error())
 		}
 
 	case changelist.ActionDelete:
 		logrus.Debug("changelist remove: ", c.Path())
 
-		err = doWithRoleFallback(c.Scope(), func(role string) error {
-			return repo.RemoveTargets(role, c.Path())
-		})
-		if err != nil {
+		// Attempt to remove the target from this role, with no fallback
+		if err = repo.RemoveTargets(c.Scope(), c.Path()); err != nil {
 			logrus.Errorf("couldn't remove target from %s: %s", c.Scope(), err.Error())
 		}
 

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -141,7 +141,7 @@ func changeTargetMeta(repo *tuf.Repo, c changelist.Change) error {
 		}
 		files := data.Files{c.Path(): *meta}
 
-		// Attempt to add the target to this role, with no fallback
+		// Attempt to add the target to this role
 		if _, err = repo.AddTargets(c.Scope(), files); err != nil {
 			logrus.Errorf("couldn't add target to %s: %s", c.Scope(), err.Error())
 		}
@@ -149,7 +149,7 @@ func changeTargetMeta(repo *tuf.Repo, c changelist.Change) error {
 	case changelist.ActionDelete:
 		logrus.Debug("changelist remove: ", c.Path())
 
-		// Attempt to remove the target from this role, with no fallback
+		// Attempt to remove the target from this role
 		if err = repo.RemoveTargets(c.Scope(), c.Path()); err != nil {
 			logrus.Errorf("couldn't remove target from %s: %s", c.Scope(), err.Error())
 		}

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -864,8 +864,8 @@ func TestApplyChangelistTargetsToMultipleRoles(t *testing.T) {
 	require.False(t, ok, "no change to targets/level2, so metadata not created")
 }
 
-// ApplyTargets does not fall back to role that exists when adding or deleting a change to a nonexistent delegation
-func TestApplyChangelistTargetsDoesNotFallbackRoles(t *testing.T) {
+// ApplyTargets fails when adding or deleting a change to a nonexistent delegation
+func TestApplyChangelistTargetsFailsNonexistentRole(t *testing.T) {
 	repo, _, err := testutils.EmptyRepo("docker.com/notary")
 	require.NoError(t, err)
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -227,7 +227,7 @@ other delegation roles will be supported in a future release. By default, Engine
 `targets/releases` role if it exists; if it does not exist, the Engine  will
 fall back to retrieving images signed by the default `targets` role.
 
-To use the `targets/releases` role for pushing and pulling images with content trust, follow the steps above to add and publish the delegation role with notary. When adding the delegation, the `--all-paths` flag should be used. By default, pushing with Docker Content Trust will attempt to add to the `targets/releases` role and will fallback to `targets` _only_ if the delegation does not exist.
+To use the `targets/releases` role for pushing and pulling images with content trust, follow the steps above to add and publish the delegation role with notary. When adding the delegation, the `--all-paths` flag should be used. By default, pushing with Docker Content Trust will attempt to add to whichever delegations exist directly under targets (ex: `targets/releases`, but not `targets/nested/delegation`).
 
 # Files and state on disk
 


### PR DESCRIPTION
Given the behavior proposed in https://github.com/docker/docker/pull/21046, the fallback behavior is no longer that necessary -- this PR removes the fallback logic when applying changes on targets entirely.

Docker will be able to determine the roles it will sign for from TUF metadata and private keys in its trust directory, so there is no need to silently fallback on the notary side (I'm especially worried about any potential role confusion)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>