### PR TITLE
remove signatures that are no longer valid during signing

### DIFF
--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -297,10 +297,7 @@ func testValidateSuccessfulRootRotation(t *testing.T, keyAlg, rootKeyType string
 	signedTestRoot, err := testRoot.ToSigned()
 	assert.NoError(t, err)
 
-	err = signed.Sign(cs, signedTestRoot, replRootKey)
-	assert.NoError(t, err)
-
-	err = signed.Sign(cs, signedTestRoot, origRootKey)
+	err = signed.Sign(cs, signedTestRoot, replRootKey, origRootKey)
 	assert.NoError(t, err)
 
 	// This call to ValidateRoot will succeed since we are using a valid PEM

--- a/tuf/signed/sign.go
+++ b/tuf/signed/sign.go
@@ -22,10 +22,13 @@ import (
 
 // Sign takes a data.Signed and a key, calculated and adds the signature
 // to the data.Signed
+// N.B. All public keys for a role should be passed so that this function
+//      can correctly clean up signatures that are no longer valid.
 func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
 	logrus.Debugf("sign called with %d keys", len(keys))
 	signatures := make([]data.Signature, 0, len(s.Signatures)+1)
 	signingKeyIDs := make(map[string]struct{})
+	tufIDs := make(map[string]data.PublicKey)
 	ids := make([]string, 0, len(keys))
 
 	privKeys := make(map[string]data.PrivateKey)
@@ -34,6 +37,7 @@ func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
 	for _, key := range keys {
 		canonicalID, err := utils.CanonicalKeyID(key)
 		ids = append(ids, canonicalID)
+		tufIDs[key.ID()] = key
 		if err != nil {
 			continue
 		}
@@ -78,6 +82,20 @@ func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
 			// key is in the set of key IDs for which a signature has been created
 			continue
 		}
+		var (
+			k  data.PublicKey
+			ok bool
+		)
+		if k, ok = tufIDs[sig.KeyID]; !ok {
+			// key is no longer a valid signing key
+			continue
+		}
+		if err := VerifySignature(s.Signed, sig, k); err != nil {
+			// signature is no longer valid
+			continue
+		}
+		// keep any signatures that still represent valid keys and are
+		// themselves valid
 		signatures = append(signatures, sig)
 	}
 	s.Signatures = signatures

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -919,12 +919,7 @@ func (tr *Repo) SignTimestamp(expires time.Time) (*data.Signed, error) {
 }
 
 func (tr Repo) sign(signedData *data.Signed, role data.BaseRole) (*data.Signed, error) {
-	ks := role.ListKeys()
-	if len(ks) < 1 {
-		return nil, signed.ErrNoKeys{}
-	}
-	err := signed.Sign(tr.cryptoService, signedData, ks...)
-	if err != nil {
+	if err := signed.Sign(tr.cryptoService, signedData, role.ListKeys()...); err != nil {
 		return nil, err
 	}
 	return signedData, nil


### PR DESCRIPTION
either because the key is no longer a valid signing key for the role, or the signature is invalid.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)