### PR TITLE
Rework the main for notary signer

### DIFF
--- a/cmd/notary-signer/config.go
+++ b/cmd/notary-signer/config.go
@@ -1,0 +1,3 @@
+package main
+
+import ()

--- a/cmd/notary-signer/config.go
+++ b/cmd/notary-signer/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/notary/signer"
 	"github.com/docker/notary/signer/api"
 	"github.com/docker/notary/signer/keydbstore"
+	"github.com/docker/notary/storage"
 	"github.com/docker/notary/storage/rethinkdb"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
@@ -170,4 +171,12 @@ func getAddrAndTLSConfig(configuration *viper.Viper) (string, string, *tls.Confi
 	}
 
 	return httpAddr, grpcAddr, tlsConfig, nil
+}
+
+func bootstrap(s interface{}) error {
+	store, ok := s.(storage.Bootstrapper)
+	if !ok {
+		return fmt.Errorf("Store does not support bootstrapping.")
+	}
+	return store.Bootstrap()
 }

--- a/cmd/notary-signer/config.go
+++ b/cmd/notary-signer/config.go
@@ -152,3 +152,22 @@ func setupHTTPServer(httpAddr string, tlsConfig *tls.Config,
 		TLSConfig: tlsConfig,
 	}
 }
+
+func getAddrAndTLSConfig(configuration *viper.Viper) (string, string, *tls.Config, error) {
+	tlsConfig, err := utils.ParseServerTLS(configuration, true)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("unable to set up TLS: %s", err.Error())
+	}
+
+	grpcAddr := configuration.GetString("server.grpc_addr")
+	if grpcAddr == "" {
+		return "", "", nil, fmt.Errorf("grpc listen address required for server")
+	}
+
+	httpAddr := configuration.GetString("server.http_addr")
+	if httpAddr == "" {
+		return "", "", nil, fmt.Errorf("http listen address required for server")
+	}
+
+	return httpAddr, grpcAddr, tlsConfig, nil
+}

--- a/cmd/notary-signer/config.go
+++ b/cmd/notary-signer/config.go
@@ -1,3 +1,16 @@
 package main
 
-import ()
+import (
+	"errors"
+	"strings"
+)
+
+func passphraseRetriever(keyName, alias string, createNew bool, attempts int) (passphrase string, giveup bool, err error) {
+	passphrase = mainViper.GetString(strings.ToUpper(alias))
+
+	if passphrase == "" {
+		return "", false, errors.New("expected env variable to not be empty: " + alias)
+	}
+
+	return passphrase, false, nil
+}

--- a/cmd/notary-signer/config.go
+++ b/cmd/notary-signer/config.go
@@ -2,7 +2,24 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/dancannon/gorethink"
+	"github.com/docker/distribution/health"
+	"github.com/docker/notary"
+	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/passphrase"
+	"github.com/docker/notary/signer"
+	"github.com/docker/notary/signer/keydbstore"
+	"github.com/docker/notary/storage/rethinkdb"
+	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/utils"
+	"github.com/spf13/viper"
 )
 
 func passphraseRetriever(keyName, alias string, createNew bool, attempts int) (passphrase string, giveup bool, err error) {
@@ -13,4 +30,81 @@ func passphraseRetriever(keyName, alias string, createNew bool, attempts int) (p
 	}
 
 	return passphrase, false, nil
+}
+
+// Reads the configuration file for storage setup, and sets up the cryptoservice
+// mapping
+func setUpCryptoservices(configuration *viper.Viper, allowedBackends []string) (
+	signer.CryptoServiceIndex, error) {
+	backend := configuration.GetString("storage.backend")
+
+	var keyStore trustmanager.KeyStore
+	switch backend {
+	case notary.MemoryBackend:
+		keyStore = trustmanager.NewKeyMemoryStore(
+			passphrase.ConstantRetriever("memory-db-ignore"))
+	case notary.RethinkDBBackend:
+		var sess *gorethink.Session
+		storeConfig, err := utils.ParseRethinkDBStorage(configuration)
+		if err != nil {
+			return nil, err
+		}
+		defaultAlias, err := getDefaultAlias(configuration)
+		if err != nil {
+			return nil, err
+		}
+		sess, err = rethinkdb.Connection(storeConfig.CA, storeConfig.Source)
+		if err != nil {
+			return nil, err
+		}
+		s := keydbstore.NewRethinkDBKeyStore(passphraseRetriever, defaultAlias, sess)
+		health.RegisterPeriodicFunc("DB operational", s.CheckHealth, time.Minute)
+		keyStore = s
+	case notary.MySQLBackend, notary.SQLiteBackend:
+		storeConfig, err := utils.ParseSQLStorage(configuration)
+		if err != nil {
+			return nil, err
+		}
+		defaultAlias, err := getDefaultAlias(configuration)
+		if err != nil {
+			return nil, err
+		}
+		dbStore, err := keydbstore.NewKeyDBStore(
+			passphraseRetriever, defaultAlias, storeConfig.Backend, storeConfig.Source)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a new keydbstore: %v", err)
+		}
+
+		health.RegisterPeriodicFunc(
+			"DB operational", dbStore.HealthCheck, time.Minute)
+		keyStore = dbStore
+	}
+
+	if doBootstrap {
+		err := bootstrap(keyStore)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+		os.Exit(0)
+	}
+
+	cryptoService := cryptoservice.NewCryptoService(keyStore)
+	cryptoServices := make(signer.CryptoServiceIndex)
+	cryptoServices[data.ED25519Key] = cryptoService
+	cryptoServices[data.ECDSAKey] = cryptoService
+	return cryptoServices, nil
+}
+
+func getDefaultAlias(configuration *viper.Viper) (string, error) {
+	defaultAlias := configuration.GetString("storage.default_alias")
+	if defaultAlias == "" {
+		// backwards compatibility - support this environment variable
+		defaultAlias = configuration.GetString(defaultAliasEnv)
+	}
+
+	if defaultAlias == "" {
+		return "", fmt.Errorf("must provide a default alias for the key DB")
+	}
+	logrus.Debug("Default Alias: ", defaultAlias)
+	return defaultAlias, nil
 }

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"errors"
 	_ "expvar"
 	"flag"
 	"fmt"
