### PR TITLE
Use require instead of assert for cmd

### DIFF
--- a/cmd/notary/delegations_test.go
+++ b/cmd/notary/delegations_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/trustmanager"
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testTrustDir = "trust_dir"
@@ -33,10 +33,10 @@ func TestAddInvalidDelegationName(t *testing.T) {
 
 	// Setup certificate
 	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cert, _, err := generateValidTestCert()
 	_, err = tempFile.Write(trustmanager.CertToPEM(cert))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
@@ -45,7 +45,7 @@ func TestAddInvalidDelegationName(t *testing.T) {
 
 	// Should error due to invalid delegation name (should be prefixed by "targets/")
 	err = commander.delegationAdd(commander.GetCommand(), []string{"gun", "INVALID_NAME", tempFile.Name()})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestAddInvalidDelegationCert(t *testing.T) {
@@ -54,10 +54,10 @@ func TestAddInvalidDelegationCert(t *testing.T) {
 
 	// Setup certificate
 	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cert, _, err := generateExpiredTestCert()
 	_, err = tempFile.Write(trustmanager.CertToPEM(cert))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
@@ -66,7 +66,7 @@ func TestAddInvalidDelegationCert(t *testing.T) {
 
 	// Should error due to expired cert
 	err = commander.delegationAdd(commander.GetCommand(), []string{"gun", "targets/delegation", tempFile.Name(), "--paths", "path"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestAddInvalidShortPubkeyCert(t *testing.T) {
@@ -75,10 +75,10 @@ func TestAddInvalidShortPubkeyCert(t *testing.T) {
 
 	// Setup certificate
 	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cert, _, err := generateShortRSAKeyTestCert()
 	_, err = tempFile.Write(trustmanager.CertToPEM(cert))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
@@ -87,7 +87,7 @@ func TestAddInvalidShortPubkeyCert(t *testing.T) {
 
 	// Should error due to short RSA key
 	err = commander.delegationAdd(commander.GetCommand(), []string{"gun", "targets/delegation", tempFile.Name(), "--paths", "path"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRemoveInvalidDelegationName(t *testing.T) {
@@ -99,7 +99,7 @@ func TestRemoveInvalidDelegationName(t *testing.T) {
 
 	// Should error due to invalid delegation name (should be prefixed by "targets/")
 	err := commander.delegationRemove(commander.GetCommand(), []string{"gun", "INVALID_NAME", "fake_key_id1", "fake_key_id2"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRemoveAllInvalidDelegationName(t *testing.T) {
@@ -111,7 +111,7 @@ func TestRemoveAllInvalidDelegationName(t *testing.T) {
 
 	// Should error due to invalid delegation name (should be prefixed by "targets/")
 	err := commander.delegationRemove(commander.GetCommand(), []string{"gun", "INVALID_NAME"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestAddInvalidNumArgs(t *testing.T) {
@@ -120,7 +120,7 @@ func TestAddInvalidNumArgs(t *testing.T) {
 
 	// Should error due to invalid number of args (2 instead of 3)
 	err := commander.delegationAdd(commander.GetCommand(), []string{"not", "enough"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestListInvalidNumArgs(t *testing.T) {
@@ -129,7 +129,7 @@ func TestListInvalidNumArgs(t *testing.T) {
 
 	// Should error due to invalid number of args (0 instead of 1)
 	err := commander.delegationsList(commander.GetCommand(), []string{})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRemoveInvalidNumArgs(t *testing.T) {
@@ -138,7 +138,7 @@ func TestRemoveInvalidNumArgs(t *testing.T) {
 
 	// Should error due to invalid number of args (1 instead of 2)
 	err := commander.delegationRemove(commander.GetCommand(), []string{"notenough"})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func generateValidTestCert() (*x509.Certificate, string, error) {

--- a/cmd/notary/integration_pkcs11_test.go
+++ b/cmd/notary/integration_pkcs11_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/notary/trustmanager/yubikey"
 	"github.com/docker/notary/tuf/data"
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var _retriever passphrase.Retriever
@@ -47,10 +47,10 @@ var rootOnHardware = yubikey.YubikeyAccessible
 func setUp(t *testing.T) {
 	//we're just removing keys here, so nil is fine
 	s, err := yubikey.NewYubiKeyStore(nil, _retriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	for k := range s.ListKeys() {
 		err := s.RemoveKey(k)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -62,10 +62,10 @@ func verifyRootKeyOnHardware(t *testing.T, rootKeyID string) {
 	if yubikey.YubikeyAccessible() {
 		// //we're just getting keys here, so nil is fine
 		s, err := yubikey.NewYubiKeyStore(nil, _retriever)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		privKey, role, err := s.GetKey(rootKeyID)
-		assert.NoError(t, err)
-		assert.NotNil(t, privKey)
-		assert.Equal(t, data.CanonicalRootRole, role)
+		require.NoError(t, err)
+		require.NotNil(t, privKey)
+		require.Equal(t, data.CanonicalRootRole, role)
 	}
 }

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/utils"
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -48,7 +48,7 @@ func runCommand(t *testing.T, tempDir string, args ...string) (string, error) {
 	cmd.SetOutput(b)
 	retErr := cmd.Execute()
 	output, err := ioutil.ReadAll(b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Clean up state to mimic running a fresh command next time
 	for _, command := range cmd.Commands() {
@@ -91,7 +91,7 @@ func TestClientTufInteraction(t *testing.T) {
 	defer server.Close()
 
 	tempFile, err := ioutil.TempFile("", "targetfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
@@ -103,52 +103,52 @@ func TestClientTufInteraction(t *testing.T) {
 
 	// init repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// add a target
 	_, err = runCommand(t, tempDir, "add", "gun", target, tempFile.Name())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// check status - see target
 	output, err = runCommand(t, tempDir, "status", "gun")
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(output, target))
+	require.NoError(t, err)
+	require.True(t, strings.Contains(output, target))
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// check status - no targets
 	output, err = runCommand(t, tempDir, "status", "gun")
-	assert.NoError(t, err)
-	assert.False(t, strings.Contains(string(output), target))
+	require.NoError(t, err)
+	require.False(t, strings.Contains(string(output), target))
 
 	// list repo - see target
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun")
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(string(output), target))
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(output), target))
 
 	// lookup target and repo - see target
 	output, err = runCommand(t, tempDir, "-s", server.URL, "lookup", "gun", target)
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(string(output), target))
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(output), target))
 
 	// verify repo - empty file
 	output, err = runCommand(t, tempDir, "-s", server.URL, "verify", "gun", target)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// remove target
 	_, err = runCommand(t, tempDir, "remove", "gun", target)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list repo - don't see target
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun")
-	assert.NoError(t, err)
-	assert.False(t, strings.Contains(string(output), target))
+	require.NoError(t, err)
+	require.False(t, strings.Contains(string(output), target))
 }
 
 // Initialize repo and test delegations commands by adding, listing, and removing delegations
@@ -163,23 +163,23 @@ func TestClientDelegationsInteraction(t *testing.T) {
 
 	// Setup certificate
 	tempFile, err := ioutil.TempFile("", "pemfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
 	startTime := time.Now()
 	endTime := startTime.AddDate(10, 0, 0)
 	cert, err := cryptoservice.GenerateCertificate(privKey, "gun", startTime, endTime)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = tempFile.Write(trustmanager.CertToPEM(cert))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
 	rawPubBytes, _ := ioutil.ReadFile(tempFile.Name())
 	parsedPubKey, _ := trustmanager.ParsePEMPublicKey(rawPubBytes)
 	keyID, err := utils.CanonicalKeyID(parsedPubKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var output string
 
@@ -187,339 +187,339 @@ func TestClientDelegationsInteraction(t *testing.T) {
 
 	// init repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - none yet
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No delegations present in this repository.")
+	require.NoError(t, err)
+	require.Contains(t, output, "No delegations present in this repository.")
 
 	// add new valid delegation with single new cert, and no path
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", tempFile.Name())
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Addition of delegation role")
-	assert.Contains(t, output, keyID)
-	assert.NotContains(t, output, "path")
+	require.NoError(t, err)
+	require.Contains(t, output, "Addition of delegation role")
+	require.Contains(t, output, keyID)
+	require.NotContains(t, output, "path")
 
 	// check status - see delegation
 	output, err = runCommand(t, tempDir, "status", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Unpublished changes for gun")
+	require.NoError(t, err)
+	require.Contains(t, output, "Unpublished changes for gun")
 
 	// list delegations - none yet because still unpublished
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No delegations present in this repository.")
+	require.NoError(t, err)
+	require.Contains(t, output, "No delegations present in this repository.")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// check status - no changelist
 	output, err = runCommand(t, tempDir, "status", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No unpublished changes for gun")
+	require.NoError(t, err)
+	require.Contains(t, output, "No unpublished changes for gun")
 
 	// list delegations - we should see our added delegation, with no paths
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "targets/delegation")
-	assert.Contains(t, output, keyID)
-	assert.NotContains(t, output, "\"\"")
+	require.NoError(t, err)
+	require.Contains(t, output, "targets/delegation")
+	require.Contains(t, output, keyID)
+	require.NotContains(t, output, "\"\"")
 
 	// add all paths to this delegation
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--all-paths")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Addition of delegation role")
-	assert.Contains(t, output, "\"\"")
-	assert.Contains(t, output, "<all paths>")
+	require.NoError(t, err)
+	require.Contains(t, output, "Addition of delegation role")
+	require.Contains(t, output, "\"\"")
+	require.Contains(t, output, "<all paths>")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see our added delegation, with no paths
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "targets/delegation")
-	assert.Contains(t, output, "\"\"")
-	assert.Contains(t, output, "<all paths>")
+	require.NoError(t, err)
+	require.Contains(t, output, "targets/delegation")
+	require.Contains(t, output, "\"\"")
+	require.Contains(t, output, "<all paths>")
 
 	// Setup another certificate
 	tempFile2, err := ioutil.TempFile("", "pemfile2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	privKey, err = trustmanager.GenerateECDSAKey(rand.Reader)
 	startTime = time.Now()
 	endTime = startTime.AddDate(10, 0, 0)
 	cert, err = cryptoservice.GenerateCertificate(privKey, "gun", startTime, endTime)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = tempFile2.Write(trustmanager.CertToPEM(cert))
-	assert.NoError(t, err)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NoError(t, err)
 	tempFile2.Close()
 	defer os.Remove(tempFile2.Name())
 
 	rawPubBytes2, _ := ioutil.ReadFile(tempFile2.Name())
 	parsedPubKey2, _ := trustmanager.ParsePEMPublicKey(rawPubBytes2)
 	keyID2, err := utils.CanonicalKeyID(parsedPubKey2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// add to the delegation by specifying the same role, this time add a scoped path
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", tempFile2.Name(), "--paths", "path")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Addition of delegation role")
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.Contains(t, output, "Addition of delegation role")
+	require.Contains(t, output, keyID2)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see two keys
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "path")
-	assert.Contains(t, output, keyID)
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.Contains(t, output, "path")
+	require.Contains(t, output, keyID)
+	require.Contains(t, output, keyID2)
 
 	// remove the delegation's first key
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", keyID)
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Removal of delegation role")
+	require.NoError(t, err)
+	require.Contains(t, output, "Removal of delegation role")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see the delegation but with only the second key
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.NotContains(t, output, keyID)
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.NotContains(t, output, keyID)
+	require.Contains(t, output, keyID2)
 
 	// remove the delegation's second key
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", keyID2)
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Removal of delegation role")
+	require.NoError(t, err)
+	require.Contains(t, output, "Removal of delegation role")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see no delegations
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No delegations present in this repository.")
+	require.NoError(t, err)
+	require.Contains(t, output, "No delegations present in this repository.")
 
 	// add delegation with multiple certs and multiple paths
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", tempFile.Name(), tempFile2.Name(), "--paths", "path1,path2")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Addition of delegation role")
-	assert.Contains(t, output, keyID)
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.Contains(t, output, "Addition of delegation role")
+	require.Contains(t, output, keyID)
+	require.Contains(t, output, keyID2)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see two keys
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "path1")
-	assert.Contains(t, output, "path2")
-	assert.Contains(t, output, keyID)
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.Contains(t, output, "path1")
+	require.Contains(t, output, "path2")
+	require.Contains(t, output, keyID)
+	require.Contains(t, output, keyID2)
 
 	// add delegation with multiple certs and multiple paths
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--paths", "path3")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Addition of delegation role")
+	require.NoError(t, err)
+	require.Contains(t, output, "Addition of delegation role")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see two keys
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "path1")
-	assert.Contains(t, output, "path2")
-	assert.Contains(t, output, "path3")
-	assert.Contains(t, output, keyID)
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.Contains(t, output, "path1")
+	require.Contains(t, output, "path2")
+	require.Contains(t, output, "path3")
+	require.Contains(t, output, keyID)
+	require.Contains(t, output, keyID2)
 
 	// just remove two paths from this delegation
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "--paths", "path2,path3")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Removal of delegation role")
+	require.NoError(t, err)
+	require.Contains(t, output, "Removal of delegation role")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see the same two keys, and only path1
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "path1")
-	assert.NotContains(t, output, "path2")
-	assert.NotContains(t, output, "path3")
-	assert.Contains(t, output, keyID)
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.Contains(t, output, "path1")
+	require.NotContains(t, output, "path2")
+	require.NotContains(t, output, "path3")
+	require.Contains(t, output, keyID)
+	require.Contains(t, output, keyID2)
 
 	// remove the remaining path, should not remove the delegation entirely
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "--paths", "path1")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Removal of delegation role")
+	require.NoError(t, err)
+	require.Contains(t, output, "Removal of delegation role")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see the same two keys, and no paths
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.NotContains(t, output, "path1")
-	assert.NotContains(t, output, "path2")
-	assert.NotContains(t, output, "path3")
-	assert.Contains(t, output, keyID)
-	assert.Contains(t, output, keyID2)
+	require.NoError(t, err)
+	require.NotContains(t, output, "path1")
+	require.NotContains(t, output, "path2")
+	require.NotContains(t, output, "path3")
+	require.Contains(t, output, keyID)
+	require.Contains(t, output, keyID2)
 
 	// Add a bunch of individual paths so we can test a delegation remove --all-paths
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--paths", "abcdef,123456")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Add more individual paths so we can test a delegation remove --all-paths
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--paths", "banana/split,apple/crumble/pie,orange.peel,kiwi")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see all of our paths
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "abcdef")
-	assert.Contains(t, output, "123456")
-	assert.Contains(t, output, "banana/split")
-	assert.Contains(t, output, "apple/crumble/pie")
-	assert.Contains(t, output, "orange.peel")
-	assert.Contains(t, output, "kiwi")
+	require.NoError(t, err)
+	require.Contains(t, output, "abcdef")
+	require.Contains(t, output, "123456")
+	require.Contains(t, output, "banana/split")
+	require.Contains(t, output, "apple/crumble/pie")
+	require.Contains(t, output, "orange.peel")
+	require.Contains(t, output, "kiwi")
 
 	// Try adding "", and check that adding it with other paths clears out the others
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--paths", "\"\",grapefruit,pomegranate")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see all of our old paths, and ""
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "abcdef")
-	assert.Contains(t, output, "123456")
-	assert.Contains(t, output, "banana/split")
-	assert.Contains(t, output, "apple/crumble/pie")
-	assert.Contains(t, output, "orange.peel")
-	assert.Contains(t, output, "kiwi")
-	assert.Contains(t, output, "\"\"")
-	assert.NotContains(t, output, "grapefruit")
-	assert.NotContains(t, output, "pomegranate")
+	require.NoError(t, err)
+	require.Contains(t, output, "abcdef")
+	require.Contains(t, output, "123456")
+	require.Contains(t, output, "banana/split")
+	require.Contains(t, output, "apple/crumble/pie")
+	require.Contains(t, output, "orange.peel")
+	require.Contains(t, output, "kiwi")
+	require.Contains(t, output, "\"\"")
+	require.NotContains(t, output, "grapefruit")
+	require.NotContains(t, output, "pomegranate")
 
 	// Try removing just ""
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "--paths", "\"\"")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see all of our old paths without ""
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "abcdef")
-	assert.Contains(t, output, "123456")
-	assert.Contains(t, output, "banana/split")
-	assert.Contains(t, output, "apple/crumble/pie")
-	assert.Contains(t, output, "orange.peel")
-	assert.Contains(t, output, "kiwi")
-	assert.NotContains(t, output, "\"\"")
+	require.NoError(t, err)
+	require.Contains(t, output, "abcdef")
+	require.Contains(t, output, "123456")
+	require.Contains(t, output, "banana/split")
+	require.Contains(t, output, "apple/crumble/pie")
+	require.Contains(t, output, "orange.peel")
+	require.Contains(t, output, "kiwi")
+	require.NotContains(t, output, "\"\"")
 
 	// Remove --all-paths to clear out all paths from this delegation
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "--all-paths")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see all of our paths
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.NotContains(t, output, "abcdef")
-	assert.NotContains(t, output, "123456")
-	assert.NotContains(t, output, "banana/split")
-	assert.NotContains(t, output, "apple/crumble/pie")
-	assert.NotContains(t, output, "orange.peel")
-	assert.NotContains(t, output, "kiwi")
+	require.NoError(t, err)
+	require.NotContains(t, output, "abcdef")
+	require.NotContains(t, output, "123456")
+	require.NotContains(t, output, "banana/split")
+	require.NotContains(t, output, "apple/crumble/pie")
+	require.NotContains(t, output, "orange.peel")
+	require.NotContains(t, output, "kiwi")
 
 	// Check that we ignore other --paths if we pass in --all-paths on an add
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--all-paths", "--paths", "grapefruit,pomegranate")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should only see "", and not the other paths specified
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "\"\"")
-	assert.NotContains(t, output, "grapefruit")
-	assert.NotContains(t, output, "pomegranate")
+	require.NoError(t, err)
+	require.Contains(t, output, "\"\"")
+	require.NotContains(t, output, "grapefruit")
+	require.NotContains(t, output, "pomegranate")
 
 	// Add those extra paths we ignored to set up the next test
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/delegation", "--paths", "grapefruit,pomegranate")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check that we ignore other --paths if we pass in --all-paths on a remove
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "--all-paths", "--paths", "pomegranate")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see no paths
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.NotContains(t, output, "\"\"")
-	assert.NotContains(t, output, "grapefruit")
-	assert.NotContains(t, output, "pomegranate")
+	require.NoError(t, err)
+	require.NotContains(t, output, "\"\"")
+	require.NotContains(t, output, "grapefruit")
+	require.NotContains(t, output, "pomegranate")
 
 	// remove by force to delete the delegation entirely
 	output, err = runCommand(t, tempDir, "delegation", "remove", "gun", "targets/delegation", "-y")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Forced removal (including all keys and paths) of delegation role")
+	require.NoError(t, err)
+	require.Contains(t, output, "Forced removal (including all keys and paths) of delegation role")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see no delegations
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No delegations present in this repository.")
+	require.NoError(t, err)
+	require.Contains(t, output, "No delegations present in this repository.")
 }
 
 // Initialize repo and test publishing targets with delegation roles
@@ -534,32 +534,32 @@ func TestClientDelegationsPublishing(t *testing.T) {
 
 	// Setup certificate for delegation role
 	tempFile, err := ioutil.TempFile("", "pemfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	privKey, err := trustmanager.GenerateRSAKey(rand.Reader, 2048)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	privKeyBytesNoRole, err := trustmanager.KeyToPEM(privKey, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	privKeyBytesWithRole, err := trustmanager.KeyToPEM(privKey, "user")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	startTime := time.Now()
 	endTime := startTime.AddDate(10, 0, 0)
 	cert, err := cryptoservice.GenerateCertificate(privKey, "gun", startTime, endTime)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = tempFile.Write(trustmanager.CertToPEM(cert))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
 	rawPubBytes, _ := ioutil.ReadFile(tempFile.Name())
 	parsedPubKey, _ := trustmanager.ParsePEMPublicKey(rawPubBytes)
 	canonicalKeyID, err := utils.CanonicalKeyID(parsedPubKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Set up targets for publishing
 	tempTargetFile, err := ioutil.TempFile("", "targetfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempTargetFile.Close()
 	defer os.Remove(tempTargetFile.Name())
 
@@ -569,31 +569,31 @@ func TestClientDelegationsPublishing(t *testing.T) {
 
 	// init repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - none yet
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No delegations present in this repository.")
+	require.NoError(t, err)
+	require.Contains(t, output, "No delegations present in this repository.")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// validate that we have all keys, including snapshot
 	assertNumKeys(t, tempDir, 1, 2, true)
 
 	// rotate the snapshot key to server
 	output, err = runCommand(t, tempDir, "-s", server.URL, "key", "rotate", "gun", "snapshot", "-r")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// validate that we lost the snapshot signing key
 	_, signingKeyIDs := assertNumKeys(t, tempDir, 1, 1, true)
@@ -601,125 +601,125 @@ func TestClientDelegationsPublishing(t *testing.T) {
 
 	// add new valid delegation with single new cert
 	output, err = runCommand(t, tempDir, "delegation", "add", "gun", "targets/releases", tempFile.Name(), "--paths", "\"\"")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "Addition of delegation role")
-	assert.Contains(t, output, canonicalKeyID)
+	require.NoError(t, err)
+	require.Contains(t, output, "Addition of delegation role")
+	require.Contains(t, output, canonicalKeyID)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list delegations - we should see our one delegation
 	output, err = runCommand(t, tempDir, "-s", server.URL, "delegation", "list", "gun")
-	assert.NoError(t, err)
-	assert.NotContains(t, output, "No delegations present in this repository.")
+	require.NoError(t, err)
+	require.NotContains(t, output, "No delegations present in this repository.")
 
 	// remove the targets key to demonstrate that delegates don't need this key
 	keyDir := filepath.Join(tempDir, "private", "tuf_keys")
-	assert.NoError(t, os.Remove(filepath.Join(keyDir, "gun", targetKeyID+".key")))
+	require.NoError(t, os.Remove(filepath.Join(keyDir, "gun", targetKeyID+".key")))
 
 	// Note that we need to use the canonical key ID, followed by the base of the role here
 	err = ioutil.WriteFile(filepath.Join(keyDir, canonicalKeyID+"_releases.key"), privKeyBytesNoRole, 0700)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// add a target using the delegation -- will only add to targets/releases
 	_, err = runCommand(t, tempDir, "add", "gun", target, tempTargetFile.Name(), "--roles", "targets/releases")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list targets for targets/releases - we should see no targets until we publish
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun", "--roles", "targets/releases")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No targets")
+	require.NoError(t, err)
+	require.Contains(t, output, "No targets")
 
 	output, err = runCommand(t, tempDir, "-s", server.URL, "status", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list targets for targets/releases - we should see our target!
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun", "--roles", "targets/releases")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "targets/releases")
+	require.NoError(t, err)
+	require.Contains(t, output, "targets/releases")
 
 	// remove the target for this role only
 	_, err = runCommand(t, tempDir, "remove", "gun", target, "--roles", "targets/releases")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list targets for targets/releases - we should see no targets
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun", "--roles", "targets/releases")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No targets present")
+	require.NoError(t, err)
+	require.Contains(t, output, "No targets present")
 
 	// Try adding a target with a different key style - private/tuf_keys/canonicalKeyID.key with "user" set as the "role" PEM header
 	// First remove the old key and add the new style
-	assert.NoError(t, os.Remove(filepath.Join(keyDir, canonicalKeyID+"_releases.key")))
+	require.NoError(t, os.Remove(filepath.Join(keyDir, canonicalKeyID+"_releases.key")))
 	err = ioutil.WriteFile(filepath.Join(keyDir, canonicalKeyID+".key"), privKeyBytesWithRole, 0700)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// add a target using the delegation -- will only add to targets/releases
 	_, err = runCommand(t, tempDir, "add", "gun", target, tempTargetFile.Name(), "--roles", "targets/releases")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list targets for targets/releases - we should see no targets until we publish
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun", "--roles", "targets/releases")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No targets")
+	require.NoError(t, err)
+	require.Contains(t, output, "No targets")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list targets for targets/releases - we should see our target!
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun", "--roles", "targets/releases")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "targets/releases")
+	require.NoError(t, err)
+	require.Contains(t, output, "targets/releases")
 
 	// remove the target for this role only
 	_, err = runCommand(t, tempDir, "remove", "gun", target, "--roles", "targets/releases")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Now remove this key, and make a new file to import the delegation's key from
-	assert.NoError(t, os.Remove(filepath.Join(keyDir, canonicalKeyID+".key")))
+	require.NoError(t, os.Remove(filepath.Join(keyDir, canonicalKeyID+".key")))
 	tempPrivFile, err := ioutil.TempFile("/tmp", "privfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tempPrivFile.Name())
 
 	// Write the private key to a file so we can import it
 	_, err = tempPrivFile.Write(privKeyBytesNoRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempPrivFile.Close()
 
 	// Import the private key, associating it with our delegation role
 	_, err = runCommand(t, tempDir, "key", "import", tempPrivFile.Name(), "--role", "targets/releases")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// add a target using the delegation -- will only add to targets/releases
 	_, err = runCommand(t, tempDir, "add", "gun", target, tempTargetFile.Name(), "--roles", "targets/releases")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list targets for targets/releases - we should see no targets until we publish
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun", "--roles", "targets/releases")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "No targets")
+	require.NoError(t, err)
+	require.Contains(t, output, "No targets")
 
 	// publish repo
 	_, err = runCommand(t, tempDir, "-s", server.URL, "publish", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// list targets for targets/releases - we should see our target!
 	output, err = runCommand(t, tempDir, "-s", server.URL, "list", "gun", "--roles", "targets/releases")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "targets/releases")
+	require.NoError(t, err)
+	require.Contains(t, output, "targets/releases")
 }
 
 // Splits a string into lines, and returns any lines that are not empty (
@@ -747,7 +747,7 @@ func splitLines(chunk string) []string {
 //   targets    repo    f5b84e2d92708c5acb...   file (.../private)
 func getUniqueKeys(t *testing.T, tempDir string) ([]string, []string) {
 	output, err := runCommand(t, tempDir, "key", "list")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	lines := splitLines(output)
 	if len(lines) == 1 && lines[0] == "No signing keys found." {
 		return []string{}, []string{}
@@ -777,7 +777,7 @@ func getUniqueKeys(t *testing.T, tempDir string) ([]string, []string) {
 			placeToGo, keyID = nonrootMap, parts[2]
 		}
 		// keys are 32-chars long (32 byte shasum, hex-encoded)
-		assert.Len(t, keyID, 64)
+		require.Len(t, keyID, 64)
 		placeToGo[keyID] = true
 	}
 	for k := range rootMap {
@@ -796,14 +796,14 @@ func assertNumKeys(t *testing.T, tempDir string, numRoot, numSigning int,
 	rootOnDisk bool) ([]string, []string) {
 
 	root, signing := getUniqueKeys(t, tempDir)
-	assert.Len(t, root, numRoot)
-	assert.Len(t, signing, numSigning)
+	require.Len(t, root, numRoot)
+	require.Len(t, signing, numSigning)
 	for _, rootKeyID := range root {
 		_, err := os.Stat(filepath.Join(
 			tempDir, "private", "root_keys", rootKeyID+".key"))
 		// os.IsExist checks to see if the error is because a file already
 		// exists, and hence it isn't actually the right function to use here
-		assert.Equal(t, rootOnDisk, !os.IsNotExist(err))
+		require.Equal(t, rootOnDisk, !os.IsNotExist(err))
 
 		// this function is declared is in the build-tagged setup files
 		verifyRootKeyOnHardware(t, rootKeyID)
@@ -817,14 +817,14 @@ func assertSuccessfullyPublish(
 	t *testing.T, tempDir, url, gun, target, fname string) string {
 
 	_, err := runCommand(t, tempDir, "add", gun, target, fname)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = runCommand(t, tempDir, "-s", url, "publish", gun)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	output, err := runCommand(t, tempDir, "-s", url, "list", gun)
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(string(output), target))
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(output), target))
 
 	return output
 }
@@ -840,7 +840,7 @@ func TestClientKeyGenerationRotation(t *testing.T) {
 	tempfiles := make([]string, 2)
 	for i := 0; i < 2; i++ {
 		tempFile, err := ioutil.TempFile("", "targetfile")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		tempFile.Close()
 		tempfiles[i] = tempFile.Name()
 		defer os.Remove(tempFile.Name())
@@ -858,12 +858,12 @@ func TestClientKeyGenerationRotation(t *testing.T) {
 
 	// generate root key produces a single root key and no other keys
 	_, err := runCommand(t, tempDir, "key", "generate", data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertNumKeys(t, tempDir, 1, 0, true)
 
 	// initialize a repo, should have signing keys and no new root key
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	origRoot, origSign := assertNumKeys(t, tempDir, 1, 2, true)
 
 	// publish using the original keys
@@ -871,16 +871,16 @@ func TestClientKeyGenerationRotation(t *testing.T) {
 
 	// rotate the signing keys
 	_, err = runCommand(t, tempDir, "-s", server.URL, "key", "rotate", "gun", data.CanonicalSnapshotRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = runCommand(t, tempDir, "-s", server.URL, "key", "rotate", "gun", data.CanonicalTargetsRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	root, sign := assertNumKeys(t, tempDir, 1, 2, true)
-	assert.Equal(t, origRoot[0], root[0])
+	require.Equal(t, origRoot[0], root[0])
 
 	// just do a cursory rotation check that the keys aren't equal anymore
 	for _, origKey := range origSign {
 		for _, key := range sign {
-			assert.NotEqual(
+			require.NotEqual(
 				t, key, origKey, "One of the signing keys was not removed")
 		}
 	}
@@ -889,7 +889,7 @@ func TestClientKeyGenerationRotation(t *testing.T) {
 	output := assertSuccessfullyPublish(
 		t, tempDir, server.URL, "gun", target+"2", tempfiles[1])
 	// assert that the previous target is sitll there
-	assert.True(t, strings.Contains(string(output), target))
+	require.True(t, strings.Contains(string(output), target))
 }
 
 // Tests backup/restore root+signing keys - repo with restored keys should be
@@ -908,7 +908,7 @@ func TestClientKeyBackupAndRestore(t *testing.T) {
 	tempfiles := make([]string, 2)
 	for i := 0; i < 2; i++ {
 		tempFile, err := ioutil.TempFile("", "tempfile")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		tempFile.Close()
 		tempfiles[i] = tempFile.Name()
 		defer os.Remove(tempFile.Name())
@@ -925,7 +925,7 @@ func TestClientKeyBackupAndRestore(t *testing.T) {
 	// create two repos and publish a target
 	for _, gun := range []string{"gun1", "gun2"} {
 		_, err = runCommand(t, dirs[0], "-s", server.URL, "init", gun)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assertSuccessfullyPublish(
 			t, dirs[0], server.URL, gun, target, tempfiles[0])
@@ -938,10 +938,10 @@ func TestClientKeyBackupAndRestore(t *testing.T) {
 
 	// backup then restore all keys
 	_, err = runCommand(t, dirs[0], "key", "backup", zipfile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = runCommand(t, dirs[1], "key", "restore", zipfile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// all keys should be there, including root because the root key was backed up to disk,
 	// and export just backs up all the keys on disk
 	assertNumKeys(t, dirs[1], 1, 4, !rootOnHardware())
@@ -949,8 +949,8 @@ func TestClientKeyBackupAndRestore(t *testing.T) {
 	// can list and publish to both repos using restored keys
 	for _, gun := range []string{"gun1", "gun2"} {
 		output, err := runCommand(t, dirs[1], "-s", server.URL, "list", gun)
-		assert.NoError(t, err)
-		assert.True(t, strings.Contains(string(output), target))
+		require.NoError(t, err)
+		require.True(t, strings.Contains(string(output), target))
 
 		assertSuccessfullyPublish(
 			t, dirs[1], server.URL, gun, target+"2", tempfiles[1])
@@ -958,10 +958,10 @@ func TestClientKeyBackupAndRestore(t *testing.T) {
 
 	// backup and restore keys for one gun
 	_, err = runCommand(t, dirs[0], "key", "backup", zipfile, "-g", "gun1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = runCommand(t, dirs[2], "key", "restore", zipfile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// this function is declared is in the build-tagged setup files
 	if rootOnHardware() {
@@ -982,7 +982,7 @@ func exportRoot(t *testing.T, exportTo string) string {
 
 	// generate root key produces a single root key and no other keys
 	_, err := runCommand(t, tempDir, "key", "generate", data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	oldRoot, _ := assertNumKeys(t, tempDir, 1, 0, true)
 
 	// export does not require a password
@@ -997,7 +997,7 @@ func exportRoot(t *testing.T, exportTo string) string {
 
 	_, err = runCommand(
 		t, tempDir, "key", "export", oldRoot[0], exportTo)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return oldRoot[0]
 }
@@ -1019,7 +1019,7 @@ func TestClientKeyImportExportRootOnly(t *testing.T) {
 	)
 
 	tempFile, err := ioutil.TempFile("", "pemfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// close later, because we might need to write to it
 	defer os.Remove(tempFile.Name())
 
@@ -1029,15 +1029,15 @@ func TestClientKeyImportExportRootOnly(t *testing.T) {
 		t.Log("Cannot export a key from hardware. Will generate one to import.")
 
 		privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		pemBytes, err := trustmanager.EncryptPrivateKey(privKey, "root", testPassphrase)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		nBytes, err := tempFile.Write(pemBytes)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		tempFile.Close()
-		assert.Equal(t, len(pemBytes), nBytes)
+		require.Equal(t, len(pemBytes), nBytes)
 		rootKeyID = privKey.ID()
 	} else {
 		tempFile.Close()
@@ -1046,16 +1046,16 @@ func TestClientKeyImportExportRootOnly(t *testing.T) {
 
 	// import the key
 	_, err = runCommand(t, tempDir, "key", "import", tempFile.Name())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// if there is hardware available, root will only be on hardware, and not
 	// on disk
 	newRoot, _ := assertNumKeys(t, tempDir, 1, 0, !rootOnHardware())
-	assert.Equal(t, rootKeyID, newRoot[0])
+	require.Equal(t, rootKeyID, newRoot[0])
 
 	// Just to make sure, init a repo and publish
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertNumKeys(t, tempDir, 1, 2, !rootOnHardware())
 	assertSuccessfullyPublish(
 		t, tempDir, server.URL, "gun", target, tempFile.Name())
@@ -1063,35 +1063,35 @@ func TestClientKeyImportExportRootOnly(t *testing.T) {
 	// Now assert that bad root keys give an error
 	// Try importing an unencrypted root key:
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	decryptedPEMBytes, err := trustmanager.KeyToPEM(privKey, data.CanonicalRootRole)
 	decryptedKeyFile, err := ioutil.TempFile("", "decryptedPem")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// close later, because we might need to write to it
 	defer os.Remove(decryptedKeyFile.Name())
 
 	nBytes, err := decryptedKeyFile.Write(decryptedPEMBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	decryptedKeyFile.Close()
-	assert.Equal(t, len(decryptedPEMBytes), nBytes)
+	require.Equal(t, len(decryptedPEMBytes), nBytes)
 	// import the key
 	_, err = runCommand(t, tempDir, "key", "import", decryptedKeyFile.Name())
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Now try importing an invalid PEM as a root key
 	invalidPEMBytes := []byte("this is not PEM")
 	invalidPEMFile, err := ioutil.TempFile("", "invalidPem")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// close later, because we might need to write to it
 	defer os.Remove(invalidPEMFile.Name())
 
 	nBytes, err = invalidPEMFile.Write(invalidPEMBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	invalidPEMFile.Close()
-	assert.Equal(t, len(invalidPEMBytes), nBytes)
+	require.Equal(t, len(invalidPEMBytes), nBytes)
 	// import the key
 	_, err = runCommand(t, tempDir, "key", "import", invalidPEMFile.Name())
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // Helper method to get the subdirectory for TUF keys
@@ -1126,7 +1126,7 @@ func TestClientKeyImportExportAllRoles(t *testing.T) {
 
 	// -- tests --
 	_, err := runCommand(t, tempDir, "-s", server.URL, "init", "gun")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testRoles := append(data.BaseRoles, "targets/releases")
 	// Test importing and exporting keys to all base roles and delegation role
@@ -1135,15 +1135,15 @@ func TestClientKeyImportExportAllRoles(t *testing.T) {
 		for _, setKeyRole := range []bool{true, false} {
 			// Make a new key for this role
 			privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Make a tempfile for importing
 			tempFile, err := ioutil.TempFile("", "pemfile")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Specify the role in the PEM header
 			pemBytes, err := trustmanager.EncryptPrivateKey(privKey, role, testPassphrase)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			ioutil.WriteFile(tempFile.Name(), pemBytes, 0644)
 
 			// If we need to set the key role with the --role flag, do so on import
@@ -1162,52 +1162,52 @@ func TestClientKeyImportExportAllRoles(t *testing.T) {
 					_, err = runCommand(t, tempDir, "key", "import", tempFile.Name())
 				}
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Test that we imported correctly
 			keySubdir := getKeySubdir(role, "gun")
 			_, err = os.Stat(filepath.Join(tempDir, keySubdir, privKey.ID()+".key"))
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Remove the input file so we can test exporting
-			assert.NoError(t, os.Remove(tempFile.Name()))
+			require.NoError(t, os.Remove(tempFile.Name()))
 
 			// Make a tempfile for exporting to
 			tempFile, err = ioutil.TempFile("", "pemfile")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Ensure exporting this key by ID gets the same key
 			_, err = runCommand(t, tempDir, "key", "export", privKey.ID(), tempFile.Name())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Compare the bytes of the exported file and the root key file in the repo
 			exportedBytes, err := ioutil.ReadFile(tempFile.Name())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			repoBytes, err := ioutil.ReadFile(filepath.Join(tempDir, keySubdir, privKey.ID()+".key"))
-			assert.NoError(t, err)
-			assert.Equal(t, repoBytes, exportedBytes)
+			require.NoError(t, err)
+			require.Equal(t, repoBytes, exportedBytes)
 
 			// Ensure exporting this key and changing the passphrase works
 			_, err = runCommand(t, tempDir, "key", "export", privKey.ID(), tempFile.Name(), "-p")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Remove the export file for cleanup
-			assert.NoError(t, os.Remove(tempFile.Name()))
+			require.NoError(t, os.Remove(tempFile.Name()))
 		}
 	}
 }
 
 func assertNumCerts(t *testing.T, tempDir string, expectedNum int) []string {
 	output, err := runCommand(t, tempDir, "cert", "list")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	lines := splitLines(strings.TrimSpace(output))
 
 	if expectedNum == 0 {
-		assert.Len(t, lines, 1)
-		assert.Equal(t, "No trusted root certificates present.", lines[0])
+		require.Len(t, lines, 1)
+		require.Equal(t, "No trusted root certificates present.", lines[0])
 		return []string{}
 	}
 
-	assert.Len(t, lines, expectedNum+2)
+	require.Len(t, lines, expectedNum+2)
 	return lines[2:]
 }
 
@@ -1224,23 +1224,23 @@ func TestClientCertInteraction(t *testing.T) {
 
 	// -- tests --
 	_, err := runCommand(t, tempDir, "-s", server.URL, "init", "gun1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	certs := assertNumCerts(t, tempDir, 2)
 	// root is always on disk, because even if there's a yubikey a backup is created
 	assertNumKeys(t, tempDir, 1, 4, true)
 
 	// remove certs for one gun
 	_, err = runCommand(t, tempDir, "cert", "remove", "-g", "gun1", "-y")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	certs = assertNumCerts(t, tempDir, 1)
 	// assert that when we remove cert by gun, we do not remove repo signing keys
 	// (root is always on disk, because even if there's a yubikey a backup is created)
 	assertNumKeys(t, tempDir, 1, 4, true)
 	// assert that when we remove cert by gun, we also remove TUF metadata
 	_, err = os.Stat(filepath.Join(tempDir, "tuf", "gun1"))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// remove a single cert
 	certID := strings.Fields(certs[0])[1]
@@ -1248,41 +1248,41 @@ func TestClientCertInteraction(t *testing.T) {
 	// has already been stored (a drawback of running these commands without)
 	// shelling out
 	_, err = runCommand(t, tempDir, "cert", "remove", certID, "-y", "-g", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertNumCerts(t, tempDir, 0)
 	// assert that when we remove the last cert ID for a gun, we also remove TUF metadata
 	_, err = os.Stat(filepath.Join(tempDir, "tuf", "gun2"))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Setup certificate with nonexistent repo GUN
 	// Check that we can only remove one certificate when specifying one ID
 	startTime := time.Now()
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	noGunCert, err := cryptoservice.GenerateCertificate(
 		privKey, "nonexistent", startTime, startTime.AddDate(10, 0, 0))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	certStore, err := trustmanager.NewX509FileStore(filepath.Join(tempDir, "trusted_certificates"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = certStore.AddCert(noGunCert)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	certs = assertNumCerts(t, tempDir, 1)
 	certID = strings.Fields(certs[0])[1]
 
 	privKey, err = trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	noGunCert2, err := cryptoservice.GenerateCertificate(
 		privKey, "nonexistent", startTime, startTime.AddDate(10, 0, 0))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = certStore.AddCert(noGunCert2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	certs = assertNumCerts(t, tempDir, 2)
 
 	// passing an empty gun to overwrite previously stored gun
 	_, err = runCommand(t, tempDir, "cert", "remove", certID, "-y", "-g", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Since another cert with the same GUN exists, we didn't remove everything
 	assertNumCerts(t, tempDir, 1)
@@ -1303,7 +1303,7 @@ func TestDefaultRootKeyGeneration(t *testing.T) {
 
 	// generate root key with no algorithm produces a single ECDSA root key and no other keys
 	_, err := runCommand(t, tempDir, "key", "generate")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertNumKeys(t, tempDir, 1, 0, true)
 }
 
@@ -1312,22 +1312,22 @@ func TestLogLevelFlags(t *testing.T) {
 	// Test default to fatal
 	n := notaryCommander{}
 	n.setVerbosityLevel()
-	assert.Equal(t, "fatal", logrus.GetLevel().String())
+	require.Equal(t, "fatal", logrus.GetLevel().String())
 
 	// Test that verbose (-v) sets to error
 	n.verbose = true
 	n.setVerbosityLevel()
-	assert.Equal(t, "error", logrus.GetLevel().String())
+	require.Equal(t, "error", logrus.GetLevel().String())
 
 	// Test that debug (-D) sets to debug
 	n.debug = true
 	n.setVerbosityLevel()
-	assert.Equal(t, "debug", logrus.GetLevel().String())
+	require.Equal(t, "debug", logrus.GetLevel().String())
 
 	// Test that unsetting verboseError still uses verboseDebug
 	n.verbose = false
 	n.setVerbosityLevel()
-	assert.Equal(t, "debug", logrus.GetLevel().String())
+	require.Equal(t, "debug", logrus.GetLevel().String())
 }
 
 func TestClientKeyPassphraseChange(t *testing.T) {
@@ -1342,24 +1342,24 @@ func TestClientKeyPassphraseChange(t *testing.T) {
 
 	target := "sdgkadga"
 	tempFile, err := ioutil.TempFile("/tmp", "targetfile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())
 
 	// -- tests --
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// we should have three keys stored locally in total: root, targets, snapshot
 	rootIDs, signingIDs := assertNumKeys(t, tempDir, 1, 2, true)
 	for _, keyID := range signingIDs {
 		// try changing the private key passphrase
 		_, err = runCommand(t, tempDir, "-s", server.URL, "key", "passwd", keyID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// assert that the signing keys (number and IDs) didn't change
 		_, signingIDs = assertNumKeys(t, tempDir, 1, 2, true)
-		assert.Contains(t, signingIDs, keyID)
+		require.Contains(t, signingIDs, keyID)
 
 		// make sure we can still publish with this signing key
 		assertSuccessfullyPublish(t, tempDir, server.URL, "gun1", target, tempFile.Name())
@@ -1368,22 +1368,22 @@ func TestClientKeyPassphraseChange(t *testing.T) {
 	// only one rootID, try changing the private key passphrase
 	rootID := rootIDs[0]
 	_, err = runCommand(t, tempDir, "-s", server.URL, "key", "passwd", rootID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// make sure we can init a new repo with this key
 	_, err = runCommand(t, tempDir, "-s", server.URL, "init", "gun2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// assert that the root key ID didn't change
 	rootIDs, _ = assertNumKeys(t, tempDir, 1, 4, true)
-	assert.Equal(t, rootID, rootIDs[0])
+	require.Equal(t, rootID, rootIDs[0])
 }
 
 func tempDirWithConfig(t *testing.T, config string) string {
 	tempDir, err := ioutil.TempDir("", "repo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = ioutil.WriteFile(filepath.Join(tempDir, "config.json"), []byte(config), 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return tempDir
 }
 

--- a/cmd/notary/prettyprint_test.go
+++ b/cmd/notary/prettyprint_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- tests for pretty printing keys ---
@@ -26,14 +26,14 @@ import (
 func TestTruncateWithEllipsis(t *testing.T) {
 	digits := "1234567890"
 	// do not truncate
-	assert.Equal(t, truncateWithEllipsis(digits, 10, true), digits)
-	assert.Equal(t, truncateWithEllipsis(digits, 10, false), digits)
-	assert.Equal(t, truncateWithEllipsis(digits, 11, true), digits)
-	assert.Equal(t, truncateWithEllipsis(digits, 11, false), digits)
+	require.Equal(t, truncateWithEllipsis(digits, 10, true), digits)
+	require.Equal(t, truncateWithEllipsis(digits, 10, false), digits)
+	require.Equal(t, truncateWithEllipsis(digits, 11, true), digits)
+	require.Equal(t, truncateWithEllipsis(digits, 11, false), digits)
 
 	// left and right truncate
-	assert.Equal(t, truncateWithEllipsis(digits, 8, true), "...67890")
-	assert.Equal(t, truncateWithEllipsis(digits, 8, false), "12345...")
+	require.Equal(t, truncateWithEllipsis(digits, 8, true), "...67890")
+	require.Equal(t, truncateWithEllipsis(digits, 8, false), "12345...")
 }
 
 func TestKeyInfoSorter(t *testing.T) {
@@ -54,7 +54,7 @@ func TestKeyInfoSorter(t *testing.T) {
 	}
 
 	sort.Sort(keyInfoSorter(jumbled))
-	assert.True(t, reflect.DeepEqual(expected, jumbled),
+	require.True(t, reflect.DeepEqual(expected, jumbled),
 		fmt.Sprintf("Expected %v, Got %v", expected, jumbled))
 }
 
@@ -75,11 +75,11 @@ func TestPrettyPrintZeroKeys(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintKeys([]trustmanager.KeyStore{emptyKeyStore}, &b)
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, 1)
-	assert.Equal(t, "No signing keys found.", lines[0])
+	require.Len(t, lines, 1)
+	require.Equal(t, "No signing keys found.", lines[0])
 }
 
 // Given a list of key stores, the keys should be pretty-printed with their
@@ -96,19 +96,19 @@ func TestPrettyPrintRootAndSigningKeys(t *testing.T) {
 	keys := make([]data.PrivateKey, 4)
 	for i := 0; i < 4; i++ {
 		key, err := trustmanager.GenerateED25519Key(rand.Reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		keys[i] = key
 	}
 
 	root := data.CanonicalRootRole
 
 	// add keys to the key stores
-	assert.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: root, Gun: ""}, keys[0]))
-	assert.NoError(t, keyStores[1].AddKey(trustmanager.KeyInfo{Role: root, Gun: ""}, keys[0]))
-	assert.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: data.CanonicalTargetsRole, Gun: strings.Repeat("/a", 30)}, keys[1]))
-	assert.NoError(t, keyStores[1].AddKey(trustmanager.KeyInfo{Role: data.CanonicalSnapshotRole, Gun: "short/gun"}, keys[1]))
-	assert.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: "targets/a", Gun: ""}, keys[3]))
-	assert.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: "invalidRole", Gun: ""}, keys[2]))
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: root, Gun: ""}, keys[0]))
+	require.NoError(t, keyStores[1].AddKey(trustmanager.KeyInfo{Role: root, Gun: ""}, keys[0]))
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: data.CanonicalTargetsRole, Gun: strings.Repeat("/a", 30)}, keys[1]))
+	require.NoError(t, keyStores[1].AddKey(trustmanager.KeyInfo{Role: data.CanonicalSnapshotRole, Gun: "short/gun"}, keys[1]))
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: "targets/a", Gun: ""}, keys[3]))
+	require.NoError(t, keyStores[0].AddKey(trustmanager.KeyInfo{Role: "invalidRole", Gun: ""}, keys[2]))
 
 	expected := [][]string{
 		// root always comes first
@@ -125,21 +125,21 @@ func TestPrettyPrintRootAndSigningKeys(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintKeys(keyStores, &b)
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, len(expected)+2)
+	require.Len(t, lines, len(expected)+2)
 
 	// starts with headers
-	assert.True(t, reflect.DeepEqual(strings.Fields(lines[0]),
+	require.True(t, reflect.DeepEqual(strings.Fields(lines[0]),
 		[]string{"ROLE", "GUN", "KEY", "ID", "LOCATION"}))
-	assert.Equal(t, "----", lines[1][:4])
+	require.Equal(t, "----", lines[1][:4])
 
 	for i, line := range lines[2:] {
 		// we are purposely not putting spaces in test data so easier to split
 		splitted := strings.Fields(line)
 		for j, v := range splitted {
-			assert.Equal(t, expected[i][j], strings.TrimSpace(v))
+			require.Equal(t, expected[i][j], strings.TrimSpace(v))
 		}
 	}
 }
@@ -152,11 +152,11 @@ func TestPrettyPrintZeroTargets(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintTargets([]*client.TargetWithRole{}, &b)
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, 1)
-	assert.Equal(t, "No targets present in this repository.", lines[0])
+	require.Len(t, lines, 1)
+	require.Equal(t, "No targets present in this repository.", lines[0])
 
 }
 
@@ -167,7 +167,7 @@ func TestPrettyPrintSortedTargets(t *testing.T) {
 	var err error
 	for i, letter := range []string{"a012", "b012", "c012"} {
 		hashes[i], err = hex.DecodeString(letter)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	unsorted := []*client.TargetWithRole{
 		{Target: client.Target{Name: "zebra", Hashes: data.Hashes{"sha256": hashes[0]}, Length: 8}, Role: "targets/b"},
@@ -179,7 +179,7 @@ func TestPrettyPrintSortedTargets(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintTargets(unsorted, &b)
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := [][]string{
 		{"aardvark", "b012", "1", "targets"},
@@ -188,16 +188,16 @@ func TestPrettyPrintSortedTargets(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, len(expected)+2)
+	require.Len(t, lines, len(expected)+2)
 
 	// starts with headers
-	assert.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
+	require.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
 		"NAME     DIGEST      SIZE (BYTES)   ROLE")))
-	assert.Equal(t, "----", lines[1][:4])
+	require.Equal(t, "----", lines[1][:4])
 
 	for i, line := range lines[2:] {
 		splitted := strings.Fields(line)
-		assert.Equal(t, expected[i], splitted)
+		require.Equal(t, expected[i], splitted)
 	}
 }
 
@@ -205,12 +205,12 @@ func TestPrettyPrintSortedTargets(t *testing.T) {
 
 func generateCertificate(t *testing.T, gun string, expireInHours int64) *x509.Certificate {
 	ecdsaPrivKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	startTime := time.Now()
 	endTime := startTime.Add(time.Hour * time.Duration(expireInHours))
 	cert, err := cryptoservice.GenerateCertificate(ecdsaPrivKey, gun, startTime, endTime)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return cert
 }
 
@@ -222,11 +222,11 @@ func TestPrettyPrintZeroRoles(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintRoles([]*data.Role{}, &b, "delegations")
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, 1)
-	assert.Equal(t, "No delegations present in this repository.", lines[0])
+	require.Len(t, lines, 1)
+	require.Equal(t, "No delegations present in this repository.", lines[0])
 }
 
 // Roles are sorted by name, and the name, paths, and KeyIDs are printed.
@@ -243,7 +243,7 @@ func TestPrettyPrintSortedRoles(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintRoles(unsorted, &b, "delegations")
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := [][]string{
 		{"targets/aardvark/unicorn/pony", "rainbows", "135", "1"},
@@ -256,16 +256,16 @@ func TestPrettyPrintSortedRoles(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, len(expected)+2)
+	require.Len(t, lines, len(expected)+2)
 
 	// starts with headers
-	assert.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
+	require.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
 		"ROLE     PATHS      KEY IDS   THRESHOLD")))
-	assert.Equal(t, "----", lines[1][:4])
+	require.Equal(t, "----", lines[1][:4])
 
 	for i, line := range lines[2:] {
 		splitted := strings.Fields(line)
-		assert.Equal(t, expected[i], splitted)
+		require.Equal(t, expected[i], splitted)
 	}
 }
 
@@ -275,11 +275,11 @@ func TestPrettyPrintZeroCerts(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintCerts([]*x509.Certificate{}, &b)
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, 1)
-	assert.Equal(t, "No trusted root certificates present.", lines[0])
+	require.Len(t, lines, 1)
+	require.Equal(t, "No trusted root certificates present.", lines[0])
 }
 
 // Certificates are pretty-printed in table form sorted by gun and then expiry
@@ -294,7 +294,7 @@ func TestPrettyPrintSortedCerts(t *testing.T) {
 	var b bytes.Buffer
 	prettyPrintCerts(unsorted, &b)
 	text, err := ioutil.ReadAll(&b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := [][]string{
 		{"baklava", "9 days"},
@@ -304,17 +304,17 @@ func TestPrettyPrintSortedCerts(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(text)), "\n")
-	assert.Len(t, lines, len(expected)+2)
+	require.Len(t, lines, len(expected)+2)
 
 	// starts with headers
-	assert.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
+	require.True(t, reflect.DeepEqual(strings.Fields(lines[0]), strings.Fields(
 		"GUN     FINGERPRINT OF TRUSTED ROOT CERTIFICATE      EXPIRES IN")))
-	assert.Equal(t, "----", lines[1][:4])
+	require.Equal(t, "----", lines[1][:4])
 
 	for i, line := range lines[2:] {
 		splitted := strings.Fields(line)
-		assert.True(t, len(splitted) >= 3)
-		assert.Equal(t, expected[i][0], splitted[0])
-		assert.Equal(t, expected[i][1], strings.Join(splitted[2:], " "))
+		require.True(t, len(splitted) >= 3)
+		require.Equal(t, expected[i][0], splitted[0])
+		require.Equal(t, expected[i][1], strings.Join(splitted[2:], " "))
 	}
 }


### PR DESCRIPTION
Updates all test assertions to use require in the `cmd` package, part of #628 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>