### PR TITLE
Update to use require for cryptoservice package

### DIFF
--- a/cryptoservice/certificate_test.go
+++ b/cryptoservice/certificate_test.go
@@ -8,30 +8,30 @@ import (
 
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateCertificate(t *testing.T) {
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err, "could not generate key")
+	require.NoError(t, err, "could not generate key")
 
 	keyStore := trustmanager.NewKeyMemoryStore(passphraseRetriever)
 
 	err = keyStore.AddKey(trustmanager.KeyInfo{Role: data.CanonicalRootRole, Gun: ""}, privKey)
-	assert.NoError(t, err, "could not add key to store")
+	require.NoError(t, err, "could not add key to store")
 
 	// Check GenerateCertificate method
 	gun := "docker.com/notary"
 	startTime := time.Now()
 	cert, err := GenerateCertificate(privKey, gun, startTime, startTime.AddDate(10, 0, 0))
-	assert.NoError(t, err, "could not generate certificate")
+	require.NoError(t, err, "could not generate certificate")
 
 	// Check public key
 	ecdsaPrivateKey, err := x509.ParseECPrivateKey(privKey.Private())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ecdsaPublicKey := ecdsaPrivateKey.Public()
-	assert.Equal(t, ecdsaPublicKey, cert.PublicKey)
+	require.Equal(t, ecdsaPublicKey, cert.PublicKey)
 
 	// Check CommonName
-	assert.Equal(t, cert.Subject.CommonName, gun)
+	require.Equal(t, cert.Subject.CommonName, gun)
 }

