### PR TITLE
Update vendoring test to use new vendor structure

### DIFF
--- a/misc/docker-integration-test.py
+++ b/misc/docker-integration-test.py
@@ -65,9 +65,10 @@ def fake_vendor():
     # based on a tag or SHA, and we want to build based on what was vendored in
     dockerfile_addition = ("\n"
         "RUN set -x && "
-        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
+        "export GO15VENDOREXPERIMENT=1 && "
+        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/vendor:$GOPATH "
         "go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server &&"
-        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/Godeps/_workspace:$GOPATH "
+        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/vendor:$GOPATH "
         "go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary")
 
     with open(os.path.join(DOCKER_DIR, "Dockerfile")) as dockerfile:

--- a/misc/docker-integration-test.py
+++ b/misc/docker-integration-test.py
@@ -66,9 +66,7 @@ def fake_vendor():
     dockerfile_addition = ("\n"
         "RUN set -x && "
         "export GO15VENDOREXPERIMENT=1 && "
-        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/vendor:$GOPATH "
         "go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server &&"
-        "GOPATH=$(pwd)/vendor/src/github.com/docker/notary/vendor:$GOPATH "
         "go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary")
 
     with open(os.path.join(DOCKER_DIR, "Dockerfile")) as dockerfile:


### PR DESCRIPTION
Since we changed our Godeps structure to the `vendor` directory, this test should also be updated.  Was able to successfully run on my local OSX setup (and all tests passed against master :+1: )

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>