### PR TITLE
Write to file to signal success for make integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x \
 	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
 	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
 	&& curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
-	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
+	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh > /dev/null
 ENV PATH /osxcross/target/bin:$PATH
 
 ENV NOTARYDIR /go/src/github.com/docker/notary

--- a/buildscripts/integrationtest.sh
+++ b/buildscripts/integrationtest.sh
@@ -10,7 +10,12 @@ function cleanup {
 
 function cleanupAndExit {
     cleanup
-    rm /test_output/SUCCESS
+    # Check for existence of SUCCESS
+    ls test_output/SUCCESS
+    exitCode=$?
+    # Clean up test_output dir and exit
+    rm -rf test_output
+    exit $exitCode
 }
 
 if [[ -z "${CIRCLECI}" ]]; then

--- a/buildscripts/integrationtest.sh
+++ b/buildscripts/integrationtest.sh
@@ -13,8 +13,10 @@ function cleanupAndExit {
     # Check for existence of SUCCESS
     ls test_output/SUCCESS
     exitCode=$?
-    # Clean up test_output dir and exit
-    rm -rf test_output
+    # Clean up test_output dir (if not in CircleCI) and exit
+    if [[ -z "${CIRCLECI}" ]]; then
+        rm -rf test_output
+    fi
     exit $exitCode
 }
 

--- a/buildscripts/integrationtest.sh
+++ b/buildscripts/integrationtest.sh
@@ -8,6 +8,11 @@ function cleanup {
 	fi
 }
 
+function cleanupAndExit {
+    cleanup
+    rm /test_output/SUCCESS
+}
+
 if [[ -z "${CIRCLECI}" ]]; then
 	BUILDOPTS="--force-rm"
 fi
@@ -17,7 +22,8 @@ set -x
 
 cleanup
 
+docker-compose -f development.yml config
 docker-compose -f development.yml build ${BUILDOPTS} --pull | tee
 docker-compose -f development.yml up --abort-on-container-exit
 
-trap cleanup SIGINT SIGTERM EXIT
+trap cleanupAndExit SIGINT SIGTERM EXIT

--- a/buildscripts/testclient.sh
+++ b/buildscripts/testclient.sh
@@ -44,4 +44,4 @@ bin/notary ${OPTS} delegation add ${REPONAME} targets/releases fixtures/secure.e
 bin/notary ${OPTS} add ${REPONAME} readmetarget README.md
 bin/notary ${OPTS} publish ${REPONAME}
 bin/notary ${OPTS} delegation list ${REPONAME} | grep targets/releases
-cat README.md | bin/notary ${OPTS} verify $REPONAME readmetarget > /dev/null
+cat README.md | bin/notary ${OPTS} verify $REPONAME readmetarget > /test_output/SUCCESS

--- a/buildscripts/testclient.sh
+++ b/buildscripts/testclient.sh
@@ -45,3 +45,6 @@ bin/notary ${OPTS} add ${REPONAME} readmetarget README.md
 bin/notary ${OPTS} publish ${REPONAME}
 bin/notary ${OPTS} delegation list ${REPONAME} | grep targets/releases
 cat README.md | bin/notary ${OPTS} verify $REPONAME readmetarget > /test_output/SUCCESS
+
+# Make this file accessible for CI
+chmod 777 /test_output/SUCCESS

--- a/development.yml
+++ b/development.yml
@@ -27,6 +27,8 @@ mysql:
     - MYSQL_ALLOW_EMPTY_PASSWORD="true"
   command: mysqld --innodb_file_per_table
 client:
+  volumes:
+    - ./test_output:/test_output
   build: .
   dockerfile: Dockerfile
   links:


### PR DESCRIPTION
Ensures that we actually fail when one of the containers in the integration test aborts, since docker-compose may return a 0 exit code when aborting containers.

Relies on https://github.com/docker/notary/pull/674 to be green

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>