@@ -10,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -64,16 +62,6 @@ func init() {
 	if logFormat == jsonLogFormat {
 		logrus.SetFormatter(new(logrus.JSONFormatter))
 	}
-}
-
-func passphraseRetriever(keyName, alias string, createNew bool, attempts int) (passphrase string, giveup bool, err error) {
-	passphrase = mainViper.GetString(strings.ToUpper(alias))
-
-	if passphrase == "" {
-		return "", false, errors.New("expected env variable to not be empty: " + alias)
-	}
-
-	return passphrase, false, nil
 }
 
 // Reads the configuration file for storage setup, and sets up the cryptoservice

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	_ "expvar"
 	"flag"
 	"fmt"
@@ -45,25 +44,6 @@ func init() {
 	if logFormat == jsonLogFormat {
 		logrus.SetFormatter(new(logrus.JSONFormatter))
 	}
-}
-
-func getAddrAndTLSConfig(configuration *viper.Viper) (string, string, *tls.Config, error) {
-	tlsConfig, err := utils.ParseServerTLS(configuration, true)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("unable to set up TLS: %s", err.Error())
-	}
-
-	grpcAddr := configuration.GetString("server.grpc_addr")
-	if grpcAddr == "" {
-		return "", "", nil, fmt.Errorf("grpc listen address required for server")
-	}
-
-	httpAddr := configuration.GetString("server.http_addr")
-	if httpAddr == "" {
-		return "", "", nil, fmt.Errorf("http listen address required for server")
-	}
-
-	return httpAddr, grpcAddr, tlsConfig, nil
 }
 
 func main() {

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -3,14 +3,12 @@ package main
 import (
 	_ "expvar"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary"
-	"github.com/docker/notary/storage"
 	"github.com/docker/notary/utils"
 	"github.com/docker/notary/version"
 	_ "github.com/go-sql-driver/mysql"
@@ -121,12 +119,4 @@ func debugServer(addr string) {
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		logrus.Fatalf("error listening on debug interface: %v", err)
 	}
-}
-
-func bootstrap(s interface{}) error {
-	store, ok := s.(storage.Bootstrapper)
-	if !ok {
-		return fmt.Errorf("Store does not support bootstrapping.")
-	}
-	return store.Bootstrap()
 }

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -9,23 +9,15 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/dancannon/gorethink"
 	"github.com/docker/distribution/health"
 	"github.com/docker/notary"
-	"github.com/docker/notary/cryptoservice"
-	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/signer"
 	"github.com/docker/notary/signer/api"
-	"github.com/docker/notary/signer/keydbstore"
 	"github.com/docker/notary/storage"
-	"github.com/docker/notary/storage/rethinkdb"
-	"github.com/docker/notary/trustmanager"
-	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/utils"
 	"github.com/docker/notary/version"
 	_ "github.com/go-sql-driver/mysql"
@@ -62,83 +54,6 @@ func init() {
 	if logFormat == jsonLogFormat {
 		logrus.SetFormatter(new(logrus.JSONFormatter))
 	}
-}
-
-// Reads the configuration file for storage setup, and sets up the cryptoservice
-// mapping
-func setUpCryptoservices(configuration *viper.Viper, allowedBackends []string) (
-	signer.CryptoServiceIndex, error) {
-	backend := configuration.GetString("storage.backend")
-
-	var keyStore trustmanager.KeyStore
-	switch backend {
-	case notary.MemoryBackend:
-		keyStore = trustmanager.NewKeyMemoryStore(
-			passphrase.ConstantRetriever("memory-db-ignore"))
-	case notary.RethinkDBBackend:
-		var sess *gorethink.Session
-		storeConfig, err := utils.ParseRethinkDBStorage(configuration)
-		if err != nil {
-			return nil, err
-		}
-		defaultAlias, err := getDefaultAlias(configuration)
-		if err != nil {
-			return nil, err
-		}
-		sess, err = rethinkdb.Connection(storeConfig.CA, storeConfig.Source)
-		if err != nil {
-			return nil, err
-		}
-		s := keydbstore.NewRethinkDBKeyStore(passphraseRetriever, defaultAlias, sess)
-		health.RegisterPeriodicFunc("DB operational", s.CheckHealth, time.Minute)
-		keyStore = s
-	case notary.MySQLBackend, notary.SQLiteBackend:
-		storeConfig, err := utils.ParseSQLStorage(configuration)
-		if err != nil {
-			return nil, err
-		}
-		defaultAlias, err := getDefaultAlias(configuration)
-		if err != nil {
-			return nil, err
-		}
-		dbStore, err := keydbstore.NewKeyDBStore(
-			passphraseRetriever, defaultAlias, storeConfig.Backend, storeConfig.Source)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create a new keydbstore: %v", err)
-		}
-
-		health.RegisterPeriodicFunc(
-			"DB operational", dbStore.HealthCheck, time.Minute)
-		keyStore = dbStore
-	}
-
-	if doBootstrap {
-		err := bootstrap(keyStore)
-		if err != nil {
-			logrus.Fatal(err.Error())
-		}
-		os.Exit(0)
-	}
-
-	cryptoService := cryptoservice.NewCryptoService(keyStore)
-	cryptoServices := make(signer.CryptoServiceIndex)
-	cryptoServices[data.ED25519Key] = cryptoService
-	cryptoServices[data.ECDSAKey] = cryptoService
-	return cryptoServices, nil
-}
-
-func getDefaultAlias(configuration *viper.Viper) (string, error) {
-	defaultAlias := configuration.GetString("storage.default_alias")
-	if defaultAlias == "" {
-		// backwards compatibility - support this environment variable
-		defaultAlias = configuration.GetString(defaultAliasEnv)
-	}
-
-	if defaultAlias == "" {
-		return "", fmt.Errorf("must provide a default alias for the key DB")
-	}
-	logrus.Debug("Default Alias: ", defaultAlias)
-	return defaultAlias, nil
 }
 
 // set up the GRPC server

