### PR TITLE
Fix Create arg order for signer

### DIFF
--- a/signer/client/signer_trust.go
+++ b/signer/client/signer_trust.go
@@ -128,7 +128,7 @@ func NewNotarySigner(hostname string, port string, tlsConfig *tls.Config) *Notar
 }
 
 // Create creates a remote key and returns the PublicKey associated with the remote private key
-func (trust *NotarySigner) Create(role, algorithm, gun string) (data.PublicKey, error) {
+func (trust *NotarySigner) Create(role, gun, algorithm string) (data.PublicKey, error) {
 	publicKey, err := trust.kmClient.CreateKey(context.Background(), &pb.Algorithm{Algorithm: algorithm})
 	if err != nil {
 		return nil, err

--- a/signer/client/signer_trust_test.go
+++ b/signer/client/signer_trust_test.go
@@ -114,6 +114,18 @@ func TestGetPrivateKeyIfNoKey(t *testing.T) {
 	assert.Nil(t, privKey)
 }
 
+func TestCreatePrivateKey(t *testing.T) {
+	signer := setUpSigner(t, trustmanager.NewKeyMemoryStore(ret))
+	key, err := signer.Create(data.CanonicalSnapshotRole, "docker.com/notary", data.ECDSAKey)
+	assert.NoError(t, err)
+	assert.NotNil(t, key)
+	retrievedKey := signer.GetKey(key.ID())
+	assert.NotNil(t, retrievedKey)
+	assert.Equal(t, key.Public(), retrievedKey.Public())
+	assert.Equal(t, key.ID(), retrievedKey.ID())
+	assert.Equal(t, data.ECDSAKey, retrievedKey.Algorithm())
+}
+
 func TestGetPrivateKeyAndSignWithExistingKey(t *testing.T) {
 	key, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	assert.NoError(t, err, "could not generate key")


### PR DESCRIPTION
This one got away in the flatten keystore PR -- here's a fix and added test to make sure we have coverage.

Also, another reason I'm super excited to have #634 since that test would've caught this :+1: 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>