### PR TITLE
Embed SignedCommon in Root, Snapshot, and Timestamp

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -101,9 +101,11 @@ func TestGetRoleByHash(t *testing.T) {
 	ts := data.SignedTimestamp{
 		Signatures: make([]data.Signature, 0),
 		Signed: data.Timestamp{
-			Type:    data.TUFTypes[data.CanonicalTimestampRole],
-			Version: 1,
-			Expires: data.DefaultExpires(data.CanonicalTimestampRole),
+			SignedCommon: data.SignedCommon{
+				Type:    data.TUFTypes[data.CanonicalTimestampRole],
+				Version: 1,
+				Expires: data.DefaultExpires(data.CanonicalTimestampRole),
+			},
 		},
 	}
 	j, err := json.Marshal(&ts)
@@ -121,9 +123,11 @@ func TestGetRoleByHash(t *testing.T) {
 	ts = data.SignedTimestamp{
 		Signatures: make([]data.Signature, 0),
 		Signed: data.Timestamp{
-			Type:    data.TUFTypes[data.CanonicalTimestampRole],
-			Version: 2,
-			Expires: data.DefaultExpires(data.CanonicalTimestampRole),
+			SignedCommon: data.SignedCommon{
+				Type:    data.TUFTypes[data.CanonicalTimestampRole],
+				Version: 2,
+				Expires: data.DefaultExpires(data.CanonicalTimestampRole),
+			},
 		},
 	}
 	newTS, err := json.Marshal(&ts)

--- a/server/snapshot/snapshot_test.go
+++ b/server/snapshot/snapshot_test.go
@@ -17,7 +17,7 @@ func TestSnapshotExpired(t *testing.T) {
 	sn := &data.SignedSnapshot{
 		Signatures: nil,
 		Signed: data.Snapshot{
-			Expires: time.Now().AddDate(-1, 0, 0),
+			SignedCommon: data.SignedCommon{Expires: time.Now().AddDate(-1, 0, 0)},
 		},
 	}
 	require.True(t, snapshotExpired(sn), "Snapshot should have expired")
@@ -27,7 +27,7 @@ func TestSnapshotNotExpired(t *testing.T) {
 	sn := &data.SignedSnapshot{
 		Signatures: nil,
 		Signed: data.Snapshot{
-			Expires: time.Now().AddDate(1, 0, 0),
+			SignedCommon: data.SignedCommon{Expires: time.Now().AddDate(1, 0, 0)},
 		},
 	}
 	require.False(t, snapshotExpired(sn), "Snapshot should NOT have expired")

--- a/server/storage/database_test.go
+++ b/server/storage/database_test.go
@@ -456,9 +456,11 @@ func TestDBGetChecksum(t *testing.T) {
 	ts := data.SignedTimestamp{
 		Signatures: make([]data.Signature, 0),
 		Signed: data.Timestamp{
-			Type:    data.TUFTypes["timestamp"],
-			Version: 1,
-			Expires: data.DefaultExpires("timestamp"),
+			SignedCommon: data.SignedCommon{
+				Type:    data.TUFTypes[data.CanonicalTimestampRole],
+				Version: 1,
+				Expires: data.DefaultExpires(data.CanonicalTimestampRole),
+			},
 		},
 	}
 	j, err := json.Marshal(&ts)
@@ -478,9 +480,11 @@ func TestDBGetChecksum(t *testing.T) {
 	ts = data.SignedTimestamp{
 		Signatures: make([]data.Signature, 0),
 		Signed: data.Timestamp{
-			Type:    data.TUFTypes["timestamp"],
-			Version: 2,
-			Expires: data.DefaultExpires("timestamp"),
+			SignedCommon: data.SignedCommon{
+				Type:    data.TUFTypes[data.CanonicalTimestampRole],
+				Version: 2,
+				Expires: data.DefaultExpires(data.CanonicalTimestampRole),
+			},
 		},
 	}
 	newJ, err := json.Marshal(&ts)

--- a/server/timestamp/timestamp_test.go
+++ b/server/timestamp/timestamp_test.go
@@ -18,7 +18,7 @@ func TestTimestampExpired(t *testing.T) {
 	ts := &data.SignedTimestamp{
 		Signatures: nil,
 		Signed: data.Timestamp{
-			Expires: time.Now().AddDate(-1, 0, 0),
+			SignedCommon: data.SignedCommon{Expires: time.Now().AddDate(-1, 0, 0)},
 		},
 	}
 	require.True(t, timestampExpired(ts), "Timestamp should have expired")
@@ -28,7 +28,7 @@ func TestTimestampNotExpired(t *testing.T) {
 	ts := &data.SignedTimestamp{
 		Signatures: nil,
 		Signed: data.Timestamp{
-			Expires: time.Now().AddDate(1, 0, 0),
+			SignedCommon: data.SignedCommon{Expires: time.Now().AddDate(1, 0, 0)},
 		},
 	}
 	require.False(t, timestampExpired(ts), "Timestamp should NOT have expired")

--- a/tuf/data/root.go
+++ b/tuf/data/root.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/docker/go/canonical/json"
 )
@@ -16,9 +15,7 @@ type SignedRoot struct {
 
 // Root is the Signed component of a root.json
 type Root struct {
-	Type               string               `json:"_type"`
-	Version            int                  `json:"version"`
-	Expires            time.Time            `json:"expires"`
+	SignedCommon
 	Keys               Keys                 `json:"keys"`
 	Roles              map[string]*RootRole `json:"roles"`
 	ConsistentSnapshot bool                 `json:"consistent_snapshot"`
@@ -72,9 +69,11 @@ func NewRoot(keys map[string]PublicKey, roles map[string]*RootRole, consistent b
 	signedRoot := &SignedRoot{
 		Signatures: make([]Signature, 0),
 		Signed: Root{
-			Type:               TUFTypes[CanonicalRootRole],
-			Version:            0,
-			Expires:            DefaultExpires(CanonicalRootRole),
+			SignedCommon: SignedCommon{
+				Type:    TUFTypes[CanonicalRootRole],
+				Version: 0,
+				Expires: DefaultExpires(CanonicalRootRole),
+			},
 			Keys:               keys,
 			Roles:              roles,
 			ConsistentSnapshot: consistent,

--- a/tuf/data/root_test.go
+++ b/tuf/data/root_test.go
@@ -27,9 +27,11 @@ func (e errorSerializer) Unmarshal([]byte, interface{}) error {
 func validRootTemplate() *SignedRoot {
 	return &SignedRoot{
 		Signed: Root{
-			Type:    "Root",
-			Version: 1,
-			Expires: time.Now(),
+			SignedCommon: SignedCommon{
+				Type:    TUFTypes[CanonicalRootRole],
+				Version: 1,
+				Expires: time.Now(),
+			},
 			Keys: Keys{
 				"key1":  NewPublicKey(RSAKey, []byte("key1")),
 				"key2":  NewPublicKey(RSAKey, []byte("key2")),
@@ -52,7 +54,8 @@ func validRootTemplate() *SignedRoot {
 }
 
 func TestRootToSignedMarshalsSignedPortionWithCanonicalJSON(t *testing.T) {
-	r := SignedRoot{Signed: Root{Type: "root", Version: 2, Expires: time.Now()}}
+	r := SignedRoot{Signed: Root{SignedCommon: SignedCommon{
+		Type: TUFTypes[CanonicalRootRole], Version: 2, Expires: time.Now()}}}
 	signedCanonical, err := r.ToSigned()
 	require.NoError(t, err)
 
@@ -69,7 +72,8 @@ func TestRootToSignedMarshalsSignedPortionWithCanonicalJSON(t *testing.T) {
 
 func TestRootToSignCopiesSignatures(t *testing.T) {
 	r := SignedRoot{
-		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+		Signed: Root{SignedCommon: SignedCommon{
+			Type: TUFTypes[CanonicalRootRole], Version: 2, Expires: time.Now()}},
 		Signatures: []Signature{
 			{KeyID: "key1", Method: "method1", Signature: []byte("hello")},
 		},
@@ -89,7 +93,8 @@ func TestRootToSignedMarshallingErrorsPropagated(t *testing.T) {
 	setDefaultSerializer(errorSerializer{})
 	defer setDefaultSerializer(canonicalJSON{})
 	r := SignedRoot{
-		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+		Signed: Root{SignedCommon: SignedCommon{
+			Type: TUFTypes[CanonicalRootRole], Version: 2, Expires: time.Now()}},
 	}
 	_, err := r.ToSigned()
 	require.EqualError(t, err, "bad")
@@ -97,7 +102,7 @@ func TestRootToSignedMarshallingErrorsPropagated(t *testing.T) {
 
 func TestRootMarshalJSONMarshalsSignedWithRegularJSON(t *testing.T) {
 	r := SignedRoot{
-		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+		Signed: Root{SignedCommon: SignedCommon{Type: "root", Version: 2, Expires: time.Now()}},
 		Signatures: []Signature{
 			{KeyID: "key1", Method: "method1", Signature: []byte("hello")},
 			{KeyID: "key2", Method: "method2", Signature: []byte("there")},
@@ -122,7 +127,8 @@ func TestRootMarshalJSONMarshallingErrorsPropagated(t *testing.T) {
 	setDefaultSerializer(errorSerializer{})
 	defer setDefaultSerializer(canonicalJSON{})
 	r := SignedRoot{
-		Signed: Root{Type: "root", Version: 2, Expires: time.Now()},
+		Signed: Root{SignedCommon: SignedCommon{
+			Type: TUFTypes[CanonicalRootRole], Version: 2, Expires: time.Now()}},
 	}
 	_, err := r.MarshalJSON()
 	require.EqualError(t, err, "bad")

--- a/tuf/data/snapshot.go
+++ b/tuf/data/snapshot.go
@@ -3,7 +3,6 @@ package data
 import (
 	"bytes"
 	"fmt"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/go/canonical/json"
@@ -19,10 +18,8 @@ type SignedSnapshot struct {
 
 // Snapshot is the Signed component of a snapshot.json
 type Snapshot struct {
-	Type    string    `json:"_type"`
-	Version int       `json:"version"`
-	Expires time.Time `json:"expires"`
-	Meta    Files     `json:"meta"`
+	SignedCommon
+	Meta Files `json:"meta"`
 }
 
 // isValidSnapshotStructure returns an error, or nil, depending on whether the content of the
@@ -82,9 +79,11 @@ func NewSnapshot(root *Signed, targets *Signed) (*SignedSnapshot, error) {
 	return &SignedSnapshot{
 		Signatures: make([]Signature, 0),
 		Signed: Snapshot{
-			Type:    TUFTypes[CanonicalSnapshotRole],
-			Version: 0,
-			Expires: DefaultExpires(CanonicalSnapshotRole),
+			SignedCommon: SignedCommon{
+				Type:    TUFTypes[CanonicalSnapshotRole],
+				Version: 0,
+				Expires: DefaultExpires(CanonicalSnapshotRole),
+			},
 			Meta: Files{
 				CanonicalRootRole:    rootMeta,
 				CanonicalTargetsRole: targetsMeta,

--- a/tuf/data/snapshot_test.go
+++ b/tuf/data/snapshot_test.go
@@ -16,7 +16,8 @@ import (
 func validSnapshotTemplate() *SignedSnapshot {
 	return &SignedSnapshot{
 		Signed: Snapshot{
-			Type: "Snapshot", Version: 1, Expires: time.Now(), Meta: Files{
+			SignedCommon: SignedCommon{Type: TUFTypes[CanonicalSnapshotRole], Version: 1, Expires: time.Now()},
+			Meta: Files{
 				CanonicalRootRole:    FileMeta{Hashes: Hashes{"sha256": bytes.Repeat([]byte("a"), sha256.Size)}},
 				CanonicalTargetsRole: FileMeta{Hashes: Hashes{"sha256": bytes.Repeat([]byte("a"), sha256.Size)}},
 				"targets/a":          FileMeta{},
@@ -28,7 +29,8 @@ func validSnapshotTemplate() *SignedSnapshot {
 }
 
 func TestSnapshotToSignedMarshalsSignedPortionWithCanonicalJSON(t *testing.T) {
-	sn := SignedSnapshot{Signed: Snapshot{Type: "Snapshot", Version: 1, Expires: time.Now()}}
+	sn := SignedSnapshot{Signed: Snapshot{SignedCommon: SignedCommon{
+		Type: TUFTypes[CanonicalSnapshotRole], Version: 1, Expires: time.Now()}}}
 	signedCanonical, err := sn.ToSigned()
 	require.NoError(t, err)
 
@@ -45,7 +47,8 @@ func TestSnapshotToSignedMarshalsSignedPortionWithCanonicalJSON(t *testing.T) {
 
 func TestSnapshotToSignCopiesSignatures(t *testing.T) {
 	sn := SignedSnapshot{
-		Signed: Snapshot{Type: "Snapshot", Version: 2, Expires: time.Now()},
+		Signed: Snapshot{SignedCommon: SignedCommon{
+			Type: TUFTypes[CanonicalSnapshotRole], Version: 2, Expires: time.Now()}},
 		Signatures: []Signature{
 			{KeyID: "key1", Method: "method1", Signature: []byte("hello")},
 		},
@@ -65,7 +68,8 @@ func TestSnapshotToSignedMarshallingErrorsPropagated(t *testing.T) {
 	setDefaultSerializer(errorSerializer{})
 	defer setDefaultSerializer(canonicalJSON{})
 	sn := SignedSnapshot{
-		Signed: Snapshot{Type: "Snapshot", Version: 2, Expires: time.Now()},
+		Signed: Snapshot{SignedCommon: SignedCommon{
+			Type: TUFTypes[CanonicalSnapshotRole], Version: 2, Expires: time.Now()}},
 	}
 	_, err := sn.ToSigned()
 	require.EqualError(t, err, "bad")
@@ -73,7 +77,8 @@ func TestSnapshotToSignedMarshallingErrorsPropagated(t *testing.T) {
 
 func TestSnapshotMarshalJSONMarshalsSignedWithRegularJSON(t *testing.T) {
 	sn := SignedSnapshot{
-		Signed: Snapshot{Type: "Snapshot", Version: 1, Expires: time.Now()},
+		Signed: Snapshot{SignedCommon: SignedCommon{
+			Type: TUFTypes[CanonicalSnapshotRole], Version: 1, Expires: time.Now()}},
 		Signatures: []Signature{
 			{KeyID: "key1", Method: "method1", Signature: []byte("hello")},
 			{KeyID: "key2", Method: "method2", Signature: []byte("there")},
@@ -98,7 +103,8 @@ func TestSnapshotMarshalJSONMarshallingErrorsPropagated(t *testing.T) {
 	setDefaultSerializer(errorSerializer{})
 	defer setDefaultSerializer(canonicalJSON{})
 	sn := SignedSnapshot{
-		Signed: Snapshot{Type: "Snapshot", Version: 2, Expires: time.Now()},
+		Signed: Snapshot{SignedCommon: SignedCommon{
+			Type: TUFTypes[CanonicalSnapshotRole], Version: 2, Expires: time.Now()}},
 	}
 	_, err := sn.MarshalJSON()
 	require.EqualError(t, err, "bad")
@@ -182,10 +188,10 @@ func TestSnapshotFromSignedValidatesRoleType(t *testing.T) {
 	}
 
 	sn = validSnapshotTemplate()
-	sn.Signed.Type = "Snapshot"
+	sn.Signed.Type = TUFTypes[CanonicalSnapshotRole]
 	sSnapshot, err := snapshotToSignedAndBack(t, sn)
 	require.NoError(t, err)
-	require.Equal(t, "Snapshot", sSnapshot.Signed.Type)
+	require.Equal(t, TUFTypes[CanonicalSnapshotRole], sSnapshot.Signed.Type)
 }
 
 // GetMeta returns the checksum, or an error if it is missing.

--- a/tuf/data/timestamp.go
+++ b/tuf/data/timestamp.go
@@ -3,7 +3,6 @@ package data
 import (
 	"bytes"
 	"fmt"
-	"time"
 
 	"github.com/docker/go/canonical/json"
 	"github.com/docker/notary"
@@ -18,10 +17,8 @@ type SignedTimestamp struct {
 
 // Timestamp is the Signed component of a timestamp.json
 type Timestamp struct {
-	Type    string    `json:"_type"`
-	Version int       `json:"version"`
-	Expires time.Time `json:"expires"`
-	Meta    Files     `json:"meta"`
+	SignedCommon
+	Meta Files `json:"meta"`
 }
 
 // isValidTimestampStructure returns an error, or nil, depending on whether the content of the struct
@@ -64,9 +61,11 @@ func NewTimestamp(snapshot *Signed) (*SignedTimestamp, error) {
 	return &SignedTimestamp{
 		Signatures: make([]Signature, 0),
 		Signed: Timestamp{
-			Type:    TUFTypes["timestamp"],
-			Version: 0,
-			Expires: DefaultExpires("timestamp"),
+			SignedCommon: SignedCommon{
+				Type:    TUFTypes[CanonicalTimestampRole],
+				Version: 0,
+				Expires: DefaultExpires(CanonicalTimestampRole),
+			},
 			Meta: Files{
 				CanonicalSnapshotRole: snapshotMeta,
 			},


### PR DESCRIPTION
Since it's already embedded in `Targets`.

Will be useful for me for https://github.com/docker/notary/pull/580