--- a/cryptoservice/crypto_service_test.go
+++ b/cryptoservice/crypto_service_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
@@ -41,21 +41,21 @@ func (c CryptoServiceTester) TestCreateAndGetKey(t *testing.T) {
 
 	// Test Create
 	tufKey, err := cryptoService.Create(c.role, c.gun, c.keyAlgo)
-	assert.NoError(t, err, c.errorMsg("error creating key"))
+	require.NoError(t, err, c.errorMsg("error creating key"))
 
 	// Test GetKey
 	retrievedKey := cryptoService.GetKey(tufKey.ID())
-	assert.NotNil(t, retrievedKey,
+	require.NotNil(t, retrievedKey,
 		c.errorMsg("Could not find key ID %s", tufKey.ID()))
-	assert.Equal(t, tufKey.Public(), retrievedKey.Public(),
+	require.Equal(t, tufKey.Public(), retrievedKey.Public(),
 		c.errorMsg("retrieved public key didn't match"))
 
 	// Test GetPrivateKey
 	retrievedKey, alias, err := cryptoService.GetPrivateKey(tufKey.ID())
-	assert.NoError(t, err)
-	assert.Equal(t, tufKey.ID(), retrievedKey.ID(),
+	require.NoError(t, err)
+	require.Equal(t, tufKey.ID(), retrievedKey.ID(),
 		c.errorMsg("retrieved private key didn't have the right ID"))
-	assert.Equal(t, c.role, alias)
+	require.Equal(t, c.role, alias)
 }
 
 // If there are multiple keystores, ensure that a key is only added to one -
@@ -67,7 +67,7 @@ func (c CryptoServiceTester) TestCreateAndGetWhenMultipleKeystores(t *testing.T)
 
 	// Test Create
 	tufKey, err := cryptoService.Create(c.role, c.gun, c.keyAlgo)
-	assert.NoError(t, err, c.errorMsg("error creating key"))
+	require.NoError(t, err, c.errorMsg("error creating key"))
 
 	// Only the first keystore should have the key
 	keyPath := tufKey.ID()
@@ -75,15 +75,15 @@ func (c CryptoServiceTester) TestCreateAndGetWhenMultipleKeystores(t *testing.T)
 		keyPath = filepath.Join(c.gun, keyPath)
 	}
 	_, _, err = cryptoService.keyStores[0].GetKey(keyPath)
-	assert.NoError(t, err, c.errorMsg(
+	require.NoError(t, err, c.errorMsg(
 		"First keystore does not have the key %s", keyPath))
 	_, _, err = cryptoService.keyStores[1].GetKey(keyPath)
-	assert.Error(t, err, c.errorMsg(
+	require.Error(t, err, c.errorMsg(
 		"Second keystore has the key %s", keyPath))
 
 	// GetKey works across multiple keystores
 	retrievedKey := cryptoService.GetKey(tufKey.ID())
-	assert.NotNil(t, retrievedKey,
+	require.NotNil(t, retrievedKey,
 		c.errorMsg("Could not find key ID %s", tufKey.ID()))
 }
 
@@ -91,14 +91,14 @@ func (c CryptoServiceTester) TestCreateAndGetWhenMultipleKeystores(t *testing.T)
 func (c CryptoServiceTester) TestGetNonexistentKey(t *testing.T) {
 	cryptoService := c.cryptoServiceFactory()
 
-	assert.Nil(t, cryptoService.GetKey("boguskeyid"),
+	require.Nil(t, cryptoService.GetKey("boguskeyid"),
 		c.errorMsg("non-nil result for bogus keyid"))
 
 	_, _, err := cryptoService.GetPrivateKey("boguskeyid")
-	assert.Error(t, err)
+	require.Error(t, err)
 	// The underlying error has been correctly propagated.
 	_, ok := err.(*trustmanager.ErrKeyNotFound)
-	assert.True(t, ok)
+	require.True(t, ok)
 }
 
 // asserts that signing with a created key creates a valid signature
@@ -107,21 +107,21 @@ func (c CryptoServiceTester) TestSignWithKey(t *testing.T) {
 	content := []byte("this is a secret")
 
 	tufKey, err := cryptoService.Create(c.role, c.gun, c.keyAlgo)
-	assert.NoError(t, err, c.errorMsg("error creating key"))
+	require.NoError(t, err, c.errorMsg("error creating key"))
 
 	// Test Sign
 	privKey, role, err := cryptoService.GetPrivateKey(tufKey.ID())
-	assert.NoError(t, err, c.errorMsg("failed to get private key"))
-	assert.Equal(t, c.role, role)
+	require.NoError(t, err, c.errorMsg("failed to get private key"))
+	require.Equal(t, c.role, role)
 
 	signature, err := privKey.Sign(rand.Reader, content, nil)
-	assert.NoError(t, err, c.errorMsg("signing failed"))
+	require.NoError(t, err, c.errorMsg("signing failed"))
 
 	verifier, ok := signed.Verifiers[algoToSigType[c.keyAlgo]]
-	assert.True(t, ok, c.errorMsg("Unknown verifier for algorithm"))
+	require.True(t, ok, c.errorMsg("Unknown verifier for algorithm"))
 
 	err = verifier.Verify(tufKey, signature, content)
-	assert.NoError(t, err,
+	require.NoError(t, err,
 		c.errorMsg("verification failed for %s key type", c.keyAlgo))
 }
 
@@ -130,11 +130,11 @@ func (c CryptoServiceTester) TestSignNoMatchingKeys(t *testing.T) {
 	cryptoService := c.cryptoServiceFactory()
 
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err, c.errorMsg("error creating key"))
+	require.NoError(t, err, c.errorMsg("error creating key"))
 
 	// Test Sign
 	_, _, err = cryptoService.GetPrivateKey(privKey.ID())
-	assert.Error(t, err, c.errorMsg("Should not have found private key"))
+	require.Error(t, err, c.errorMsg("Should not have found private key"))
 }
 
 // Test GetPrivateKey succeeds when multiple keystores have the same key
@@ -144,17 +144,17 @@ func (c CryptoServiceTester) TestGetPrivateKeyMultipleKeystores(t *testing.T) {
 		trustmanager.NewKeyMemoryStore(passphraseRetriever))
 
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err, c.errorMsg("error creating key"))
+	require.NoError(t, err, c.errorMsg("error creating key"))
 
 	for _, store := range cryptoService.keyStores {
 		err := store.AddKey(trustmanager.KeyInfo{Role: c.role, Gun: c.gun}, privKey)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	foundKey, role, err := cryptoService.GetPrivateKey(privKey.ID())
-	assert.NoError(t, err, c.errorMsg("failed to get private key"))
-	assert.Equal(t, c.role, role)
-	assert.Equal(t, privKey.ID(), foundKey.ID())
+	require.NoError(t, err, c.errorMsg("failed to get private key"))
+	require.Equal(t, c.role, role)
+	require.Equal(t, privKey.ID(), foundKey.ID())
 }
 
 func giveUpPassphraseRetriever(_, _ string, _ bool, _ int) (string, bool, error) {
@@ -164,40 +164,40 @@ func giveUpPassphraseRetriever(_, _ string, _ bool, _ int) (string, bool, error)
 // Test that ErrPasswordInvalid is correctly propagated
 func (c CryptoServiceTester) TestGetPrivateKeyPasswordInvalid(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("", "cs-test-")
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 
 	// Do not use c.cryptoServiceFactory(), we need a KeyFileStore.
 	retriever := passphrase.ConstantRetriever("password")
 	store, err := trustmanager.NewKeyFileStore(tempBaseDir, retriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cryptoService := NewCryptoService(store)
 	pubKey, err := cryptoService.Create(c.role, c.gun, c.keyAlgo)
-	assert.NoError(t, err, "error generating key: %s", err)
+	require.NoError(t, err, "error generating key: %s", err)
 
 	// cryptoService's FileKeyStore caches the unlocked private key, so to test
 	// private key unlocking we need a new instance.
 	store, err = trustmanager.NewKeyFileStore(tempBaseDir, giveUpPassphraseRetriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cryptoService = NewCryptoService(store)
 
 	_, _, err = cryptoService.GetPrivateKey(pubKey.ID())
-	assert.EqualError(t, err, trustmanager.ErrPasswordInvalid{}.Error())
+	require.EqualError(t, err, trustmanager.ErrPasswordInvalid{}.Error())
 }
 
 // Test that ErrAtttemptsExceeded is correctly propagated
 func (c CryptoServiceTester) TestGetPrivateKeyAttemptsExceeded(t *testing.T) {
 	tempBaseDir, err := ioutil.TempDir("", "cs-test-")
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 
 	// Do not use c.cryptoServiceFactory(), we need a KeyFileStore.
 	retriever := passphrase.ConstantRetriever("password")
 	store, err := trustmanager.NewKeyFileStore(tempBaseDir, retriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cryptoService := NewCryptoService(store)
 	pubKey, err := cryptoService.Create(c.role, c.gun, c.keyAlgo)
-	assert.NoError(t, err, "error generating key: %s", err)
+	require.NoError(t, err, "error generating key: %s", err)
 
 	// trustmanager.KeyFileStore and trustmanager.KeyMemoryStore both cache the unlocked
 	// private key, so to test private key unlocking we need a new instance using the
@@ -205,11 +205,11 @@ func (c CryptoServiceTester) TestGetPrivateKeyAttemptsExceeded(t *testing.T) {
 	// c.cryptoServiceFactory()) unsuitable.
 	retriever = passphrase.ConstantRetriever("incorrect password")
 	store, err = trustmanager.NewKeyFileStore(tempBaseDir, retriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cryptoService = NewCryptoService(store)
 
 	_, _, err = cryptoService.GetPrivateKey(pubKey.ID())
-	assert.EqualError(t, err, trustmanager.ErrAttemptsExceeded{}.Error())
+	require.EqualError(t, err, trustmanager.ErrAttemptsExceeded{}.Error())
 }
 
 // asserts that removing key that exists succeeds
@@ -217,14 +217,14 @@ func (c CryptoServiceTester) TestRemoveCreatedKey(t *testing.T) {
 	cryptoService := c.cryptoServiceFactory()
 
 	tufKey, err := cryptoService.Create(c.role, c.gun, c.keyAlgo)
-	assert.NoError(t, err, c.errorMsg("error creating key"))
-	assert.NotNil(t, cryptoService.GetKey(tufKey.ID()))
+	require.NoError(t, err, c.errorMsg("error creating key"))
+	require.NotNil(t, cryptoService.GetKey(tufKey.ID()))
 
 	// Test RemoveKey
 	err = cryptoService.RemoveKey(tufKey.ID())
-	assert.NoError(t, err, c.errorMsg("could not remove key"))
+	require.NoError(t, err, c.errorMsg("could not remove key"))
 	retrievedKey := cryptoService.GetKey(tufKey.ID())
-	assert.Nil(t, retrievedKey, c.errorMsg("remove didn't work"))
+	require.Nil(t, retrievedKey, c.errorMsg("remove didn't work"))
 }
 
 // asserts that removing key will remove it from all keystores
@@ -234,22 +234,22 @@ func (c CryptoServiceTester) TestRemoveFromMultipleKeystores(t *testing.T) {
 		trustmanager.NewKeyMemoryStore(passphraseRetriever))
 
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err, c.errorMsg("error creating key"))
+	require.NoError(t, err, c.errorMsg("error creating key"))
 
 	for _, store := range cryptoService.keyStores {
 		err := store.AddKey(trustmanager.KeyInfo{Role: data.CanonicalRootRole, Gun: ""}, privKey)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
-	assert.NotNil(t, cryptoService.GetKey(privKey.ID()))
+	require.NotNil(t, cryptoService.GetKey(privKey.ID()))
 
 	// Remove removes it from all key stores
 	err = cryptoService.RemoveKey(privKey.ID())
-	assert.NoError(t, err, c.errorMsg("could not remove key"))
+	require.NoError(t, err, c.errorMsg("could not remove key"))
 
 	for _, store := range cryptoService.keyStores {
 		_, _, err := store.GetKey(privKey.ID())
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -264,7 +264,7 @@ func (c CryptoServiceTester) TestListFromMultipleKeystores(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-		assert.NoError(t, err, c.errorMsg("error creating key"))
+		require.NoError(t, err, c.errorMsg("error creating key"))
 		expectedKeysIDs[privKey.ID()] = true
 
 		// adds one different key to each keystore, and then one key to
@@ -277,26 +277,26 @@ func (c CryptoServiceTester) TestListFromMultipleKeystores(t *testing.T) {
 	}
 	// sanity check - each should have 2
 	for _, store := range cryptoService.keyStores {
-		assert.Len(t, store.ListKeys(), 2, c.errorMsg("added keys wrong"))
+		require.Len(t, store.ListKeys(), 2, c.errorMsg("added keys wrong"))
 	}
 
 	keyList := cryptoService.ListKeys("root")
-	assert.Len(t, keyList, 4,
+	require.Len(t, keyList, 4,
 		c.errorMsg(
 			"ListKeys should have 4 keys (not necesarily unique) but does not: %v", keyList))
 	for _, k := range keyList {
 		_, ok := expectedKeysIDs[k]
-		assert.True(t, ok, c.errorMsg("Unexpected key %s", k))
+		require.True(t, ok, c.errorMsg("Unexpected key %s", k))
 	}
 
 	keyMap := cryptoService.ListAllKeys()
-	assert.Len(t, keyMap, 3,
+	require.Len(t, keyMap, 3,
 		c.errorMsg("ListAllKeys should have 3 unique keys but does not: %v", keyMap))
 
 	for k, role := range keyMap {
 		_, ok := expectedKeysIDs[k]
-		assert.True(t, ok)
-		assert.Equal(t, "root", role)
+		require.True(t, ok)
+		require.Equal(t, "root", role)
 	}
 }
 
@@ -308,43 +308,43 @@ func (c CryptoServiceTester) TestAddKey(t *testing.T) {
 		trustmanager.NewKeyMemoryStore(passphraseRetriever))
 
 	privKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Add the key to the targets role
-	assert.NoError(t, cryptoService.AddKey(data.CanonicalTargetsRole, c.gun, privKey))
+	require.NoError(t, cryptoService.AddKey(data.CanonicalTargetsRole, c.gun, privKey))
 
 	// Check that we added the key and its info to only the first keystore
 	retrievedKey, retrievedRole, err := cryptoService.keyStores[0].GetKey(privKey.ID())
-	assert.NoError(t, err)
-	assert.Equal(t, privKey.Private(), retrievedKey.Private())
-	assert.Equal(t, data.CanonicalTargetsRole, retrievedRole)
+	require.NoError(t, err)
+	require.Equal(t, privKey.Private(), retrievedKey.Private())
+	require.Equal(t, data.CanonicalTargetsRole, retrievedRole)
 
 	retrievedKeyInfo, err := cryptoService.keyStores[0].GetKeyInfo(privKey.ID())
-	assert.NoError(t, err)
-	assert.Equal(t, data.CanonicalTargetsRole, retrievedKeyInfo.Role)
-	assert.Equal(t, c.gun, retrievedKeyInfo.Gun)
+	require.NoError(t, err)
+	require.Equal(t, data.CanonicalTargetsRole, retrievedKeyInfo.Role)
+	require.Equal(t, c.gun, retrievedKeyInfo.Gun)
 
 	// The key should not exist in the second keystore
 	_, _, err = cryptoService.keyStores[1].GetKey(privKey.ID())
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = cryptoService.keyStores[1].GetKeyInfo(privKey.ID())
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// We should be able to successfully get the key from the cryptoservice level
 	retrievedKey, retrievedRole, err = cryptoService.GetPrivateKey(privKey.ID())
-	assert.NoError(t, err)
-	assert.Equal(t, privKey.Private(), retrievedKey.Private())
-	assert.Equal(t, data.CanonicalTargetsRole, retrievedRole)
+	require.NoError(t, err)
+	require.Equal(t, privKey.Private(), retrievedKey.Private())
+	require.Equal(t, data.CanonicalTargetsRole, retrievedRole)
 	retrievedKeyInfo, err = cryptoService.GetKeyInfo(privKey.ID())
-	assert.NoError(t, err)
-	assert.Equal(t, data.CanonicalTargetsRole, retrievedKeyInfo.Role)
-	assert.Equal(t, c.gun, retrievedKeyInfo.Gun)
+	require.NoError(t, err)
+	require.Equal(t, data.CanonicalTargetsRole, retrievedKeyInfo.Role)
+	require.Equal(t, c.gun, retrievedKeyInfo.Gun)
 
 	// Add the same key to the targets role, since the info is the same we should have no error
-	assert.NoError(t, cryptoService.AddKey(data.CanonicalTargetsRole, c.gun, privKey))
+	require.NoError(t, cryptoService.AddKey(data.CanonicalTargetsRole, c.gun, privKey))
 
 	// Try to add the same key to the snapshot role, which should error due to the role mismatch
-	assert.Error(t, cryptoService.AddKey(data.CanonicalSnapshotRole, c.gun, privKey))
+	require.Error(t, cryptoService.AddKey(data.CanonicalSnapshotRole, c.gun, privKey))
 }
 
 // Prints out an error message with information about the key algorithm,

--- a/cryptoservice/import_export_test.go
+++ b/cryptoservice/import_export_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/notary"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const timestampECDSAKeyJSON = `
@@ -45,12 +45,12 @@ func TestImportExportZip(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore, err := trustmanager.NewKeyFileStore(tempBaseDir, newPassphraseRetriever)
 	cs := NewCryptoService(fileStore)
 	pubKey, err := cs.Create(data.CanonicalRootRole, gun, data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rootKeyID := pubKey.ID()
 
@@ -60,11 +60,11 @@ func TestImportExportZip(t *testing.T) {
 
 	err = cs.ExportAllKeys(tempZipFile, newPassphraseRetriever)
 	tempZipFile.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Reopen the zip file for importing
 	zipReader, err := zip.OpenReader(tempZipFilePath)
-	assert.NoError(t, err, "could not open zip file")
+	require.NoError(t, err, "could not open zip file")
 
 	// Map of files to expect in the zip file, with the passphrases
 	passphraseByFile := make(map[string]string)
@@ -74,7 +74,7 @@ func TestImportExportZip(t *testing.T) {
 	privKeyMap := cs.ListAllKeys()
 	for privKeyName := range privKeyMap {
 		_, alias, err := cs.GetPrivateKey(privKeyName)
-		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
+		require.NoError(t, err, "privKey %s has no alias", privKeyName)
 
 		if alias == data.CanonicalRootRole {
 			continue
@@ -92,18 +92,18 @@ func TestImportExportZip(t *testing.T) {
 	// exist and are encrypted with the expected passphrase.
 	for _, f := range zipReader.File {
 		expectedPassphrase, present := passphraseByFile[f.Name]
-		assert.True(t, present, "unexpected file %s in zip file", f.Name)
+		require.True(t, present, "unexpected file %s in zip file", f.Name)
 
 		delete(passphraseByFile, f.Name)
 
 		rc, err := f.Open()
-		assert.NoError(t, err, "could not open file inside zip archive")
+		require.NoError(t, err, "could not open file inside zip archive")
 
 		pemBytes, err := ioutil.ReadAll(rc)
-		assert.NoError(t, err, "could not read file from zip")
+		require.NoError(t, err, "could not read file from zip")
 
 		_, err = trustmanager.ParsePEMPrivateKey(pemBytes, expectedPassphrase)
-		assert.NoError(t, err, "PEM not encrypted with the expected passphrase")
+		require.NoError(t, err, "PEM not encrypted with the expected passphrase")
 
 		rc.Close()
 	}
@@ -111,31 +111,31 @@ func TestImportExportZip(t *testing.T) {
 	zipReader.Close()
 
 	// Are there any keys that didn't make it to the zip?
-	assert.Len(t, passphraseByFile, 0)
+	require.Len(t, passphraseByFile, 0)
 
 	// Create new repo to test import
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir2)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore2, err := trustmanager.NewKeyFileStore(tempBaseDir2, newPassphraseRetriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cs2 := NewCryptoService(fileStore2)
 
 	// Reopen the zip file for importing
 	zipReader, err = zip.OpenReader(tempZipFilePath)
-	assert.NoError(t, err, "could not open zip file")
+	require.NoError(t, err, "could not open zip file")
 
 	// Now try with a valid passphrase. This time it should succeed.
 	err = cs2.ImportKeysZip(zipReader.Reader, newPassphraseRetriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	zipReader.Close()
 
 	// Look for keys in private. The filenames should match the key IDs
 	// in the repo's private key store.
 	for privKeyName := range privKeyMap {
 		_, alias, err := cs2.GetPrivateKey(privKeyName)
-		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
+		require.NoError(t, err, "privKey %s has no alias", privKeyName)
 
 		if alias == data.CanonicalRootRole {
 			continue
@@ -143,7 +143,7 @@ func TestImportExportZip(t *testing.T) {
 		relKeyPath := filepath.Join(notary.NonRootKeysSubdir, privKeyName+".key")
 		privKeyFileName := filepath.Join(tempBaseDir2, notary.PrivDir, relKeyPath)
 		_, err = os.Stat(privKeyFileName)
-		assert.NoError(t, err, "missing private key for role %s: %s", alias, privKeyName)
+		require.NoError(t, err, "missing private key for role %s: %s", alias, privKeyName)
 	}
 
 	// Look for keys in root_keys
@@ -151,7 +151,7 @@ func TestImportExportZip(t *testing.T) {
 	// passed in.
 	rootKeyFilename := rootKeyID + ".key"
 	_, err = os.Stat(filepath.Join(tempBaseDir2, notary.PrivDir, notary.RootKeysSubdir, rootKeyFilename))
-	assert.NoError(t, err, "missing root key")
+	require.NoError(t, err, "missing root key")
 }
 
 func TestImportExportGUN(t *testing.T) {
@@ -160,31 +160,31 @@ func TestImportExportGUN(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore, err := trustmanager.NewKeyFileStore(tempBaseDir, newPassphraseRetriever)
 	cs := NewCryptoService(fileStore)
 	_, err = cs.Create(data.CanonicalRootRole, gun, data.ECDSAKey)
 	_, err = cs.Create(data.CanonicalTargetsRole, gun, data.ECDSAKey)
 	_, err = cs.Create(data.CanonicalSnapshotRole, gun, data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tempZipFile, err := ioutil.TempFile("", "notary-test-export-")
 	tempZipFilePath := tempZipFile.Name()
 	defer os.Remove(tempZipFilePath)
 
 	err = cs.ExportKeysByGUN(tempZipFile, gun, newPassphraseRetriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// With an invalid GUN, this should return an error
 	err = cs.ExportKeysByGUN(tempZipFile, "does.not.exist/in/repository", newPassphraseRetriever)
-	assert.EqualError(t, err, ErrNoKeysFoundForGUN.Error())
+	require.EqualError(t, err, ErrNoKeysFoundForGUN.Error())
 
 	tempZipFile.Close()
 
 	// Reopen the zip file for importing
 	zipReader, err := zip.OpenReader(tempZipFilePath)
-	assert.NoError(t, err, "could not open zip file")
+	require.NoError(t, err, "could not open zip file")
 
 	// Map of files to expect in the zip file, with the passphrases
 	passphraseByFile := make(map[string]string)
@@ -194,7 +194,7 @@ func TestImportExportGUN(t *testing.T) {
 	privKeyMap := cs.ListAllKeys()
 	for privKeyName := range privKeyMap {
 		_, alias, err := cs.GetPrivateKey(privKeyName)
-		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
+		require.NoError(t, err, "privKey %s has no alias", privKeyName)
 		if alias == data.CanonicalRootRole {
 			continue
 		}
@@ -208,18 +208,18 @@ func TestImportExportGUN(t *testing.T) {
 	for _, f := range zipReader.File {
 
 		expectedPassphrase, present := passphraseByFile[f.Name]
-		assert.True(t, present, "unexpected file %s in zip file", f.Name)
+		require.True(t, present, "unexpected file %s in zip file", f.Name)
 
 		delete(passphraseByFile, f.Name)
 
 		rc, err := f.Open()
-		assert.NoError(t, err, "could not open file inside zip archive")
+		require.NoError(t, err, "could not open file inside zip archive")
 
 		pemBytes, err := ioutil.ReadAll(rc)
-		assert.NoError(t, err, "could not read file from zip")
+		require.NoError(t, err, "could not read file from zip")
 
 		_, err = trustmanager.ParsePEMPrivateKey(pemBytes, expectedPassphrase)
-		assert.NoError(t, err, "PEM not encrypted with the expected passphrase")
+		require.NoError(t, err, "PEM not encrypted with the expected passphrase")
 
 		rc.Close()
 	}
@@ -227,23 +227,23 @@ func TestImportExportGUN(t *testing.T) {
 	zipReader.Close()
 
 	// Are there any keys that didn't make it to the zip?
-	assert.Len(t, passphraseByFile, 0)
+	require.Len(t, passphraseByFile, 0)
 
 	// Create new repo to test import
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir2)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore2, err := trustmanager.NewKeyFileStore(tempBaseDir2, newPassphraseRetriever)
 	cs2 := NewCryptoService(fileStore2)
 
 	// Reopen the zip file for importing
 	zipReader, err = zip.OpenReader(tempZipFilePath)
-	assert.NoError(t, err, "could not open zip file")
+	require.NoError(t, err, "could not open zip file")
 
 	// Now try with a valid passphrase. This time it should succeed.
 	err = cs2.ImportKeysZip(zipReader.Reader, newPassphraseRetriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	zipReader.Close()
 
 	// Look for keys in private. The filenames should match the key IDs
@@ -253,14 +253,14 @@ func TestImportExportGUN(t *testing.T) {
 			continue
 		}
 		_, alias, err := cs2.GetPrivateKey(privKeyName)
-		assert.NoError(t, err, "privKey %s has no alias", privKeyName)
+		require.NoError(t, err, "privKey %s has no alias", privKeyName)
 		if alias == data.CanonicalRootRole {
 			continue
 		}
 		relKeyPath := filepath.Join(notary.NonRootKeysSubdir, gun, privKeyName+".key")
 		privKeyFileName := filepath.Join(tempBaseDir2, notary.PrivDir, relKeyPath)
 		_, err = os.Stat(privKeyFileName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -270,12 +270,12 @@ func TestExportRootKey(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore, err := trustmanager.NewKeyFileStore(tempBaseDir, oldPassphraseRetriever)
 	cs := NewCryptoService(fileStore)
 	pubKey, err := cs.Create(data.CanonicalRootRole, gun, data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rootKeyID := pubKey.ID()
 
@@ -284,36 +284,36 @@ func TestExportRootKey(t *testing.T) {
 	defer os.Remove(tempKeyFilePath)
 
 	err = cs.ExportKey(tempKeyFile, rootKeyID, data.CanonicalRootRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempKeyFile.Close()
 
 	// Create new repo to test import
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir2)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore2, err := trustmanager.NewKeyFileStore(tempBaseDir2, oldPassphraseRetriever)
 	cs2 := NewCryptoService(fileStore2)
 
 	keyReader, err := os.Open(tempKeyFilePath)
-	assert.NoError(t, err, "could not open key file")
+	require.NoError(t, err, "could not open key file")
 
 	pemImportBytes, err := ioutil.ReadAll(keyReader)
 	keyReader.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Convert to a data.PrivateKey, potentially decrypting the key, and add it to the cryptoservice
 	privKey, _, err := trustmanager.GetPasswdDecryptBytes(oldPassphraseRetriever, pemImportBytes, "", "imported "+data.CanonicalRootRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = cs2.AddKey(data.CanonicalRootRole, gun, privKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Look for repo's root key in repo2
 	// There should be a file named after the key ID of the root key we
 	// imported.
 	rootKeyFilename := rootKeyID + ".key"
 	_, err = os.Stat(filepath.Join(tempBaseDir2, notary.PrivDir, notary.RootKeysSubdir, rootKeyFilename))
-	assert.NoError(t, err, "missing root key")
+	require.NoError(t, err, "missing root key")
 }
 
 func TestExportRootKeyReencrypt(t *testing.T) {
@@ -322,12 +322,12 @@ func TestExportRootKeyReencrypt(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore, err := trustmanager.NewKeyFileStore(tempBaseDir, oldPassphraseRetriever)
 	cs := NewCryptoService(fileStore)
 	pubKey, err := cs.Create(data.CanonicalRootRole, gun, data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rootKeyID := pubKey.ID()
 
@@ -336,42 +336,42 @@ func TestExportRootKeyReencrypt(t *testing.T) {
 	defer os.Remove(tempKeyFilePath)
 
 	err = cs.ExportKeyReencrypt(tempKeyFile, rootKeyID, newPassphraseRetriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempKeyFile.Close()
 
 	// Create new repo to test import
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir2)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore2, err := trustmanager.NewKeyFileStore(tempBaseDir2, newPassphraseRetriever)
 	cs2 := NewCryptoService(fileStore2)
 
 	keyReader, err := os.Open(tempKeyFilePath)
-	assert.NoError(t, err, "could not open key file")
+	require.NoError(t, err, "could not open key file")
 
 	pemImportBytes, err := ioutil.ReadAll(keyReader)
 	keyReader.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Convert to a data.PrivateKey, potentially decrypting the key, and add it to the cryptoservice
 	privKey, _, err := trustmanager.GetPasswdDecryptBytes(newPassphraseRetriever, pemImportBytes, "", "imported "+data.CanonicalRootRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = cs2.AddKey(data.CanonicalRootRole, gun, privKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Look for repo's root key in repo2
 	// There should be a file named after the key ID of the root key we
 	// imported.
 	rootKeyFilename := rootKeyID + ".key"
 	_, err = os.Stat(filepath.Join(tempBaseDir2, notary.PrivDir, notary.RootKeysSubdir, rootKeyFilename))
-	assert.NoError(t, err, "missing root key")
+	require.NoError(t, err, "missing root key")
 
 	// Should be able to unlock the root key with the new password
 	key, alias, err := cs2.GetPrivateKey(rootKeyID)
-	assert.NoError(t, err, "could not unlock root key")
-	assert.Equal(t, data.CanonicalRootRole, alias)
-	assert.Equal(t, rootKeyID, key.ID())
+	require.NoError(t, err, "could not unlock root key")
+	require.Equal(t, data.CanonicalRootRole, alias)
+	require.Equal(t, rootKeyID, key.ID())
 }
 
 func TestExportNonRootKey(t *testing.T) {
@@ -380,12 +380,12 @@ func TestExportNonRootKey(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore, err := trustmanager.NewKeyFileStore(tempBaseDir, oldPassphraseRetriever)
 	cs := NewCryptoService(fileStore)
 	pubKey, err := cs.Create(data.CanonicalTargetsRole, gun, data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	targetsKeyID := pubKey.ID()
 
@@ -394,28 +394,28 @@ func TestExportNonRootKey(t *testing.T) {
 	defer os.Remove(tempKeyFilePath)
 
 	err = cs.ExportKey(tempKeyFile, targetsKeyID, data.CanonicalTargetsRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempKeyFile.Close()
 
 	// Create new repo to test import
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir2)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore2, err := trustmanager.NewKeyFileStore(tempBaseDir2, oldPassphraseRetriever)
 	cs2 := NewCryptoService(fileStore2)
 
 	keyReader, err := os.Open(tempKeyFilePath)
-	assert.NoError(t, err, "could not open key file")
+	require.NoError(t, err, "could not open key file")
 
 	pemBytes, err := ioutil.ReadAll(keyReader)
-	assert.NoError(t, err, "could not read key file")
+	require.NoError(t, err, "could not read key file")
 
 	// Convert to a data.PrivateKey, potentially decrypting the key, and add it to the cryptoservice
 	privKey, _, err := trustmanager.GetPasswdDecryptBytes(oldPassphraseRetriever, pemBytes, "", "imported "+data.CanonicalTargetsRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = cs2.AddKey(data.CanonicalTargetsRole, gun, privKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	keyReader.Close()
 
 	// Look for repo's targets key in repo2
@@ -423,13 +423,13 @@ func TestExportNonRootKey(t *testing.T) {
 	// imported.
 	targetsKeyFilename := targetsKeyID + ".key"
 	_, err = os.Stat(filepath.Join(tempBaseDir2, notary.PrivDir, notary.NonRootKeysSubdir, "docker.com/notary", targetsKeyFilename))
-	assert.NoError(t, err, "missing targets key")
+	require.NoError(t, err, "missing targets key")
 
 	// Check that the key is the same
 	key, alias, err := cs2.GetPrivateKey(targetsKeyID)
-	assert.NoError(t, err, "could not unlock targets key")
-	assert.Equal(t, data.CanonicalTargetsRole, alias)
-	assert.Equal(t, targetsKeyID, key.ID())
+	require.NoError(t, err, "could not unlock targets key")
+	require.Equal(t, data.CanonicalTargetsRole, alias)
+	require.Equal(t, targetsKeyID, key.ID())
 }
 
 func TestExportNonRootKeyReencrypt(t *testing.T) {
@@ -438,12 +438,12 @@ func TestExportNonRootKeyReencrypt(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore, err := trustmanager.NewKeyFileStore(tempBaseDir, oldPassphraseRetriever)
 	cs := NewCryptoService(fileStore)
 	pubKey, err := cs.Create(data.CanonicalSnapshotRole, gun, data.ECDSAKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	snapshotKeyID := pubKey.ID()
 
@@ -452,28 +452,28 @@ func TestExportNonRootKeyReencrypt(t *testing.T) {
 	defer os.Remove(tempKeyFilePath)
 
 	err = cs.ExportKeyReencrypt(tempKeyFile, snapshotKeyID, newPassphraseRetriever)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempKeyFile.Close()
 
 	// Create new repo to test import
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir2)
-	assert.NoError(t, err, "failed to create a temporary directory: %s", err)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
 	fileStore2, err := trustmanager.NewKeyFileStore(tempBaseDir2, newPassphraseRetriever)
 	cs2 := NewCryptoService(fileStore2)
 
 	keyReader, err := os.Open(tempKeyFilePath)
-	assert.NoError(t, err, "could not open key file")
+	require.NoError(t, err, "could not open key file")
 
 	pemBytes, err := ioutil.ReadAll(keyReader)
-	assert.NoError(t, err, "could not read key file")
+	require.NoError(t, err, "could not read key file")
 
 	// Convert to a data.PrivateKey, potentially decrypting the key, and add it to the cryptoservice
 	privKey, _, err := trustmanager.GetPasswdDecryptBytes(newPassphraseRetriever, pemBytes, "", "imported "+data.CanonicalSnapshotRole)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = cs2.AddKey(data.CanonicalSnapshotRole, gun, privKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	keyReader.Close()
 
 	// Look for repo's snapshot key in repo2
@@ -481,11 +481,11 @@ func TestExportNonRootKeyReencrypt(t *testing.T) {
 	// imported.
 	snapshotKeyFilename := snapshotKeyID + ".key"
 	_, err = os.Stat(filepath.Join(tempBaseDir2, notary.PrivDir, notary.NonRootKeysSubdir, "docker.com/notary", snapshotKeyFilename))
-	assert.NoError(t, err, "missing snapshot key")
+	require.NoError(t, err, "missing snapshot key")
 
 	// Should be able to unlock the root key with the new password
 	key, alias, err := cs2.GetPrivateKey(snapshotKeyID)
-	assert.NoError(t, err, "could not unlock snapshot key")
-	assert.Equal(t, data.CanonicalSnapshotRole, alias)
-	assert.Equal(t, snapshotKeyID, key.ID())
+	require.NoError(t, err, "could not unlock snapshot key")
+	require.Equal(t, data.CanonicalSnapshotRole, alias)
+	require.Equal(t, snapshotKeyID, key.ID())
 }


### PR DESCRIPTION
Using require instead of assert for the cryptoservice package, part of #628

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>