### PR TITLE
remove signatures that are no longer valid during signing, either bec…

### DIFF
--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -297,10 +297,17 @@ func testValidateSuccessfulRootRotation(t *testing.T, keyAlg, rootKeyType string
 	signedTestRoot, err := testRoot.ToSigned()
 	assert.NoError(t, err)
 
-	err = signed.Sign(cs, signedTestRoot, replRootKey)
+	baseRootRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		replRootKey,
+		origRootKey,
+	)
+
+	err = signed.Sign(cs, signedTestRoot, baseRootRole)
 	assert.NoError(t, err)
 
-	err = signed.Sign(cs, signedTestRoot, origRootKey)
+	err = signed.Sign(cs, signedTestRoot, baseRootRole)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -355,8 +362,13 @@ func testValidateRootRotationMissingOrigSig(t *testing.T, keyAlg, rootKeyType st
 	signedTestRoot, err := testRoot.ToSigned()
 	assert.NoError(t, err)
 
+	baseRootRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		replRootKey,
+	)
 	// We only sign with the new key, and not with the original one.
-	err = signed.Sign(cryptoService, signedTestRoot, replRootKey)
+	err = signed.Sign(cryptoService, signedTestRoot, baseRootRole)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM
@@ -414,8 +426,14 @@ func testValidateRootRotationMissingNewSig(t *testing.T, keyAlg, rootKeyType str
 	signedTestRoot, err := testRoot.ToSigned()
 	assert.NoError(t, err)
 
+	baseRootRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		origRootKey,
+	)
+
 	// We only sign with the old key, and not with the new one
-	err = signed.Sign(cryptoService, signedTestRoot, origRootKey)
+	err = signed.Sign(cryptoService, signedTestRoot, baseRootRole)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -183,7 +183,13 @@ func TestValidateRootRotation(t *testing.T) {
 
 	r, err = repo.SignRoot(data.DefaultExpires(data.CanonicalRootRole))
 	assert.NoError(t, err)
-	err = signed.Sign(crypto, r, rootKey, oldRootKey)
+	baseRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		rootKey,
+		oldRootKey,
+	)
+	err = signed.Sign(crypto, r, baseRole)
 	assert.NoError(t, err)
 
 	rt, err := data.RootFromSigned(r)

--- a/server/snapshot/snapshot.go
+++ b/server/snapshot/snapshot.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
+	"github.com/docker/notary"
 	"github.com/docker/notary/server/storage"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
@@ -110,7 +111,12 @@ func createSnapshot(gun string, sn *data.SignedSnapshot, store storage.MetaStore
 	if err != nil {
 		return nil, 0, err
 	}
-	err = signed.Sign(cryptoService, out, key)
+	baseSnapshotRole := data.NewBaseRole(
+		data.CanonicalSnapshotRole,
+		notary.MinThreshold,
+		key,
+	)
+	err = signed.Sign(cryptoService, out, baseSnapshotRole)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -2,6 +2,7 @@ package timestamp
 
 import (
 	"github.com/docker/go/canonical/json"
+	"github.com/docker/notary"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 
@@ -133,7 +134,12 @@ func CreateTimestamp(gun string, prev *data.SignedTimestamp, snapshot []byte, st
 		Signatures: ts.Signatures,
 		Signed:     sgndTs,
 	}
-	err = signed.Sign(cryptoService, out, key)
+	tsBaseRole := data.NewBaseRole(
+		data.CanonicalTimestampRole,
+		notary.MinThreshold,
+		key,
+	)
+	err = signed.Sign(cryptoService, out, tsBaseRole)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -60,7 +60,13 @@ func TestRotation(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, rootKey, replacementKey)
+	baseRootRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		rootKey,
+		replacementKey,
+	)
+	err = signed.Sign(signer, signedRoot, baseRootRole)
 	assert.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -122,7 +128,12 @@ func TestRotationNewSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, rootKey)
+	baseRootRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		rootKey,
+	)
+	err = signed.Sign(signer, signedRoot, baseRootRole)
 	assert.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool
@@ -185,7 +196,12 @@ func TestRotationOldSigMissing(t *testing.T) {
 
 	// Sign testRoot with both old and new keys
 	signedRoot, err := testRoot.ToSigned()
-	err = signed.Sign(signer, signedRoot, replacementKey)
+	baseRootRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		replacementKey,
+	)
+	err = signed.Sign(signer, signedRoot, baseRootRole)
 	assert.NoError(t, err, "Failed to sign root")
 	var origKeySig bool
 	var replKeySig bool

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -2,6 +2,7 @@ package signed
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -124,16 +125,8 @@ func VerifySignatures(s *data.Signed, roleData data.BaseRole) error {
 			logrus.Debugf("continuing b/c keyid lookup was nil: %s\n", sig.KeyID)
 			continue
 		}
