### PR TITLE
Tiny refactor

### DIFF
--- a/utils/http.go
+++ b/utils/http.go
@@ -64,8 +64,10 @@ func (root *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var authCtx context.Context
 		var err error
 		if authCtx, err = root.auth.Authorized(ctx, access...); err != nil {
-			if err, ok := err.(auth.Challenge); ok {
-				err.ServeHTTP(w, r)
+			if challenge, ok := err.(auth.Challenge); ok {
+				// Let the challenge write the response.
+				challenge.ServeHTTP(w, r)
+
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}


### PR DESCRIPTION
It is a little wired to use "err.ServeHTTP". Via the sample from
docker/distribution, we can use "challenge" as the variable name here.

Signed-off-by: Hu Keping <hukeping@huawei.com>