### PR TITLE
Do not install go vet on the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN go get golang.org/x/tools/cmd/vet \
-	&& go get golang.org/x/tools/cmd/cover \
-	&& go get github.com/tools/godep
+RUN go get golang.org/x/tools/cmd/cover
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,12 @@ RUN go get golang.org/x/tools/cmd/cover
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk
+ENV OSX_CROSS_COMMIT 8aa9b71a394905e6c5f4b59e2b97b87a004658a4
 RUN set -x \
 	&& export OSXCROSS_PATH="/osxcross" \
-	&& git clone --depth 1 https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
-	&& curl -sSL https://s3.dockerproject.org/darwin/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
+	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
+	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
+	&& curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
 	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
 ENV PATH /osxcross/target/bin:$PATH
 


### PR DESCRIPTION
Not sure what changed, but looks like go vet just comes with the image now and also osxcross breaks unless pinned to a commit.  Copied the OSX cross stuff from docker/docker Dockerfile.

Also bumped the min OSX version to 10.9.