### PR TITLE
Print one key and/or path per line when listing delegations

### DIFF
--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -283,7 +283,6 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	// list delegations - we should see two keys
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
 	assert.NoError(t, err)
-	assert.Contains(t, output, ",")
 	assert.Contains(t, output, "path")
 	assert.Contains(t, output, keyID)
 	assert.Contains(t, output, keyID2)
@@ -331,8 +330,8 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	// list delegations - we should see two keys
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
 	assert.NoError(t, err)
-	assert.Contains(t, output, ",")
-	assert.Contains(t, output, "path1,path2")
+	assert.Contains(t, output, "path1")
+	assert.Contains(t, output, "path2")
 	assert.Contains(t, output, keyID)
 	assert.Contains(t, output, keyID2)
 
@@ -348,8 +347,11 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	// list delegations - we should see two keys
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
 	assert.NoError(t, err)
-	assert.Contains(t, output, ",")
-	assert.Contains(t, output, "path1,path2,path3")
+	assert.Contains(t, output, "path1")
+	assert.Contains(t, output, "path2")
+	assert.Contains(t, output, "path3")
+	assert.Contains(t, output, keyID)
+	assert.Contains(t, output, keyID2)
 
 	// just remove two paths from this delegation
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "--paths", "path2,path3")
@@ -363,7 +365,6 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	// list delegations - we should see the same two keys, and only path1
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
 	assert.NoError(t, err)
-	assert.Contains(t, output, ",")
 	assert.Contains(t, output, "path1")
 	assert.NotContains(t, output, "path2")
 	assert.NotContains(t, output, "path3")
@@ -382,7 +383,6 @@ func TestClientDelegationsInteraction(t *testing.T) {
 	// list delegations - we should see the same two keys, and no paths
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
 	assert.NoError(t, err)
-	assert.Contains(t, output, ",")
 	assert.NotContains(t, output, "path1")
 	assert.NotContains(t, output, "path2")
 	assert.NotContains(t, output, "path3")

--- a/cmd/notary/prettyprint.go
+++ b/cmd/notary/prettyprint.go
@@ -183,7 +183,7 @@ func prettyPrintRoles(rs []*data.Role, writer io.Writer, roleType string) {
 		table.Append([]string{
 			r.Name,
 			prettyPrintPaths(r.Paths),
-			strings.Join(r.KeyIDs, ","),
+			strings.Join(r.KeyIDs, "\n"),
 			fmt.Sprintf("%v", r.Threshold),
 		})
 	}
@@ -202,7 +202,7 @@ func prettyPrintPaths(paths []string) string {
 		}
 		prettyPaths = append(prettyPaths, path)
 	}
-	return strings.Join(prettyPaths, ",")
+	return strings.Join(prettyPaths, "\n")
 }
 
 // --- pretty printing certs ---

--- a/cmd/notary/prettyprint_test.go
+++ b/cmd/notary/prettyprint_test.go
@@ -237,7 +237,7 @@ func TestPrettyPrintSortedRoles(t *testing.T) {
 		{Name: "targets/zebra", Paths: []string{"stripes", "black", "white"}, RootRole: data.RootRole{KeyIDs: []string{"101"}, Threshold: 1}},
 		{Name: "targets/aardvark/unicorn/pony", Paths: []string{"rainbows"}, RootRole: data.RootRole{KeyIDs: []string{"135"}, Threshold: 1}},
 		{Name: "targets/bee", Paths: []string{"honey"}, RootRole: data.RootRole{KeyIDs: []string{"246"}, Threshold: 1}},
-		{Name: "targets/bee/wasp", Paths: []string{"honey/sting"}, RootRole: data.RootRole{KeyIDs: []string{"246", "468"}, Threshold: 1}},
+		{Name: "targets/bee/wasp", Paths: []string{"honey/sting", "stuff"}, RootRole: data.RootRole{KeyIDs: []string{"246", "468"}, Threshold: 1}},
 	}
 
 	var b bytes.Buffer
@@ -248,8 +248,11 @@ func TestPrettyPrintSortedRoles(t *testing.T) {
 	expected := [][]string{
 		{"targets/aardvark/unicorn/pony", "rainbows", "135", "1"},
 		{"targets/bee", "honey", "246", "1"},
-		{"targets/bee/wasp", "honey/sting", "246,468", "1"},
-		{"targets/zebra", "black,stripes,white", "101", "1"},
+		{"targets/bee/wasp", "honey/sting", "246", "1"},
+		{"stuff", "468"}, // Extra keys and paths are printed to extra rows
+		{"targets/zebra", "black", "101", "1"},
+		{"stripes"},
+		{"white"},
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")


### PR DESCRIPTION
Changes the CLI output to print each delegation key and path on its own line, rather than keeping each role to a single line with commas between keys/paths.  Sample below:

![screen shot 2016-03-18 at 4 14 32 pm](https://cloud.githubusercontent.com/assets/1865981/13894770/efcc885e-ed28-11e5-89c1-a7f0e0c504fe.png)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>