### PR TITLE
Key ID verification

### DIFF
--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -340,7 +340,12 @@ func testValidateRootRotationMissingOrigSig(t *testing.T, keyAlg, rootKeyType st
 
 	testRoot, err := data.NewRoot(
 		map[string]data.PublicKey{replRootKey.ID(): replRootKey},
-		map[string]*data.RootRole{data.CanonicalRootRole: &rootRole.RootRole},
+		map[string]*data.RootRole{
+			data.CanonicalRootRole:      &rootRole.RootRole,
+			data.CanonicalTargetsRole:   &rootRole.RootRole,
+			data.CanonicalSnapshotRole:  &rootRole.RootRole,
+			data.CanonicalTimestampRole: &rootRole.RootRole,
+		},
 		false,
 	)
 	require.NoError(t, err, "Failed to create new root")
@@ -399,7 +404,12 @@ func testValidateRootRotationMissingNewSig(t *testing.T, keyAlg, rootKeyType str
 
 	testRoot, err := data.NewRoot(
 		map[string]data.PublicKey{replRootKey.ID(): replRootKey},
-		map[string]*data.RootRole{data.CanonicalRootRole: &rootRole.RootRole},
+		map[string]*data.RootRole{
+			data.CanonicalRootRole:      &rootRole.RootRole,
+			data.CanonicalTargetsRole:   &rootRole.RootRole,
+			data.CanonicalSnapshotRole:  &rootRole.RootRole,
+			data.CanonicalTimestampRole: &rootRole.RootRole,
+		},
 		false,
 	)
 	require.NoError(t, err, "Failed to create new root")

--- a/tuf/signed/errors.go
+++ b/tuf/signed/errors.go
@@ -51,6 +51,13 @@ func (e ErrInvalidKeyType) Error() string {
 	return "key type is not valid for signature"
 }
 
+// ErrInvalidKeyID indicates the specified key ID was incorrect for its associated data
+type ErrInvalidKeyID struct{}
+
+func (e ErrInvalidKeyID) Error() string {
+	return "key ID is not valid for key content"
+}
+
 // ErrInvalidKeyLength indicates that while we may support the cipher, the provided
 // key length is not specifically supported, i.e. we support RSA, but not 1024 bit keys
 type ErrInvalidKeyLength struct {

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -127,7 +127,7 @@ func VerifySignatures(s *data.Signed, roleData data.BaseRole) error {
 		}
 		// Check that the signature key ID actually matches the content ID of the key
 		if key.ID() != sig.KeyID {
-			return ErrInvalidKeyType{}
+			return ErrInvalidKeyID{}
 		}
 		if err := VerifySignature(msg, sig, key); err != nil {
 			logrus.Debugf("continuing b/c %s", err.Error())

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -125,6 +125,10 @@ func VerifySignatures(s *data.Signed, roleData data.BaseRole) error {
 			logrus.Debugf("continuing b/c keyid lookup was nil: %s\n", sig.KeyID)
 			continue
 		}
+		// Check that the signature key ID actually matches the content ID of the key
+		if key.ID() != sig.KeyID {
+			return ErrInvalidKeyType{}
+		}
 		if err := VerifySignature(msg, sig, key); err != nil {
 			logrus.Debugf("continuing b/c %s", err.Error())
 			continue


### PR DESCRIPTION
Adds verification to `Verify` to ensure that the key ID being used to verify signatures is actually correct against its sha256 hash