### PR TITLE
Use require for certs and trustmanager

### DIFF
--- a/trustmanager/filestore_test.go
+++ b/trustmanager/filestore_test.go
@@ -3,7 +3,7 @@ package trustmanager
 import (
 	"crypto/rand"
 	"fmt"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -19,7 +19,7 @@ func TestAddFile(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	// Since we're generating this manually we need to add the extension '.'
@@ -34,12 +34,12 @@ func TestAddFile(t *testing.T) {
 
 	// Call the Add function
 	err = store.Add(testName, testData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check to see if file exists
 	b, err := ioutil.ReadFile(expectedFilePath)
-	assert.NoError(t, err)
-	assert.Equal(t, testData, b, "unexpected content in the file: %s", expectedFilePath)
+	require.NoError(t, err)
+	require.Equal(t, testData, b, "unexpected content in the file: %s", expectedFilePath)
 }
 
 func TestRemoveFile(t *testing.T) {
@@ -49,14 +49,14 @@ func TestRemoveFile(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	// Since we're generating this manually we need to add the extension '.'
 	expectedFilePath := filepath.Join(tempBaseDir, testName+testExt)
 
 	_, err = generateRandomFile(expectedFilePath, perms)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create our SimpleFileStore
 	store := &SimpleFileStore{
@@ -67,11 +67,11 @@ func TestRemoveFile(t *testing.T) {
 
 	// Call the Remove function
 	err = store.Remove(testName)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check to see if file exists
 	_, err = os.Stat(expectedFilePath)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestRemoveDir(t *testing.T) {
@@ -81,14 +81,14 @@ func TestRemoveDir(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	// Since we're generating this manually we need to add the extension '.'
 	expectedFilePath := filepath.Join(tempBaseDir, testName+testExt)
 
 	_, err = generateRandomFile(expectedFilePath, perms)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create our SimpleFileStore
 	store := &SimpleFileStore{
@@ -99,12 +99,12 @@ func TestRemoveDir(t *testing.T) {
 
 	// Call the RemoveDir function
 	err = store.RemoveDir(testName)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedDirectory := filepath.Dir(expectedFilePath)
 	// Check to see if file exists
 	_, err = os.Stat(expectedDirectory)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestListFiles(t *testing.T) {
@@ -114,7 +114,7 @@ func TestListFiles(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	var expectedFilePath string
@@ -124,7 +124,7 @@ func TestListFiles(t *testing.T) {
 		expectedFilename := testName + strconv.Itoa(i) + "." + testExt
 		expectedFilePath = filepath.Join(tempBaseDir, expectedFilename)
 		_, err = generateRandomFile(expectedFilePath, perms)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// Create our SimpleFileStore
@@ -136,7 +136,7 @@ func TestListFiles(t *testing.T) {
 
 	// Call the List function. Expect 10 files
 	files := store.ListFiles()
-	assert.Len(t, files, 10)
+	require.Len(t, files, 10)
 }
 
 func TestListDir(t *testing.T) {
@@ -146,7 +146,7 @@ func TestListDir(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	var expectedFilePath string
@@ -156,7 +156,7 @@ func TestListDir(t *testing.T) {
 		fileName := fmt.Sprintf("%s-%s.%s", testName, strconv.Itoa(i), testExt)
 		expectedFilePath = filepath.Join(tempBaseDir, fileName)
 		_, err = generateRandomFile(expectedFilePath, perms)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// Create our SimpleFileStore
@@ -168,11 +168,11 @@ func TestListDir(t *testing.T) {
 
 	// Call the ListDir function
 	files := store.ListDir("docker.com/")
-	assert.Len(t, files, 10)
+	require.Len(t, files, 10)
 	files = store.ListDir("docker.com/notary")
-	assert.Len(t, files, 10)
+	require.Len(t, files, 10)
 	files = store.ListDir("fakedocker.com/")
-	assert.Len(t, files, 0)
+	require.Len(t, files, 0)
 }
 
 func TestGetPath(t *testing.T) {
@@ -190,10 +190,10 @@ func TestGetPath(t *testing.T) {
 	secondPath := "/docker.io/testing-dashes/@#$%^&().crt"
 
 	result, err := store.GetPath("diogomonica.com/openvpn/0xdeadbeef")
-	assert.Equal(t, firstPath, result, "unexpected error from GetPath: %v", err)
+	require.Equal(t, firstPath, result, "unexpected error from GetPath: %v", err)
 
 	result, err = store.GetPath("/docker.io/testing-dashes/@#$%^&()")
-	assert.Equal(t, secondPath, result, "unexpected error from GetPath: %v", err)
+	require.Equal(t, secondPath, result, "unexpected error from GetPath: %v", err)
 }
 
 func TestGetPathProtection(t *testing.T) {
@@ -209,18 +209,18 @@ func TestGetPathProtection(t *testing.T) {
 
 	// Should deny requests for paths outside the filestore
 	_, err := store.GetPath("../../etc/passwd")
-	assert.Error(t, err)
-	assert.Equal(t, ErrPathOutsideStore, err)
+	require.Error(t, err)
+	require.Equal(t, ErrPathOutsideStore, err)
 
 	_, err = store.GetPath("private/../../../etc/passwd")
-	assert.Error(t, err)
-	assert.Equal(t, ErrPathOutsideStore, err)
+	require.Error(t, err)
+	require.Equal(t, ErrPathOutsideStore, err)
 
 	// Convoluted paths should work as long as they end up inside the store
 	expected := "/path/to/filestore/filename.crt"
 	result, err := store.GetPath("private/../../filestore/./filename")
-	assert.NoError(t, err)
-	assert.Equal(t, expected, result)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
 
 	// Repeat tests with a relative baseDir
 	relStore := &SimpleFileStore{
@@ -231,17 +231,17 @@ func TestGetPathProtection(t *testing.T) {
 
 	// Should deny requests for paths outside the filestore
 	_, err = relStore.GetPath("../../etc/passwd")
-	assert.Error(t, err)
-	assert.Equal(t, ErrPathOutsideStore, err)
+	require.Error(t, err)
+	require.Equal(t, ErrPathOutsideStore, err)
 	_, err = relStore.GetPath("private/../../../etc/passwd")
-	assert.Error(t, err)
-	assert.Equal(t, ErrPathOutsideStore, err)
+	require.Error(t, err)
+	require.Equal(t, ErrPathOutsideStore, err)
 
 	// Convoluted paths should work as long as they end up inside the store
 	expected = "relative/file/path/filename.crt"
 	result, err = relStore.GetPath("private/../../path/./filename")
-	assert.NoError(t, err)
-	assert.Equal(t, expected, result)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
 }
 
 func TestGetData(t *testing.T) {
@@ -251,14 +251,14 @@ func TestGetData(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	// Since we're generating this manually we need to add the extension '.'
 	expectedFilePath := filepath.Join(tempBaseDir, testName+testExt)
 
 	expectedData, err := generateRandomFile(expectedFilePath, perms)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create our SimpleFileStore
 	store := &SimpleFileStore{
@@ -267,8 +267,8 @@ func TestGetData(t *testing.T) {
 		perms:   perms,
 	}
 	testData, err := store.Get(testName)
-	assert.NoError(t, err, "failed to get data from: %s", testName)
-	assert.Equal(t, expectedData, testData, "unexpected content for the file: %s", expectedFilePath)
+	require.NoError(t, err, "failed to get data from: %s", testName)
+	require.Equal(t, expectedData, testData, "unexpected content for the file: %s", expectedFilePath)
 }
 
 func TestCreateDirectory(t *testing.T) {
@@ -276,7 +276,7 @@ func TestCreateDirectory(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	dirPath := filepath.Join(tempBaseDir, testDir)
@@ -286,13 +286,13 @@ func TestCreateDirectory(t *testing.T) {
 
 	// Check to see if file exists
 	fi, err := os.Stat(dirPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check to see if it is a directory
-	assert.True(t, fi.IsDir(), "expected to be directory: %s", dirPath)
+	require.True(t, fi.IsDir(), "expected to be directory: %s", dirPath)
 
 	// Check to see if the permissions match
-	assert.Equal(t, "drwxr-xr-x", fi.Mode().String(), "permissions are wrong for: %s. Got: %s", dirPath, fi.Mode().String())
+	require.Equal(t, "drwxr-xr-x", fi.Mode().String(), "permissions are wrong for: %s. Got: %s", dirPath, fi.Mode().String())
 }
 
 func TestCreatePrivateDirectory(t *testing.T) {
@@ -300,7 +300,7 @@ func TestCreatePrivateDirectory(t *testing.T) {
 
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	dirPath := filepath.Join(tempBaseDir, testDir)
@@ -310,13 +310,13 @@ func TestCreatePrivateDirectory(t *testing.T) {
 
 	// Check to see if file exists
 	fi, err := os.Stat(dirPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check to see if it is a directory
-	assert.True(t, fi.IsDir(), "expected to be directory: %s", dirPath)
+	require.True(t, fi.IsDir(), "expected to be directory: %s", dirPath)
 
 	// Check to see if the permissions match
-	assert.Equal(t, "drwx------", fi.Mode().String(), "permissions are wrong for: %s. Got: %s", dirPath, fi.Mode().String())
+	require.Equal(t, "drwx------", fi.Mode().String(), "permissions are wrong for: %s. Got: %s", dirPath, fi.Mode().String())
 }
 
 func generateRandomFile(filePath string, perms os.FileMode) ([]byte, error) {
@@ -337,30 +337,30 @@ func generateRandomFile(filePath string, perms os.FileMode) ([]byte, error) {
 func TestFileStoreConsistency(t *testing.T) {
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 
 	tempBaseDir2, err := ioutil.TempDir("", "notary-test-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir2)
 
 	s, err := NewPrivateSimpleFileStore(tempBaseDir, "txt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	s2, err := NewPrivateSimpleFileStore(tempBaseDir2, ".txt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	file1Data := make([]byte, 20)
 	_, err = rand.Read(file1Data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	file2Data := make([]byte, 20)
 	_, err = rand.Read(file2Data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	file3Data := make([]byte, 20)
 	_, err = rand.Read(file3Data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	file1Path := "file1"
 	file2Path := "path/file2"
@@ -378,10 +378,10 @@ func TestFileStoreConsistency(t *testing.T) {
 		}
 		for _, p := range s.ListFiles() {
 			_, ok := paths[p]
-			assert.True(t, ok, fmt.Sprintf("returned path not found: %s", p))
+			require.True(t, ok, fmt.Sprintf("returned path not found: %s", p))
 			d, err := s.Get(p)
-			assert.NoError(t, err)
-			assert.Equal(t, paths[p], d)
+			require.NoError(t, err)
+			require.Equal(t, paths[p], d)
 		}
 	}
 

--- a/trustmanager/x509filestore_test.go
+++ b/trustmanager/x509filestore_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewX509FileStore(t *testing.T) {
@@ -27,38 +27,38 @@ func TestNewX509FileStore(t *testing.T) {
 // not overwrite any of the.
 func TestNewX509FileStoreLoadsExistingCerts(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "cert-test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
 	certBytes, err := ioutil.ReadFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	out, err := os.Create(filepath.Join(tempDir, "root-ca.crt"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// to distinguish it from the canonical format
 	distinguishingBytes := []byte{'\n', '\n', '\n', '\n', '\n', '\n'}
 	nBytes, err := out.Write(distinguishingBytes)
-	assert.NoError(t, err)
-	assert.Len(t, distinguishingBytes, nBytes)
+	require.NoError(t, err)
+	require.Len(t, distinguishingBytes, nBytes)
 
 	nBytes, err = out.Write(certBytes)
-	assert.NoError(t, err)
-	assert.Len(t, certBytes, nBytes)
+	require.NoError(t, err)
+	require.Len(t, certBytes, nBytes)
 
 	err = out.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	store, err := NewX509FileStore(tempDir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedCert, err := LoadCertFromFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err)
-	assert.Equal(t, []*x509.Certificate{expectedCert}, store.GetCertificates())
+	require.NoError(t, err)
+	require.Equal(t, []*x509.Certificate{expectedCert}, store.GetCertificates())
 
 	outBytes, err := ioutil.ReadFile(filepath.Join(tempDir, "root-ca.crt"))
-	assert.NoError(t, err)
-	assert.Equal(t, distinguishingBytes, outBytes[:6], "original file overwritten")
-	assert.Equal(t, certBytes, outBytes[6:], "original file overwritten")
+	require.NoError(t, err)
+	require.Equal(t, distinguishingBytes, outBytes[:6], "original file overwritten")
+	require.Equal(t, certBytes, outBytes[6:], "original file overwritten")
 }
 
 func TestAddCertX509FileStore(t *testing.T) {
@@ -100,40 +100,39 @@ func TestAddCertX509FileStore(t *testing.T) {
 
 func TestAddCertFromFileX509FileStore(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "cert-test")
-	assert.NoError(t, err, "failed to create temporary directory")
+	require.NoError(t, err, "failed to create temporary directory")
 
 	store, err := NewX509FileStore(tempDir)
-	assert.NoError(t, err, "failed to load x509 filestore")
+	require.NoError(t, err, "failed to load x509 filestore")
 
 	err = store.AddCertFromFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err, "failed to add certificate from file")
-	assert.Len(t, store.GetCertificates(), 1)
+	require.NoError(t, err, "failed to add certificate from file")
+	require.Len(t, store.GetCertificates(), 1)
 
 	// Now load the x509 filestore with the same path and expect the same result
 	newStore, err := NewX509FileStore(tempDir)
-	assert.NoError(t, err, "failed to load x509 filestore")
-	assert.Len(t, newStore.GetCertificates(), 1)
+	require.NoError(t, err, "failed to load x509 filestore")
+	require.Len(t, newStore.GetCertificates(), 1)
 
 	// Test that adding the same certificate returns an error
 	err = newStore.AddCert(newStore.GetCertificates()[0])
-	if assert.Error(t, err, "expected error when adding certificate twice") {
-		assert.Equal(t, err, &ErrCertExists{})
-	}
+	require.Error(t, err, "expected error when adding certificate twice")
+	require.Equal(t, err, &ErrCertExists{})
 }
 
 // TestNewX509FileStoreEmpty verifies the behavior of the Empty function
 func TestNewX509FileStoreEmpty(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "cert-test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
 	store, err := NewX509FileStore(tempDir)
-	assert.NoError(t, err)
-	assert.True(t, store.Empty())
+	require.NoError(t, err)
+	require.True(t, store.Empty())
 
 	err = store.AddCertFromFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err)
-	assert.False(t, store.Empty())
+	require.NoError(t, err)
+	require.False(t, store.Empty())
 }
 
 func TestAddCertFromPEMX509FileStore(t *testing.T) {

--- a/trustmanager/x509utils_test.go
+++ b/trustmanager/x509utils_test.go
@@ -11,143 +11,143 @@ import (
 	"time"
 
 	"github.com/docker/notary/tuf/data"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCertsToKeys(t *testing.T) {
 	// Get root certificate
 	rootCA, err := LoadCertFromFile("../fixtures/root-ca.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get intermediate certificate
 	intermediateCA, err := LoadCertFromFile("../fixtures/intermediate-ca.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get leaf certificate
 	leafCert, err := LoadCertFromFile("../fixtures/secure.example.com.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get our certList with Leaf Cert and Intermediate
 	certList := []*x509.Certificate{leafCert, intermediateCA, rootCA}
 
 	// Call CertsToKEys
 	keys := CertsToKeys(certList)
-	assert.NotNil(t, keys)
-	assert.Len(t, keys, 3)
+	require.NotNil(t, keys)
+	require.Len(t, keys, 3)
 
 	// Call GetLeafCerts
 	newKeys := GetLeafCerts(certList)
-	assert.NotNil(t, newKeys)
-	assert.Len(t, newKeys, 1)
+	require.NotNil(t, newKeys)
+	require.Len(t, newKeys, 1)
 
 	// Call GetIntermediateCerts (checks for certs with IsCA true)
 	newKeys = GetIntermediateCerts(certList)
-	assert.NotNil(t, newKeys)
-	assert.Len(t, newKeys, 2)
+	require.NotNil(t, newKeys)
+	require.Len(t, newKeys, 2)
 }
 
 func TestNewCertificate(t *testing.T) {
 	startTime := time.Now()
 	endTime := startTime.AddDate(10, 0, 0)
 	cert, err := NewCertificate("docker.com/alpine", startTime, endTime)
-	assert.NoError(t, err)
-	assert.Equal(t, cert.Subject.CommonName, "docker.com/alpine")
-	assert.Equal(t, cert.NotBefore, startTime)
-	assert.Equal(t, cert.NotAfter, endTime)
+	require.NoError(t, err)
+	require.Equal(t, cert.Subject.CommonName, "docker.com/alpine")
+	require.Equal(t, cert.NotBefore, startTime)
+	require.Equal(t, cert.NotAfter, endTime)
 }
 
 func TestKeyOperations(t *testing.T) {
 	// Generate our ED25519 private key
 	edKey, err := GenerateED25519Key(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Generate our EC private key
 	ecKey, err := GenerateECDSAKey(rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Generate our RSA private key
 	rsaKey, err := GenerateRSAKey(rand.Reader, 512)
 
 	// Encode our ED private key
 	edPEM, err := KeyToPEM(edKey, "root")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Encode our EC private key
 	ecPEM, err := KeyToPEM(ecKey, "root")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Encode our RSA private key
 	rsaPEM, err := KeyToPEM(rsaKey, "root")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check to see if ED key it is encoded
 	stringEncodedEDKey := string(edPEM)
-	assert.True(t, strings.Contains(stringEncodedEDKey, "-----BEGIN ED25519 PRIVATE KEY-----"))
+	require.True(t, strings.Contains(stringEncodedEDKey, "-----BEGIN ED25519 PRIVATE KEY-----"))
 
 	// Check to see if EC key it is encoded
 	stringEncodedECKey := string(ecPEM)
-	assert.True(t, strings.Contains(stringEncodedECKey, "-----BEGIN EC PRIVATE KEY-----"))
+	require.True(t, strings.Contains(stringEncodedECKey, "-----BEGIN EC PRIVATE KEY-----"))
 
 	// Check to see if RSA key it is encoded
 	stringEncodedRSAKey := string(rsaPEM)
-	assert.True(t, strings.Contains(stringEncodedRSAKey, "-----BEGIN RSA PRIVATE KEY-----"))
+	require.True(t, strings.Contains(stringEncodedRSAKey, "-----BEGIN RSA PRIVATE KEY-----"))
 
 	// Decode our ED Key
 	decodedEDKey, err := ParsePEMPrivateKey(edPEM, "")
-	assert.NoError(t, err)
-	assert.Equal(t, edKey.Private(), decodedEDKey.Private())
+	require.NoError(t, err)
+	require.Equal(t, edKey.Private(), decodedEDKey.Private())
 
 	// Decode our EC Key
 	decodedECKey, err := ParsePEMPrivateKey(ecPEM, "")
-	assert.NoError(t, err)
-	assert.Equal(t, ecKey.Private(), decodedECKey.Private())
+	require.NoError(t, err)
+	require.Equal(t, ecKey.Private(), decodedECKey.Private())
 
 	// Decode our RSA Key
 	decodedRSAKey, err := ParsePEMPrivateKey(rsaPEM, "")
-	assert.NoError(t, err)
-	assert.Equal(t, rsaKey.Private(), decodedRSAKey.Private())
+	require.NoError(t, err)
+	require.Equal(t, rsaKey.Private(), decodedRSAKey.Private())
 
 	// Encrypt our ED Key
 	encryptedEDKey, err := EncryptPrivateKey(edKey, "root", "ponies")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Encrypt our EC Key
 	encryptedECKey, err := EncryptPrivateKey(ecKey, "root", "ponies")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Encrypt our RSA Key
 	encryptedRSAKey, err := EncryptPrivateKey(rsaKey, "root", "ponies")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check to see if ED key it is encrypted
 	stringEncryptedEDKey := string(encryptedEDKey)
-	assert.True(t, strings.Contains(stringEncryptedEDKey, "-----BEGIN ED25519 PRIVATE KEY-----"))
-	assert.True(t, strings.Contains(stringEncryptedEDKey, "Proc-Type: 4,ENCRYPTED"))
+	require.True(t, strings.Contains(stringEncryptedEDKey, "-----BEGIN ED25519 PRIVATE KEY-----"))
+	require.True(t, strings.Contains(stringEncryptedEDKey, "Proc-Type: 4,ENCRYPTED"))
 
 	// Check to see if EC key it is encrypted
 	stringEncryptedECKey := string(encryptedECKey)
-	assert.True(t, strings.Contains(stringEncryptedECKey, "-----BEGIN EC PRIVATE KEY-----"))
-	assert.True(t, strings.Contains(stringEncryptedECKey, "Proc-Type: 4,ENCRYPTED"))
+	require.True(t, strings.Contains(stringEncryptedECKey, "-----BEGIN EC PRIVATE KEY-----"))
+	require.True(t, strings.Contains(stringEncryptedECKey, "Proc-Type: 4,ENCRYPTED"))
 
 	// Check to see if RSA key it is encrypted
 	stringEncryptedRSAKey := string(encryptedRSAKey)
-	assert.True(t, strings.Contains(stringEncryptedRSAKey, "-----BEGIN RSA PRIVATE KEY-----"))
-	assert.True(t, strings.Contains(stringEncryptedRSAKey, "Proc-Type: 4,ENCRYPTED"))
+	require.True(t, strings.Contains(stringEncryptedRSAKey, "-----BEGIN RSA PRIVATE KEY-----"))
+	require.True(t, strings.Contains(stringEncryptedRSAKey, "Proc-Type: 4,ENCRYPTED"))
 
 	// Decrypt our ED Key
 	decryptedEDKey, err := ParsePEMPrivateKey(encryptedEDKey, "ponies")
-	assert.NoError(t, err)
-	assert.Equal(t, edKey.Private(), decryptedEDKey.Private())
+	require.NoError(t, err)
+	require.Equal(t, edKey.Private(), decryptedEDKey.Private())
 
 	// Decrypt our EC Key
 	decryptedECKey, err := ParsePEMPrivateKey(encryptedECKey, "ponies")
-	assert.NoError(t, err)
-	assert.Equal(t, ecKey.Private(), decryptedECKey.Private())
+	require.NoError(t, err)
+	require.Equal(t, ecKey.Private(), decryptedECKey.Private())
 
 	// Decrypt our RSA Key
 	decryptedRSAKey, err := ParsePEMPrivateKey(encryptedRSAKey, "ponies")
-	assert.NoError(t, err)
-	assert.Equal(t, rsaKey.Private(), decryptedRSAKey.Private())
+	require.NoError(t, err)
+	require.Equal(t, rsaKey.Private(), decryptedRSAKey.Private())
 
 }
 
@@ -155,25 +155,25 @@ func TestKeyOperations(t *testing.T) {
 // cert ID
 func TestRSAX509PublickeyID(t *testing.T) {
 	fileBytes, err := ioutil.ReadFile("../fixtures/notary-server.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	privKey, err := ParsePEMPrivateKey(fileBytes, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expectedTufID := privKey.ID()
 
 	cert, err := LoadCertFromFile("../fixtures/notary-server.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rsaKeyBytes, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sameWayTufID := data.NewPublicKey(data.RSAKey, rsaKeyBytes).ID()
 
 	actualTufKey := CertToKey(cert)
 	actualTufID, err := X509PublicKeyID(actualTufKey)
 
-	assert.Equal(t, sameWayTufID, actualTufID)
-	assert.Equal(t, expectedTufID, actualTufID)
+	require.Equal(t, sameWayTufID, actualTufID)
+	require.Equal(t, expectedTufID, actualTufID)
 }
 
 // X509PublickeyID returns the public key ID of an ECDSA X509 key rather than
@@ -181,26 +181,26 @@ func TestRSAX509PublickeyID(t *testing.T) {
 func TestECDSAX509PublickeyID(t *testing.T) {
 	startTime := time.Now()
 	template, err := NewCertificate("something", startTime, startTime.AddDate(10, 0, 0))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	template.SignatureAlgorithm = x509.ECDSAWithSHA256
 	template.PublicKeyAlgorithm = x509.ECDSA
 
 	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tufPrivKey, err := ECDSAToPrivateKey(privKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	derBytes, err := x509.CreateCertificate(
 		rand.Reader, template, template, &privKey.PublicKey, privKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cert, err := x509.ParseCertificate(derBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tufKey := CertToKey(cert)
 	tufID, err := X509PublicKeyID(tufKey)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, tufPrivKey.ID(), tufID)
+	require.Equal(t, tufPrivKey.ID(), tufID)
 }


### PR DESCRIPTION
Part of #628 for the certs and trustmanager packages, using require instead of assert for testing

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>