### PR TITLE
Use require instead of assert for signer package

### DIFF
--- a/signer/api/api_test.go
+++ b/signer/api/api_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/notary/signer/api"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	pb "github.com/docker/notary/proto"
 )
@@ -50,12 +50,12 @@ func TestDeleteKeyHandlerReturns404WithNonexistentKey(t *testing.T) {
 	reader = strings.NewReader(string(requestJson))
 
 	request, err := http.NewRequest("POST", deleteKeyBaseURL, reader)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, 404, res.StatusCode)
+	require.Equal(t, 404, res.StatusCode)
 }
 
 func TestDeleteKeyHandler(t *testing.T) {
@@ -64,18 +64,18 @@ func TestDeleteKeyHandler(t *testing.T) {
 	setup(signer.CryptoServiceIndex{data.ED25519Key: cryptoService, data.RSAKey: cryptoService, data.ECDSAKey: cryptoService})
 
 	tufKey, _ := cryptoService.Create("", "", data.ED25519Key)
-	assert.NotNil(t, tufKey)
+	require.NotNil(t, tufKey)
 
 	requestJson, _ := json.Marshal(&pb.KeyID{ID: tufKey.ID()})
 	reader = strings.NewReader(string(requestJson))
 
 	request, err := http.NewRequest("POST", deleteKeyBaseURL, reader)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, 200, res.StatusCode)
+	require.Equal(t, 200, res.StatusCode)
 }
 
 func TestKeyInfoHandler(t *testing.T) {
@@ -84,25 +84,25 @@ func TestKeyInfoHandler(t *testing.T) {
 	setup(signer.CryptoServiceIndex{data.ED25519Key: cryptoService, data.RSAKey: cryptoService, data.ECDSAKey: cryptoService})
 
 	tufKey, _ := cryptoService.Create("", "", data.ED25519Key)
-	assert.NotNil(t, tufKey)
+	require.NotNil(t, tufKey)
 
 	keyInfoURL := fmt.Sprintf("%s/%s", keyInfoBaseURL, tufKey.ID())
 
 	request, err := http.NewRequest("GET", keyInfoURL, nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	jsonBlob, err := ioutil.ReadAll(res.Body)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	var pubKey *pb.PublicKey
 	err = json.Unmarshal(jsonBlob, &pubKey)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, tufKey.ID(), pubKey.KeyInfo.KeyID.ID)
-	assert.Equal(t, 200, res.StatusCode)
+	require.Equal(t, tufKey.ID(), pubKey.KeyInfo.KeyID.ID)
+	require.Equal(t, 200, res.StatusCode)
 }
 
 func TestKeyInfoHandlerReturns404WithNonexistentKey(t *testing.T) {
@@ -116,12 +116,12 @@ func TestKeyInfoHandlerReturns404WithNonexistentKey(t *testing.T) {
 	keyInfoURL := fmt.Sprintf("%s/%s", keyInfoBaseURL, fakeID)
 
 	request, err := http.NewRequest("GET", keyInfoURL, nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, 404, res.StatusCode)
+	require.Equal(t, 404, res.StatusCode)
 }
 
 func TestSoftwareCreateKeyHandler(t *testing.T) {
@@ -132,19 +132,19 @@ func TestSoftwareCreateKeyHandler(t *testing.T) {
 	createKeyURL := fmt.Sprintf("%s/%s", createKeyBaseURL, data.ED25519Key)
 
 	request, err := http.NewRequest("POST", createKeyURL, nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, 200, res.StatusCode)
+	require.Equal(t, 200, res.StatusCode)
 
 	jsonBlob, err := ioutil.ReadAll(res.Body)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	var keyInfo *pb.PublicKey
 	err = json.Unmarshal(jsonBlob, &keyInfo)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestSoftwareSignHandler(t *testing.T) {
@@ -153,7 +153,7 @@ func TestSoftwareSignHandler(t *testing.T) {
 	setup(signer.CryptoServiceIndex{data.ED25519Key: cryptoService, data.RSAKey: cryptoService, data.ECDSAKey: cryptoService})
 
 	tufKey, err := cryptoService.Create("", "", data.ED25519Key)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	sigRequest := &pb.SignatureRequest{KeyID: &pb.KeyID{ID: tufKey.ID()}, Content: make([]byte, 10)}
 	requestJson, _ := json.Marshal(sigRequest)
@@ -162,21 +162,21 @@ func TestSoftwareSignHandler(t *testing.T) {
 
 	request, err := http.NewRequest("POST", signBaseURL, reader)
 
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, 200, res.StatusCode)
+	require.Equal(t, 200, res.StatusCode)
 
 	jsonBlob, err := ioutil.ReadAll(res.Body)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	var sig *pb.Signature
 	err = json.Unmarshal(jsonBlob, &sig)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, tufKey.ID(), sig.KeyInfo.KeyID.ID)
+	require.Equal(t, tufKey.ID(), sig.KeyInfo.KeyID.ID)
 }
 
 func TestSoftwareSignWithInvalidRequestHandler(t *testing.T) {
@@ -189,18 +189,18 @@ func TestSoftwareSignWithInvalidRequestHandler(t *testing.T) {
 
 	request, err := http.NewRequest("POST", signBaseURL, reader)
 
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	jsonBlob, err := ioutil.ReadAll(res.Body)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	var sig *pb.Signature
 	err = json.Unmarshal(jsonBlob, &sig)
 
-	assert.Equal(t, 400, res.StatusCode)
+	require.Equal(t, 400, res.StatusCode)
 }
 
 func TestSignHandlerReturns404WithNonexistentKey(t *testing.T) {
@@ -218,12 +218,12 @@ func TestSignHandlerReturns404WithNonexistentKey(t *testing.T) {
 	reader = strings.NewReader(string(requestJson))
 
 	request, err := http.NewRequest("POST", signBaseURL, reader)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, 404, res.StatusCode)
+	require.Equal(t, 404, res.StatusCode)
 }
 
 func TestCreateKeyHandlerWithInvalidAlgorithm(t *testing.T) {
@@ -235,16 +235,16 @@ func TestCreateKeyHandlerWithInvalidAlgorithm(t *testing.T) {
 	createKeyURL := fmt.Sprintf("%s/%s", createKeyBaseURL, "rbtree-algorithm")
 
 	request, err := http.NewRequest("POST", createKeyURL, nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	res, err := http.DefaultClient.Do(request)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 
 	body, err := ioutil.ReadAll(res.Body)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	// The body may contains some `\r\n`, so we use assert.Contains not assert.Equals
-	assert.Contains(t, string(body), "algorithm rbtree-algorithm not supported")
+	// The body may contains some `\r\n`, so we use require.Contains not require.Equals
+	require.Contains(t, string(body), "algorithm rbtree-algorithm not supported")
 }

--- a/signer/api/rpc_api_test.go
+++ b/signer/api/rpc_api_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/notary/signer/api"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -73,25 +73,25 @@ func TestDeleteKeyHandlerReturnsNotFoundWithNonexistentKey(t *testing.T) {
 	keyID := &pb.KeyID{ID: fakeID}
 
 	ret, err := kmClient.DeleteKey(context.Background(), keyID)
-	assert.NotNil(t, err)
-	assert.Equal(t, grpc.Code(err), codes.NotFound)
-	assert.Nil(t, ret)
+	require.NotNil(t, err)
+	require.Equal(t, grpc.Code(err), codes.NotFound)
+	require.Nil(t, ret)
 }
 
 func TestCreateKeyHandlerCreatesKey(t *testing.T) {
 	publicKey, err := kmClient.CreateKey(context.Background(), &pb.Algorithm{Algorithm: data.ED25519Key})
-	assert.NotNil(t, publicKey)
-	assert.NotEmpty(t, publicKey.PublicKey)
-	assert.NotEmpty(t, publicKey.KeyInfo)
-	assert.Nil(t, err)
-	assert.Equal(t, grpc.Code(err), codes.OK)
+	require.NotNil(t, publicKey)
+	require.NotEmpty(t, publicKey.PublicKey)
+	require.NotEmpty(t, publicKey.KeyInfo)
+	require.Nil(t, err)
+	require.Equal(t, grpc.Code(err), codes.OK)
 }
 
 func TestDeleteKeyHandlerDeletesCreatedKey(t *testing.T) {
 	publicKey, err := kmClient.CreateKey(context.Background(), &pb.Algorithm{Algorithm: data.ED25519Key})
 	ret, err := kmClient.DeleteKey(context.Background(), publicKey.KeyInfo.KeyID)
-	assert.Nil(t, err)
-	assert.Equal(t, ret, void)
+	require.Nil(t, err)
+	require.Equal(t, ret, void)
 }
 
 func TestKeyInfoReturnsCreatedKeys(t *testing.T) {
@@ -100,19 +100,19 @@ func TestKeyInfoReturnsCreatedKeys(t *testing.T) {
 	returnedPublicKey, err := kmClient.GetKeyInfo(context.Background(), publicKey.KeyInfo.KeyID)
 	fmt.Println("returnedPublicKey ID: " + returnedPublicKey.GetKeyInfo().KeyID.ID)
 
-	assert.Nil(t, err)
-	assert.Equal(t, publicKey.KeyInfo, returnedPublicKey.KeyInfo)
-	assert.Equal(t, publicKey.PublicKey, returnedPublicKey.PublicKey)
+	require.Nil(t, err)
+	require.Equal(t, publicKey.KeyInfo, returnedPublicKey.KeyInfo)
+	require.Equal(t, publicKey.PublicKey, returnedPublicKey.PublicKey)
 }
 
 func TestCreateKeyCreatesNewKeys(t *testing.T) {
 	publicKey1, err := kmClient.CreateKey(context.Background(), &pb.Algorithm{Algorithm: data.ED25519Key})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	publicKey2, err := kmClient.CreateKey(context.Background(), &pb.Algorithm{Algorithm: data.ED25519Key})
-	assert.Nil(t, err)
-	assert.NotEqual(t, publicKey1, publicKey2)
-	assert.NotEqual(t, publicKey1.KeyInfo, publicKey2.KeyInfo)
-	assert.NotEqual(t, publicKey1.PublicKey, publicKey2.PublicKey)
+	require.Nil(t, err)
+	require.NotEqual(t, publicKey1, publicKey2)
+	require.NotEqual(t, publicKey1.KeyInfo, publicKey2.KeyInfo)
+	require.NotEqual(t, publicKey1.PublicKey, publicKey2.PublicKey)
 }
 
 func TestGetKeyInfoReturnsNotFoundOnNonexistKeys(t *testing.T) {
@@ -120,25 +120,25 @@ func TestGetKeyInfoReturnsNotFoundOnNonexistKeys(t *testing.T) {
 	keyID := &pb.KeyID{ID: fakeID}
 
 	ret, err := kmClient.GetKeyInfo(context.Background(), keyID)
-	assert.NotNil(t, err)
-	assert.Equal(t, grpc.Code(err), codes.NotFound)
-	assert.Nil(t, ret)
+	require.NotNil(t, err)
+	require.Equal(t, grpc.Code(err), codes.NotFound)
+	require.Nil(t, ret)
 }
 
 func TestCreatedKeysCanBeUsedToSign(t *testing.T) {
 	message := []byte{0, 0, 0, 0}
 
 	publicKey, err := kmClient.CreateKey(context.Background(), &pb.Algorithm{Algorithm: data.ED25519Key})
-	assert.Nil(t, err)
-	assert.NotNil(t, publicKey)
+	require.Nil(t, err)
+	require.NotNil(t, publicKey)
 
 	sr := &pb.SignatureRequest{Content: message, KeyID: publicKey.KeyInfo.KeyID}
-	assert.NotNil(t, sr)
+	require.NotNil(t, sr)
 	signature, err := sClient.Sign(context.Background(), sr)
-	assert.Nil(t, err)
-	assert.NotNil(t, signature)
-	assert.NotEmpty(t, signature.Content)
-	assert.Equal(t, publicKey.KeyInfo, signature.KeyInfo)
+	require.Nil(t, err)
+	require.NotNil(t, signature)
+	require.NotEmpty(t, signature.Content)
+	require.Equal(t, publicKey.KeyInfo, signature.KeyInfo)
 }
 
 func TestSignReturnsNotFoundOnNonexistKeys(t *testing.T) {
@@ -148,17 +148,17 @@ func TestSignReturnsNotFoundOnNonexistKeys(t *testing.T) {
 	sr := &pb.SignatureRequest{Content: message, KeyID: keyID}
 
 	ret, err := sClient.Sign(context.Background(), sr)
-	assert.NotNil(t, err)
-	assert.Equal(t, grpc.Code(err), codes.NotFound)
-	assert.Nil(t, ret)
+	require.NotNil(t, err)
+	require.Equal(t, grpc.Code(err), codes.NotFound)
+	require.Nil(t, ret)
 }
 
 func TestHealthChecksForServices(t *testing.T) {
 	sHealthStatus, err := sClient.CheckHealth(context.Background(), void)
-	assert.Nil(t, err)
-	assert.Equal(t, health, sHealthStatus.Status)
+	require.Nil(t, err)
+	require.Equal(t, health, sHealthStatus.Status)
 
 	kmHealthStatus, err := kmClient.CheckHealth(context.Background(), void)
-	assert.Nil(t, err)
-	assert.Equal(t, health, kmHealthStatus.Status)
+	require.Nil(t, err)
+	require.Equal(t, health, kmHealthStatus.Status)
 }

--- a/signer/keydbstore/keydbstore_test.go
+++ b/signer/keydbstore/keydbstore_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/notary/tuf/data"
 	"github.com/jinzhu/gorm"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var retriever = func(string, string, bool, int) (string, bool, error) {
@@ -33,12 +33,12 @@ var anotherRetriever = func(keyName, alias string, createNew bool, attempts int)
 // necessary table.  Return the file name to use and clean up.
 func initializeDB(t *testing.T) (tmpfilename string) {
 	tmpFile, err := ioutil.TempFile("/tmp", "notary-test-sqlite-db-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tmpFile.Close()
 
 	// We are using SQLite for the tests
 	gormDB, err := gorm.Open("sqlite3", tmpFile.Name())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Ensure that the private_key table exists
 	gormDB.CreateTable(&GormPrivateKey{})
@@ -49,8 +49,8 @@ func initializeDB(t *testing.T) (tmpfilename string) {
 // gets a key from the DB store, and asserts that the key is the expected key
 func testGetSuccess(t *testing.T, dbStore *KeyDBStore, expectedKey data.PrivateKey) {
 	retrKey, _, err := dbStore.GetKey(expectedKey.ID())
-	assert.NoError(t, err)
-	assert.Equal(t, retrKey, expectedKey)
+	require.NoError(t, err)
+	require.Equal(t, retrKey, expectedKey)
 }
 
 // closes the DB connection first so we can test that the successful get was
@@ -59,7 +59,7 @@ func testGetSuccessFromCache(t *testing.T, dbStore *KeyDBStore,
 	expectedKey data.PrivateKey) {
 
 	err := dbStore.db.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testGetSuccess(t, dbStore, expectedKey)
 }
@@ -67,25 +67,25 @@ func testGetSuccessFromCache(t *testing.T, dbStore *KeyDBStore,
 // Creating a new KeyDBStore propagates any db opening error
 func TestNewKeyDBStorePropagatesDBError(t *testing.T) {
 	dbStore, err := NewKeyDBStore(retriever, "ignoredalias", "nodb", "somestring")
-	assert.Error(t, err)
-	assert.Nil(t, dbStore)
+	require.Error(t, err)
+	require.Nil(t, dbStore)
 }
 
 // Creating a key, on succcess, populates the cache.
 func TestCreateSuccessPopulatesCache(t *testing.T) {
 	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilename := initializeDB(t)
 	defer os.Remove(tmpFilename)
 
 	// Create a new KeyDB store
 	dbStore, err := NewKeyDBStore(retriever, "ignoredalias", "sqlite3", tmpFilename)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test writing new key in database
 	err = dbStore.AddKey(trustmanager.KeyInfo{Role: data.CanonicalTimestampRole, Gun: "gun/ignored"}, testKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testGetSuccessFromCache(t, dbStore, testKey)
 }
@@ -93,16 +93,16 @@ func TestCreateSuccessPopulatesCache(t *testing.T) {
 // Getting a key, on succcess, populates the cache.
 func TestGetSuccessPopulatesCache(t *testing.T) {
 	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilename := initializeDB(t)
 	defer os.Remove(tmpFilename)
 
 	// Create a new KeyDB store and add a key
 	dbStore, err := NewKeyDBStore(retriever, "ignoredalias", "sqlite3", tmpFilename)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = dbStore.AddKey(trustmanager.KeyInfo{Role: data.CanonicalTimestampRole, Gun: "gun/ignored"}, testKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// delete the cache
 	dbStore.cachedKeys = make(map[string]data.PrivateKey)
@@ -113,77 +113,77 @@ func TestGetSuccessPopulatesCache(t *testing.T) {
 
 func TestDoubleCreate(t *testing.T) {
 	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	anotherTestKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilename := initializeDB(t)
 	defer os.Remove(tmpFilename)
 
 	// Create a new KeyDB store and add a key
 	dbStore, err := NewKeyDBStore(retriever, "ignoredalias", "sqlite3", tmpFilename)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test writing new key in database/cache
 	err = dbStore.AddKey(trustmanager.KeyInfo{Role: data.CanonicalTimestampRole, Gun: "gun/ignored"}, testKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test writing the same key in the database. Should fail.
 	err = dbStore.AddKey(trustmanager.KeyInfo{Role: data.CanonicalTimestampRole, Gun: "gun/ignored"}, testKey)
-	assert.Error(t, err, "failed to add private key to database:")
+	require.Error(t, err, "failed to add private key to database:")
 
 	// Test writing new key succeeds
 	err = dbStore.AddKey(trustmanager.KeyInfo{Role: data.CanonicalTimestampRole, Gun: "gun/ignored"}, anotherTestKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateDelete(t *testing.T) {
 	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilename := initializeDB(t)
 	defer os.Remove(tmpFilename)
 
 	// Create a new KeyDB store
 	dbStore, err := NewKeyDBStore(retriever, "ignoredalias", "sqlite3", tmpFilename)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test writing new key in database/cache
 	err = dbStore.AddKey(trustmanager.KeyInfo{Role: "", Gun: ""}, testKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test deleting the key from the db
 	err = dbStore.RemoveKey(testKey.ID())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// This should fail, since it is neither in the cache nor the DB
 	_, _, err = dbStore.GetKey(testKey.ID())
-	assert.Error(t, err, "signing key not found:")
+	require.Error(t, err, "signing key not found:")
 }
 
 func TestKeyRotation(t *testing.T) {
 	testKey, err := trustmanager.GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tmpFilename := initializeDB(t)
 	defer os.Remove(tmpFilename)
 
 	// Create a new KeyDB store
 	dbStore, err := NewKeyDBStore(anotherRetriever, "alias_1", "sqlite3", tmpFilename)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test writing new key in database/cache
 	err = dbStore.AddKey(trustmanager.KeyInfo{Role: data.CanonicalTimestampRole, Gun: "gun/ignored"}, testKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Try rotating the key to alias-2
 	err = dbStore.RotateKeyPassphrase(testKey.ID(), "alias_2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Try rotating the key to alias-3
 	err = dbStore.RotateKeyPassphrase(testKey.ID(), "alias_3")
-	assert.Error(t, err, "there should be no password for alias_3")
+	require.Error(t, err, "there should be no password for alias_3")
 }
 
 func TestDBHealthCheck(t *testing.T) {
@@ -193,24 +193,24 @@ func TestDBHealthCheck(t *testing.T) {
 	// Create a new KeyDB store
 	dbStore, err := NewKeyDBStore(retriever, "ignoredalias",
 		"sqlite3", filepath.Join(tempBaseDir, "test_db"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// No key table, health check fails
 	err = dbStore.HealthCheck()
-	assert.Error(t, err, "Cannot access table:")
+	require.Error(t, err, "Cannot access table:")
 
 	// Ensure that the private_key table exists
 	dbStore.db.CreateTable(&GormPrivateKey{})
 
 	// Heath check success because the table exists
 	err = dbStore.HealthCheck()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Close the connection
 	err = dbStore.db.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Heath check fail because the connection is closed
 	err = dbStore.HealthCheck()
-	assert.Error(t, err, "Cannot access table:")
+	require.Error(t, err, "Cannot access table:")
 }


### PR DESCRIPTION
Part of #628 to use require for the signer package

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>