--- a/cmd/notary-signer/main_test.go
+++ b/cmd/notary-signer/main_test.go
@@ -256,3 +256,27 @@ func TestBootstrap(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, tb.Booted)
 }
+
+func TestGetEnv(t *testing.T) {
+	os.Setenv("NOTARY_SIGNER_TIMESTAMP", "password")
+	defer os.Unsetenv("NOTARY_SIGNER_TIMESTAMP")
+
+	require.Equal(t, "password", getEnv("timestamp"))
+}
+
+func TestPassphraseRetrieverInvalid(t *testing.T) {
+	_, _, err := passphraseRetriever("fakeKey", "fakeAlias", false, 1)
+	require.Error(t, err)
+}
+
+// For sanity, make sure we can always parse the sample config
+func TestSampleConfig(t *testing.T) {
+	// We need to provide a default alias for the key DB.
+	//
+	// Generally it will be done during the building process
+	// if using signer.Dockerfile.
+	os.Setenv("NOTARY_SIGNER_DEFAULT_ALIAS", "timestamp_1")
+	defer os.Unsetenv("NOTARY_SIGNER_DEFAULT_ALIAS")
+	_, err := parseSignerConfig("../../fixtures/signer-config-local.json")
+	require.NoError(t, err)
+}

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -1,6 +1,8 @@
 package signer
 
 import (
+	"crypto/tls"
+
 	pb "github.com/docker/notary/proto"
 	"github.com/docker/notary/tuf/signed"
 )
@@ -32,4 +34,12 @@ type KeyManager interface {
 // Signer is the interface that allows the signing service to return signatures
 type Signer interface {
 	Sign(request *pb.SignatureRequest) (*pb.Signature, error)
+}
+
+// Config tells how to configure a notary-signer
+type Config struct {
+	HTTPAddr       string
+	GRPCAddr       string
+	TLSConfig      *tls.Config
+	CryptoServices CryptoServiceIndex
 }


### PR DESCRIPTION
Much prefer the architecture of `func main` of `server` to `signer` , which was changed by @cyli  , it's more simple and clear. 

In my option it's a nicer implementations that we pass the config to each component rather than use the global variable `mainViper`. That makes notary easier to run, to embed, to reuse and to test.

I think maybe we can do the same things on the `signer` side  just like what the `server` does.
