### PR TITLE
Build run integration test

### DIFF
--- a/misc/dockertest.py
+++ b/misc/dockertest.py
@@ -13,7 +13,7 @@ import re
 import shutil
 import subprocess
 from tempfile import mkdtemp
-from time import time
+from time import sleep, time
 import urllib
 from urlparse import urljoin
 
@@ -52,6 +52,11 @@ DEFAULT_DOCKER_CONFIG = os.path.expanduser("~/.docker")
 
 # Assumes the trust server will be run using compose if DOCKER_CONTENT_TRUST_SERVER is not specified
 DEFAULT_NOTARY_SERVER = "https://notary-server:4443"
+
+# please enter a custom trust server location if you do not wish to use a local
+# docker-compose instantiation.  If testing against Docker Hub's notary server or
+# another trust server, please also ensure that this script does not pick up incorrect TLS
+# certificates from ~/.notary/config.json by default
 TRUST_SERVER =  os.getenv('DOCKER_CONTENT_TRUST_SERVER', DEFAULT_NOTARY_SERVER)
 
 # Assumes the test will be run with `python misc/dockertest.py` from
@@ -253,6 +258,9 @@ def push(fout, docker_version, image, tag):
                      fout)
     sha = _DIGEST_REGEX.search(output).group(1)
     size = _SIZE_REGEX.search(output).group(1)
+
+    # sleep for 1s after pushing, just to let things propagate :)
+    time.sleep(1)
 
     # list
     targets = notary_list(fout, image)

--- a/misc/dockertest.py
+++ b/misc/dockertest.py
@@ -54,8 +54,8 @@ DEFAULT_DOCKER_CONFIG = os.path.expanduser("~/.docker")
 # the root of the notary repo after binaries are built
 NOTARY_CLIENT = "bin/notary -c cmd/notary/config.json"
 
-# Assumes the trust server will be run using compose
-TRUST_SERVER = "https://notary-server:4443"
+# Assumes the trust server will be run using compose if DOCKER_CONTENT_TRUST_SERVER is not specified
+TRUST_SERVER =  os.getenv('DOCKER_CONTENT_TRUST_SERVER', "https://notary-server:4443")
 
 # ---- setup ----
 

--- a/misc/dockertest.py
+++ b/misc/dockertest.py
@@ -50,12 +50,17 @@ REPO_PREFIX = "docker_test"
 # Assumes default docker config dir
 DEFAULT_DOCKER_CONFIG = os.path.expanduser("~/.docker")
 
+# Assumes the trust server will be run using compose if DOCKER_CONTENT_TRUST_SERVER is not specified
+DEFAULT_NOTARY_SERVER = "https://notary-server:4443"
+TRUST_SERVER =  os.getenv('DOCKER_CONTENT_TRUST_SERVER', DEFAULT_NOTARY_SERVER)
+
 # Assumes the test will be run with `python misc/dockertest.py` from
 # the root of the notary repo after binaries are built
-NOTARY_CLIENT = "bin/notary -c cmd/notary/config.json"
-
-# Assumes the trust server will be run using compose if DOCKER_CONTENT_TRUST_SERVER is not specified
-TRUST_SERVER =  os.getenv('DOCKER_CONTENT_TRUST_SERVER', "https://notary-server:4443")
+# also overrides the notary server location if need be
+if TRUST_SERVER != DEFAULT_NOTARY_SERVER:
+    NOTARY_CLIENT = "bin/notary -s {0}".format(TRUST_SERVER)
+else:
+    NOTARY_CLIENT = "bin/notary -c cmd/notary/config.json"
 
 # ---- setup ----
 
@@ -100,7 +105,7 @@ def setup():
         shutil.copytree(defaulttlsdir, tlsdir)
 
     # make sure that the cert is in the right place for local notary
-    if TRUST_SERVER == "https://notary-server:4443":
+    if TRUST_SERVER == DEFAULT_NOTARY_SERVER:
         tlsdir = os.path.join(tlsdir, "notary-server:4443")
         if not os.path.isdir(tlsdir):
             try:


### PR DESCRIPTION
Adds simple build and run tests (which pass when I run the script locally) to the docker versioning integration test.

Also bumps the version for docker 1.10 and updates the command for `notary key rotate`