### PR TITLE
@mtrmac's cleanups, split from root/cert rotation feature

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -142,8 +142,9 @@ func ValidateRoot(certStore trustmanager.X509Store, root *data.Signed, gun strin
 	return nil
 }
 
-// validRootLeafCerts returns a list of non-exipired, non-sha1 certificates whose
-// Common-Names match the provided GUN
+// validRootLeafCerts returns a list of non-expired, non-sha1 certificates
+// found in root whoose Common-Names match the provided GUN. Note that this
+// "validity" alone does not imply any measure of trust.
 func validRootLeafCerts(root *data.SignedRoot, gun string) ([]*x509.Certificate, error) {
 	// Get a list of all of the leaf certificates present in root
 	allLeafCerts, _ := parseAllCerts(root)

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -55,7 +55,8 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts := []*x509.Certificate{cert1}
 	newCerts := []*x509.Certificate{cert2}
 
-	certificates := certsToRemove(oldCerts, newCerts)
+	certificates, err := certsToRemove(oldCerts, newCerts)
+	require.NoError(t, err)
 	require.Len(t, certificates, 1)
 	_, ok := certificates[cert1KeyID]
 	require.True(t, ok)
@@ -64,7 +65,8 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts = []*x509.Certificate{cert1, cert2}
 	newCerts = []*x509.Certificate{cert3}
 
-	certificates = certsToRemove(oldCerts, newCerts)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	require.NoError(t, err)
 	require.Len(t, certificates, 2)
 	_, ok = certificates[cert1KeyID]
 	require.True(t, ok)
@@ -77,7 +79,8 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts = []*x509.Certificate{cert3}
 	newCerts = []*x509.Certificate{cert2, cert1}
 
-	certificates = certsToRemove(oldCerts, newCerts)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	require.NoError(t, err)
 	require.Len(t, certificates, 1)
 	_, ok = certificates[cert3KeyID]
 	require.True(t, ok)
@@ -90,20 +93,15 @@ func TestCertsToRemove(t *testing.T) {
 	oldCerts = []*x509.Certificate{cert1, cert2, cert3}
 	newCerts = []*x509.Certificate{}
 
-	certificates = certsToRemove(oldCerts, newCerts)
-	require.Len(t, certificates, 0)
-	_, ok = certificates[cert1KeyID]
-	require.False(t, ok)
-	_, ok = certificates[cert2KeyID]
-	require.False(t, ok)
-	_, ok = certificates[cert3KeyID]
-	require.False(t, ok)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	require.Error(t, err)
 
 	// Call CertsToRemove with three new certificates and no old
 	oldCerts = []*x509.Certificate{}
 	newCerts = []*x509.Certificate{cert1, cert2, cert3}
 
-	certificates = certsToRemove(oldCerts, newCerts)
+	certificates, err = certsToRemove(oldCerts, newCerts)
+	require.NoError(t, err)
 	require.Len(t, certificates, 0)
 	_, ok = certificates[cert1KeyID]
 	require.False(t, ok)

--- a/cryptoservice/crypto_service_test.go
+++ b/cryptoservice/crypto_service_test.go
@@ -97,7 +97,7 @@ func (c CryptoServiceTester) TestGetNonexistentKey(t *testing.T) {
 	_, _, err := cryptoService.GetPrivateKey("boguskeyid")
 	require.Error(t, err)
 	// The underlying error has been correctly propagated.
-	_, ok := err.(*trustmanager.ErrKeyNotFound)
+	_, ok := err.(trustmanager.ErrKeyNotFound)
 	require.True(t, ok)
 }
 

--- a/signer/keydbstore/keydbstore.go
+++ b/signer/keydbstore/keydbstore.go
@@ -117,7 +117,7 @@ func (s *KeyDBStore) GetKey(name string) (data.PrivateKey, string, error) {
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return nil, "", trustmanager.ErrKeyNotFound{}
+		return nil, "", trustmanager.ErrKeyNotFound{KeyID: name}
 	}
 
 	// Get the passphrase to use for this key
@@ -165,7 +165,7 @@ func (s *KeyDBStore) RemoveKey(keyID string) error {
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: keyID}).First(&dbPrivateKey).RecordNotFound() {
-		return trustmanager.ErrKeyNotFound{}
+		return trustmanager.ErrKeyNotFound{KeyID: keyID}
 	}
 
 	// Delete the key from the database
@@ -179,7 +179,7 @@ func (s *KeyDBStore) RotateKeyPassphrase(name, newPassphraseAlias string) error 
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
 	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return trustmanager.ErrKeyNotFound{}
+		return trustmanager.ErrKeyNotFound{KeyID: name}
 	}
 
 	// Get the current passphrase to use for this key

--- a/trustmanager/keyfilestore.go
+++ b/trustmanager/keyfilestore.go
@@ -361,7 +361,7 @@ func getKeyRole(s LimitedFileStore, keyID string) (string, bool, error) {
 		}
 	}
 
-	return "", false, &ErrKeyNotFound{KeyID: keyID}
+	return "", false, ErrKeyNotFound{KeyID: keyID}
 }
 
 // GetKey returns the PrivateKey given a KeyID

--- a/trustmanager/keystore.go
+++ b/trustmanager/keystore.go
@@ -43,6 +43,8 @@ type KeyStore interface {
 	// AddKey adds a key to the KeyStore, and if the key already exists,
 	// succeeds.  Otherwise, returns an error if it cannot add.
 	AddKey(keyInfo KeyInfo, privKey data.PrivateKey) error
+	// Should fail with ErrKeyNotFound if the keystore is operating normally
+	// and knows that it does not store the requested key.
 	GetKey(keyID string) (data.PrivateKey, string, error)
 	GetKeyInfo(keyID string) (KeyInfo, error)
 	ListKeys() map[string]KeyInfo

--- a/trustmanager/yubikey/yubikeystore.go
+++ b/trustmanager/yubikey/yubikeystore.go
@@ -812,15 +812,7 @@ func SetupHSMEnv(libraryPath string, libLoader pkcs11LibLoader) (
 
 	if err := p.Initialize(); err != nil {
 		defer finalizeAndDestroy(p)
-		// Sadly, if ykcs11's C_Initialize fails at all, it is likely with this
-		// error code; but because it is only discovering the slots and not interacting
-		// with individual tokens, assume that this is not a Yubikey failure, simply
-		// no slots are present.
-		message := fmt.Sprintf("found library %s, but initialize error %s", libraryPath, err.Error())
-		if err, ok := err.(pkcs11.Error); ok && err == pkcs11.CKR_FUNCTION_FAILED {
-			return nil, 0, errHSMNotPresent{err: message}
-		}
-		return nil, 0, errors.New(message)
+		return nil, 0, fmt.Errorf("found library %s, but initialize error %s", libraryPath, err.Error())
 	}
 
 	slots, err := p.GetSlotList(true)


### PR DESCRIPTION
@mtrmac fully implemented root cert (public key) rotations, which in #648 was changed to be a full root rotation as per group code review results.

Some of the cleanups are not as relevant to that feature anymore, but are still really nice, so to try to reduce the size of #648 and make it a little smaller, this PR contains some of the cleanups from that PR.