### PR TITLE
json.RawMessage needs to be a pointer 

### DIFF
--- a/tuf/data/types.go
+++ b/tuf/data/types.go
@@ -126,9 +126,9 @@ var NotaryDefaultHashes = []string{notary.SHA256, notary.SHA512}
 // FileMeta contains the size and hashes for a metadata or target file. Custom
 // data can be optionally added.
 type FileMeta struct {
-	Length int64           `json:"length"`
-	Hashes Hashes          `json:"hashes"`
-	Custom json.RawMessage `json:"custom,omitempty"`
+	Length int64            `json:"length"`
+	Hashes Hashes           `json:"hashes"`
+	Custom *json.RawMessage `json:"custom,omitempty"`
 }
 
 // CheckHashes verifies all the checksums specified by the "hashes" of the payload.


### PR DESCRIPTION
As discovered during hackday, there are double encoding issues if a `json.RawMessage` object is included in a larger JSON object. The official "fix" is to use a `*json.RawMessage`

N.B. we don't use the Custom field anywhere (other than our hackday project which doesn't count) and it's set to `omitempty` so it doesn't appear in any of our json right now, this is an "if we use it in the future" fix