### PR TITLE
Add defaults to cache-control config parsing

### DIFF
--- a/const.go
+++ b/const.go
@@ -42,6 +42,13 @@ const (
 	NotaryTargetsExpiry   = 3 * Year
 	NotarySnapshotExpiry  = 3 * Year
 	NotaryTimestampExpiry = 14 * Day
+
+	ConsistentMetadataCacheMaxAge = 30 * Day
+	CurrentMetadataCacheMaxAge    = 5 * time.Minute
+	// CacheMaxAgeLimit is the generally recommended maximum age for Cache-Control headers
+	// (one year, in seconds, since one year is forever in terms of internet
+	// content)
+	CacheMaxAgeLimit = 1 * Year
 )
 
 // NotaryDefaultExpiries is the construct used to configure the default expiry times of

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -59,6 +59,12 @@ learn more about the configuration section corresponding to that key:
       "release_stage": "production"
     }
   }
+  <a href="#caching-section-optional">"caching"</a>a>: {
+    "max_age": {
+      "current_metadata": 300,
+      "consistent_metadata": 31536000,
+    }
+  }
 }
 </code></pre>
 
@@ -283,6 +289,43 @@ authentication post login.)
 			<a href="https://github.com/docker/distribution/blob/master/docs/configuration.md#token">
 			the registry token configuration documentation</a>
 			for the parameter details.</td>
+	</tr>
+</table>
+
+## caching section (optional)
+
+Example:
+
+```json
+"caching": {
+  "max_age": {
+    "current_metadata": 300,
+    "consistent_metadata": 31536000,
+  }
+}
+```
+
+<table>
+	<tr>
+		<th>Parameter</th>
+		<th>Required</th>
+		<th>Description</th>
+	</tr>
+	<tr>
+		<td valign="top"><code>max_age</code></td>
+		<td valign="top">no</td>
+		<td valign="top">The max age, in seconds, for caching services to cache
+			the latest metadata for a role and the metadata by checksum for a
+			role.  This value will be set on the cache control headers for
+			GET-ting metadata.
+
+			Note that `must-revalidate` is also set on the cache control headers
+			for current metadata, as current metadata may change whenever new
+			metadata is signed into a repo.
+
+			Consistent metadata should never change, although it may be deleted,
+			so the max age can be a higher value.
+		</td>
 	</tr>
 </table>
 


### PR DESCRIPTION
Thanks to @HuKeping for pointing out the issue - when #597 was refactored I removed the defaults and forgot to put them back in.  :|  

This adds them, along with a test to ensure that the default config file can always be parsed without error.

Also, I forgot the doc updates in that PR, so this PR adds them.

Fixes #629 