-		// method lookup is consistent due to Unmarshal JSON doing lower case for us.
-		method := sig.Method
-		verifier, ok := Verifiers[method]
-		if !ok {
-			logrus.Debugf("continuing b/c signing method is not supported: %s\n", sig.Method)
-			continue
-		}
-
-		if err := verifier.Verify(key, sig.Signature, msg); err != nil {
-			logrus.Debugf("continuing b/c signature was invalid\n")
+		if err := VerifySignature(msg, sig, key); err != nil {
+			logrus.Debug(err.Error())
 			continue
 		}
 		valid[sig.KeyID] = struct{}{}
@@ -143,5 +136,20 @@ func VerifySignatures(s *data.Signed, roleData data.BaseRole) error {
 		return ErrRoleThreshold{}
 	}
 
+	return nil
+}
+
+// VerifySignature checks a single signature and public key against a payload
+func VerifySignature(msg []byte, sig data.Signature, pk data.PublicKey) error {
+	// method lookup is consistent due to Unmarshal JSON doing lower case for us.
+	method := sig.Method
+	verifier, ok := Verifiers[method]
+	if !ok {
+		return fmt.Errorf("continuing b/c signing method is not supported: %s\n", sig.Method)
+	}
+
+	if err := verifier.Verify(pk, sig.Signature, msg); err != nil {
+		return fmt.Errorf("continuing b/c signature was invalid\n")
+	}
 	return nil
 }

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -23,7 +23,16 @@ func TestRoleNoKeys(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	assert.NoError(t, err)
 	s := &data.Signed{Signed: b}
-	Sign(cs, s, k)
+
+	// need to define role again so we can sign. Only verify should
+	// have no keys on the role
+	baseRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		k,
+	)
+	Sign(cs, s, baseRole)
+
 	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -40,7 +49,14 @@ func TestNotEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	assert.NoError(t, err)
 	s := &data.Signed{Signed: b}
-	Sign(cs, s, k)
+
+	baseRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		k,
+	)
+	Sign(cs, s, baseRole)
+
 	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
 }
@@ -58,7 +74,13 @@ func TestMoreThanEnoughSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	assert.NoError(t, err)
 	s := &data.Signed{Signed: b}
-	Sign(cs, s, k1, k2)
+	baseRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		k1,
+		k2,
+	)
+	Sign(cs, s, baseRole)
 	assert.Equal(t, 2, len(s.Signatures))
 	err = Verify(s, roleWithKeys, 1)
 	assert.NoError(t, err)
@@ -75,7 +97,12 @@ func TestDuplicateSigs(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	assert.NoError(t, err)
 	s := &data.Signed{Signed: b}
-	Sign(cs, s, k)
+	baseRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		k,
+	)
+	Sign(cs, s, baseRole)
 	s.Signatures = append(s.Signatures, s.Signatures[0])
 	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
@@ -94,7 +121,13 @@ func TestUnknownKeyBelowThreshold(t *testing.T) {
 	b, err := json.MarshalCanonical(meta)
 	assert.NoError(t, err)
 	s := &data.Signed{Signed: b}
-	Sign(cs, s, k, unknown)
+	baseRole := data.NewBaseRole(
+		data.CanonicalRootRole,
+		1,
+		k,
+		unknown,
+	)
+	Sign(cs, s, baseRole)
 	s.Signatures = append(s.Signatures)
 	err = Verify(s, roleWithKeys, 1)
 	assert.IsType(t, ErrRoleThreshold{}, err)
@@ -169,7 +202,12 @@ func Test(t *testing.T) {
 			b, err := json.MarshalCanonical(meta)
 			assert.NoError(t, err)
 			s := &data.Signed{Signed: b}
-			Sign(cryptoService, s, k)
+			baseRole := data.NewBaseRole(
+				"", // Sign doesn't inspect role
+				1,
+				k,
+			)
+			Sign(cryptoService, s, baseRole)
 			run.s = s
 		}
 		if run.mut != nil {

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -72,7 +72,13 @@ func serializeMetadata(cs signed.CryptoService, s *data.Signed, role string,
 		return nil, ErrNoKeyForRole{role}
 	}
 
-	if err := signed.Sign(cs, s, pubKeys...); err != nil {
+	baseRole := data.NewBaseRole(
+		role,
+		1,
+		pubKeys...,
+	)
+
+	if err := signed.Sign(cs, s, baseRole); err != nil {
 		if _, ok := err.(signed.ErrNoKeys); ok {
 			return nil, ErrNoKeyForRole{Role: role}
 		}

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -917,11 +917,7 @@ func (tr *Repo) SignTimestamp(expires time.Time) (*data.Signed, error) {
 }
 
 func (tr Repo) sign(signedData *data.Signed, role data.BaseRole) (*data.Signed, error) {
-	ks := role.ListKeys()
-	if len(ks) < 1 {
-		return nil, signed.ErrNoKeys{}
-	}
-	err := signed.Sign(tr.cryptoService, signedData, ks...)
+	err := signed.Sign(tr.cryptoService, signedData, role)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…ause the key is no longer a valid signing key for the role, or the signature is invalid.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)