### PR TITLE
fix "make lint" to lint every file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ fmt:
 
 lint:
 	@echo "+ $@"
-	@test -z "$$(golint -tags "${NOTARY_BUILDTAGS}" ./... | grep -v .pb. | grep -v vendor/ | tee /dev/stderr)"
+	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)"
 
 # Requires that the following:
 # go get -u github.com/client9/misspell/cmd/misspell

--- a/client/client_pkcs11_test.go
+++ b/client/client_pkcs11_test.go
@@ -7,10 +7,10 @@ import "github.com/docker/notary/trustmanager/yubikey"
 // clear out all keys
 func init() {
 	yubikey.SetYubikeyKeyMode(0)
-	if !yubikey.YubikeyAccessible() {
+	if !yubikey.IsAccessible() {
 		return
 	}
-	store, err := yubikey.NewYubiKeyStore(nil, nil)
+	store, err := yubikey.NewYubiStore(nil, nil)
 	if err == nil {
 		for k := range store.ListKeys() {
 			store.RemoveKey(k)

--- a/client/repo_pkcs11.go
+++ b/client/repo_pkcs11.go
@@ -24,7 +24,7 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 	}
 
 	keyStores := []trustmanager.KeyStore{fileKeyStore}
-	yubiKeyStore, _ := yubikey.NewYubiKeyStore(fileKeyStore, retriever)
+	yubiKeyStore, _ := yubikey.NewYubiStore(fileKeyStore, retriever)
 	if yubiKeyStore != nil {
 		keyStores = []trustmanager.KeyStore{yubiKeyStore, fileKeyStore}
 	}

--- a/cmd/notary/integration_pkcs11_test.go
+++ b/cmd/notary/integration_pkcs11_test.go
@@ -26,7 +26,7 @@ func init() {
 	}
 
 	// best effort at removing keys here, so nil is fine
-	s, err := yubikey.NewYubiKeyStore(nil, _retriever)
+	s, err := yubikey.NewYubiStore(nil, _retriever)
 	if err != nil {
 		for k := range s.ListKeys() {
 			s.RemoveKey(k)
@@ -41,12 +41,12 @@ func init() {
 	}
 }
 
-var rootOnHardware = yubikey.YubikeyAccessible
+var rootOnHardware = yubikey.IsAccessible
 
 // Per-test set up deletes all keys on the yubikey
 func setUp(t *testing.T) {
 	//we're just removing keys here, so nil is fine
-	s, err := yubikey.NewYubiKeyStore(nil, _retriever)
+	s, err := yubikey.NewYubiStore(nil, _retriever)
 	require.NoError(t, err)
 	for k := range s.ListKeys() {
 		err := s.RemoveKey(k)
@@ -59,9 +59,9 @@ func setUp(t *testing.T) {
 // on disk
 func verifyRootKeyOnHardware(t *testing.T, rootKeyID string) {
 	// do not bother verifying if there is no yubikey available
-	if yubikey.YubikeyAccessible() {
+	if yubikey.IsAccessible() {
 		// //we're just getting keys here, so nil is fine
-		s, err := yubikey.NewYubiKeyStore(nil, _retriever)
+		s, err := yubikey.NewYubiStore(nil, _retriever)
 		require.NoError(t, err)
 		privKey, role, err := s.GetKey(rootKeyID)
 		require.NoError(t, err)

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -571,7 +571,7 @@ func (k *keyCommander) keyPassphraseChange(cmd *cobra.Command, args []string) er
 	var addingKeyStore trustmanager.KeyStore
 	switch foundKeyStore.Name() {
 	case "yubikey":
-		addingKeyStore, err = getYubiKeyStore(nil, passChangeRetriever)
+		addingKeyStore, err = getYubiStore(nil, passChangeRetriever)
 		keyInfo = trustmanager.KeyInfo{Role: data.CanonicalRootRole}
 	default:
 		addingKeyStore, err = trustmanager.NewKeyFileStore(config.GetString("trust_dir"), passChangeRetriever)
@@ -609,9 +609,9 @@ func (k *keyCommander) getKeyStores(
 	if withHardware {
 		var yubiStore trustmanager.KeyStore
 		if hardwareBackup {
-			yubiStore, err = getYubiKeyStore(fileKeyStore, retriever)
+			yubiStore, err = getYubiStore(fileKeyStore, retriever)
 		} else {
-			yubiStore, err = getYubiKeyStore(nil, retriever)
+			yubiStore, err = getYubiStore(nil, retriever)
 		}
 		if err == nil && yubiStore != nil {
 			// Note that the order is important, since we want to prioritize

--- a/cmd/notary/keys_nonpkcs11.go
+++ b/cmd/notary/keys_nonpkcs11.go
@@ -9,6 +9,6 @@ import (
 	"github.com/docker/notary/trustmanager"
 )
 
-func getYubiKeyStore(fileKeyStore trustmanager.KeyStore, ret passphrase.Retriever) (trustmanager.KeyStore, error) {
+func getYubiStore(fileKeyStore trustmanager.KeyStore, ret passphrase.Retriever) (trustmanager.KeyStore, error) {
 	return nil, errors.New("Not built with hardware support")
 }

--- a/cmd/notary/keys_pkcs11.go
+++ b/cmd/notary/keys_pkcs11.go
@@ -8,6 +8,6 @@ import (
 	"github.com/docker/notary/trustmanager/yubikey"
 )
 
-func getYubiKeyStore(fileKeyStore trustmanager.KeyStore, ret passphrase.Retriever) (trustmanager.KeyStore, error) {
-	return yubikey.NewYubiKeyStore(fileKeyStore, ret)
+func getYubiStore(fileKeyStore trustmanager.KeyStore, ret passphrase.Retriever) (trustmanager.KeyStore, error) {
+	return yubikey.NewYubiStore(fileKeyStore, ret)
 }

--- a/signer/api/api_test.go
+++ b/signer/api/api_test.go
@@ -46,8 +46,8 @@ func TestDeleteKeyHandlerReturns404WithNonexistentKey(t *testing.T) {
 	fakeID := "c62e6d68851cef1f7e55a9d56e3b0c05f3359f16838cad43600f0554e7d3b54d"
 
 	keyID := &pb.KeyID{ID: fakeID}
-	requestJson, _ := json.Marshal(keyID)
-	reader = strings.NewReader(string(requestJson))
+	requestJSON, _ := json.Marshal(keyID)
+	reader = strings.NewReader(string(requestJSON))
 
 	request, err := http.NewRequest("POST", deleteKeyBaseURL, reader)
 	require.Nil(t, err)
@@ -66,8 +66,8 @@ func TestDeleteKeyHandler(t *testing.T) {
 	tufKey, _ := cryptoService.Create("", "", data.ED25519Key)
 	require.NotNil(t, tufKey)
 
-	requestJson, _ := json.Marshal(&pb.KeyID{ID: tufKey.ID()})
-	reader = strings.NewReader(string(requestJson))
+	requestJSON, _ := json.Marshal(&pb.KeyID{ID: tufKey.ID()})
+	reader = strings.NewReader(string(requestJSON))
 
 	request, err := http.NewRequest("POST", deleteKeyBaseURL, reader)
 	require.Nil(t, err)
@@ -156,9 +156,9 @@ func TestSoftwareSignHandler(t *testing.T) {
 	require.Nil(t, err)
 
 	sigRequest := &pb.SignatureRequest{KeyID: &pb.KeyID{ID: tufKey.ID()}, Content: make([]byte, 10)}
-	requestJson, _ := json.Marshal(sigRequest)
+	requestJSON, _ := json.Marshal(sigRequest)
 
-	reader = strings.NewReader(string(requestJson))
+	reader = strings.NewReader(string(requestJSON))
 
 	request, err := http.NewRequest("POST", signBaseURL, reader)
 
@@ -184,8 +184,8 @@ func TestSoftwareSignWithInvalidRequestHandler(t *testing.T) {
 	cryptoService := cryptoservice.NewCryptoService(keyStore)
 	setup(signer.CryptoServiceIndex{data.ED25519Key: cryptoService, data.RSAKey: cryptoService, data.ECDSAKey: cryptoService})
 
-	requestJson := "{\"blob\":\"7d16f1d0b95310a7bc557747fc4f20fcd41c1c5095ae42f189df0717e7d7f4a0a2b55debce630f43c4ac099769c612965e3fda3cd4c0078ee6a460f14fa19307\"}"
-	reader = strings.NewReader(requestJson)
+	requestJSON := "{\"blob\":\"7d16f1d0b95310a7bc557747fc4f20fcd41c1c5095ae42f189df0717e7d7f4a0a2b55debce630f43c4ac099769c612965e3fda3cd4c0078ee6a460f14fa19307\"}"
+	reader = strings.NewReader(requestJSON)
 
 	request, err := http.NewRequest("POST", signBaseURL, reader)
 
@@ -213,9 +213,9 @@ func TestSignHandlerReturns404WithNonexistentKey(t *testing.T) {
 	cryptoService.Create("", "", data.ED25519Key)
 
 	sigRequest := &pb.SignatureRequest{KeyID: &pb.KeyID{ID: fakeID}, Content: make([]byte, 10)}
-	requestJson, _ := json.Marshal(sigRequest)
+	requestJSON, _ := json.Marshal(sigRequest)
 
-	reader = strings.NewReader(string(requestJson))
+	reader = strings.NewReader(string(requestJSON))
 
 	request, err := http.NewRequest("POST", signBaseURL, reader)
 	require.Nil(t, err)

--- a/signer/keydbstore/keydbstore.go
+++ b/signer/keydbstore/keydbstore.go
@@ -106,18 +106,18 @@ func (s *KeyDBStore) AddKey(keyInfo trustmanager.KeyInfo, privKey data.PrivateKe
 }
 
 // GetKey returns the PrivateKey given a KeyID
-func (s *KeyDBStore) GetKey(name string) (data.PrivateKey, string, error) {
+func (s *KeyDBStore) GetKey(keyID string) (data.PrivateKey, string, error) {
 	s.Lock()
 	defer s.Unlock()
-	cachedKeyEntry, ok := s.cachedKeys[name]
+	cachedKeyEntry, ok := s.cachedKeys[keyID]
 	if ok {
 		return cachedKeyEntry, "", nil
 	}
 
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
-	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return nil, "", trustmanager.ErrKeyNotFound{KeyID: name}
+	if s.db.Where(&GormPrivateKey{KeyID: keyID}).First(&dbPrivateKey).RecordNotFound() {
+		return nil, "", trustmanager.ErrKeyNotFound{KeyID: keyID}
 	}
 
 	// Get the passphrase to use for this key
@@ -146,7 +146,7 @@ func (s *KeyDBStore) GetKey(name string) (data.PrivateKey, string, error) {
 }
 
 // GetKeyInfo returns the PrivateKey's role and gun in a KeyInfo given a KeyID
-func (s *KeyDBStore) GetKeyInfo(name string) (trustmanager.KeyInfo, error) {
+func (s *KeyDBStore) GetKeyInfo(keyID string) (trustmanager.KeyInfo, error) {
 	return trustmanager.KeyInfo{}, fmt.Errorf("GetKeyInfo currently not supported for KeyDBStore, as it does not track roles or GUNs")
 }
 
@@ -175,11 +175,11 @@ func (s *KeyDBStore) RemoveKey(keyID string) error {
 }
 
 // RotateKeyPassphrase rotates the key-encryption-key
-func (s *KeyDBStore) RotateKeyPassphrase(name, newPassphraseAlias string) error {
+func (s *KeyDBStore) RotateKeyPassphrase(keyID, newPassphraseAlias string) error {
 	// Retrieve the GORM private key from the database
 	dbPrivateKey := GormPrivateKey{}
-	if s.db.Where(&GormPrivateKey{KeyID: name}).First(&dbPrivateKey).RecordNotFound() {
-		return trustmanager.ErrKeyNotFound{KeyID: name}
+	if s.db.Where(&GormPrivateKey{KeyID: keyID}).First(&dbPrivateKey).RecordNotFound() {
+		return trustmanager.ErrKeyNotFound{KeyID: keyID}
 	}
 
 	// Get the current passphrase to use for this key

--- a/trustmanager/yubikey/yubikeystore.go
+++ b/trustmanager/yubikey/yubikeystore.go
@@ -25,14 +25,22 @@ import (
 )
 
 const (
-	USER_PIN    = "123456"
-	SO_USER_PIN = "010203040506070801020304050607080102030405060708"
-	numSlots    = 4 // number of slots in the yubikey
+	// UserPin is the user pin of a yubikey (in PIV parlance, is the PIN)
+	UserPin = "123456"
+	// SOUserPin is the "Security Officer" user pin - this is the PIV management
+	// (MGM) key, which is different than the admin pin of the Yubikey PGP interface
+	// (which in PIV parlance is the PUK, and defaults to 12345678)
+	SOUserPin = "010203040506070801020304050607080102030405060708"
+	numSlots  = 4 // number of slots in the yubikey
 
-	KeymodeNone      = 0
-	KeymodeTouch     = 1 // touch enabled
-	KeymodePinOnce   = 2 // require pin entry once
-	KeymodePinAlways = 4 // require pin entry all the time
+	// KeymodeNone means that no touch or PIN is required to sign with the yubikey
+	KeymodeNone = 0
+	// KeymodeTouch means that only touch is required to sign with the yubikey
+	KeymodeTouch = 1
+	// KeymodePinOnce means that the pin entry is required once the first time to sign with the yubikey
+	KeymodePinOnce = 2
+	// KeymodePinAlways means that pin entry is required every time to sign with the yubikey
+	KeymodePinAlways = 4
 
 	// the key size, when importing a key into yubikey, MUST be 32 bytes
 	ecdsaPrivateKeySize = 32
@@ -95,6 +103,8 @@ func init() {
 	}
 }
 
+// ErrBackupFailed is returned when a YubiStore fails to back up a key that
+// is added
 type ErrBackupFailed struct {
 	err string
 }
@@ -127,10 +137,13 @@ type YubiPrivateKey struct {
 	libLoader     pkcs11LibLoader
 }
 
-type YubikeySigner struct {
+// YubiKeySigner wraps a YubiPrivateKey and implements the crypto.Signer interface
+type yubikeySigner struct {
 	YubiPrivateKey
 }
 
+// NewYubiPrivateKey returns a YubiPrivateKey, which implements the data.PrivateKey
+// interface except that the private material is inacessible
 func NewYubiPrivateKey(slot []byte, pubKey data.ECDSAPublicKey,
 	passRetriever passphrase.Retriever) *YubiPrivateKey {
 
@@ -142,7 +155,8 @@ func NewYubiPrivateKey(slot []byte, pubKey data.ECDSAPublicKey,
 	}
 }
 
-func (ys *YubikeySigner) Public() crypto.PublicKey {
+// Public is a required method of the crypto.Signer interface
+func (ys *yubikeySigner) Public() crypto.PublicKey {
 	publicKey, err := x509.ParsePKIXPublicKey(ys.YubiPrivateKey.Public())
 	if err != nil {
 		return nil
@@ -158,7 +172,7 @@ func (y *YubiPrivateKey) setLibLoader(loader pkcs11LibLoader) {
 // CryptoSigner returns a crypto.Signer tha wraps the YubiPrivateKey. Needed for
 // Certificate generation only
 func (y *YubiPrivateKey) CryptoSigner() crypto.Signer {
-	return &YubikeySigner{YubiPrivateKey: *y}
+	return &yubikeySigner{YubiPrivateKey: *y}
 }
 
 // Private is not implemented in hardware  keys
@@ -168,10 +182,14 @@ func (y *YubiPrivateKey) Private() []byte {
 	return nil
 }
 
+// SignatureAlgorithm returns which algorithm this key uses to sign - currently
+// hardcoded to ECDSA
 func (y YubiPrivateKey) SignatureAlgorithm() data.SigAlgorithm {
 	return data.ECDSASignature
 }
 
+// Sign is a required method of the crypto.Signer interface and the data.PrivateKey
+// interface
 func (y *YubiPrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) ([]byte, error) {
 	ctx, session, err := SetupHSMEnv(pkcs11Lib, y.libLoader)
 	if err != nil {
@@ -215,7 +233,7 @@ func addECDSAKey(
 ) error {
 	logrus.Debugf("Attempting to add key to yubikey with ID: %s", privKey.ID())
 
-	err := login(ctx, session, passRetriever, pkcs11.CKU_SO, SO_USER_PIN)
+	err := login(ctx, session, passRetriever, pkcs11.CKU_SO, SOUserPin)
 	if err != nil {
 		return err
 	}
@@ -328,7 +346,7 @@ func getECDSAKey(ctx IPKCS11Ctx, session pkcs11.SessionHandle, pkcs11KeyID []byt
 
 // Sign returns a signature for a given signature request
 func sign(ctx IPKCS11Ctx, session pkcs11.SessionHandle, pkcs11KeyID []byte, passRetriever passphrase.Retriever, payload []byte) ([]byte, error) {
-	err := login(ctx, session, passRetriever, pkcs11.CKU_USER, USER_PIN)
+	err := login(ctx, session, passRetriever, pkcs11.CKU_USER, UserPin)
 	if err != nil {
 		return nil, fmt.Errorf("error logging in: %v", err)
 	}
@@ -387,7 +405,7 @@ func sign(ctx IPKCS11Ctx, session pkcs11.SessionHandle, pkcs11KeyID []byte, pass
 }
 
 func yubiRemoveKey(ctx IPKCS11Ctx, session pkcs11.SessionHandle, pkcs11KeyID []byte, passRetriever passphrase.Retriever, keyID string) error {
-	err := login(ctx, session, passRetriever, pkcs11.CKU_SO, SO_USER_PIN)
+	err := login(ctx, session, passRetriever, pkcs11.CKU_SO, SOUserPin)
 	if err != nil {
 		return err
 	}
@@ -595,20 +613,20 @@ func getNextEmptySlot(ctx IPKCS11Ctx, session pkcs11.SessionHandle) ([]byte, err
 	return nil, errors.New("Yubikey has no available slots.")
 }
 
-// YubiKeyStore is a KeyStore for private keys inside a Yubikey
-type YubiKeyStore struct {
+// YubiStore is a KeyStore for private keys inside a Yubikey
+type YubiStore struct {
 	passRetriever passphrase.Retriever
 	keys          map[string]yubiSlot
 	backupStore   trustmanager.KeyStore
 	libLoader     pkcs11LibLoader
 }
 
-// NewYubiKeyStore returns a YubiKeyStore, given a backup key store to write any
+// NewYubiStore returns a YubiStore, given a backup key store to write any
 // generated keys to (usually a KeyFileStore)
-func NewYubiKeyStore(backupStore trustmanager.KeyStore, passphraseRetriever passphrase.Retriever) (
-	*YubiKeyStore, error) {
+func NewYubiStore(backupStore trustmanager.KeyStore, passphraseRetriever passphrase.Retriever) (
+	*YubiStore, error) {
 
-	s := &YubiKeyStore{
+	s := &YubiStore{
 		passRetriever: passphraseRetriever,
 		keys:          make(map[string]yubiSlot),
 		backupStore:   backupStore,
@@ -620,15 +638,16 @@ func NewYubiKeyStore(backupStore trustmanager.KeyStore, passphraseRetriever pass
 
 // Name returns a user friendly name for the location this store
 // keeps its data
-func (s YubiKeyStore) Name() string {
+func (s YubiStore) Name() string {
 	return "yubikey"
 }
 
-func (s *YubiKeyStore) setLibLoader(loader pkcs11LibLoader) {
+func (s *YubiStore) setLibLoader(loader pkcs11LibLoader) {
 	s.libLoader = loader
 }
 
-func (s *YubiKeyStore) ListKeys() map[string]trustmanager.KeyInfo {
+// ListKeys returns a list of keys in the yubikey store
+func (s *YubiStore) ListKeys() map[string]trustmanager.KeyInfo {
 	if len(s.keys) > 0 {
 		return buildKeyMap(s.keys)
 	}
@@ -650,7 +669,7 @@ func (s *YubiKeyStore) ListKeys() map[string]trustmanager.KeyInfo {
 }
 
 // AddKey puts a key inside the Yubikey, as well as writing it to the backup store
-func (s *YubiKeyStore) AddKey(keyInfo trustmanager.KeyInfo, privKey data.PrivateKey) error {
+func (s *YubiStore) AddKey(keyInfo trustmanager.KeyInfo, privKey data.PrivateKey) error {
 	added, err := s.addKey(privKey.ID(), keyInfo.Role, privKey)
 	if err != nil {
 		return err
@@ -667,7 +686,7 @@ func (s *YubiKeyStore) AddKey(keyInfo trustmanager.KeyInfo, privKey data.Private
 
 // Only add if we haven't seen the key already.  Return whether the key was
 // added.
-func (s *YubiKeyStore) addKey(keyID, role string, privKey data.PrivateKey) (
+func (s *YubiStore) addKey(keyID, role string, privKey data.PrivateKey) (
 	bool, error) {
 
 	// We only allow adding root keys for now
@@ -713,7 +732,7 @@ func (s *YubiKeyStore) addKey(keyID, role string, privKey data.PrivateKey) (
 
 // GetKey retrieves a key from the Yubikey only (it does not look inside the
 // backup store)
-func (s *YubiKeyStore) GetKey(keyID string) (data.PrivateKey, string, error) {
+func (s *YubiStore) GetKey(keyID string) (data.PrivateKey, string, error) {
 	ctx, session, err := SetupHSMEnv(pkcs11Lib, s.libLoader)
 	if err != nil {
 		logrus.Debugf("Failed to initialize PKCS11 environment: %s", err.Error())
@@ -748,7 +767,7 @@ func (s *YubiKeyStore) GetKey(keyID string) (data.PrivateKey, string, error) {
 
 // RemoveKey deletes a key from the Yubikey only (it does not remove it from the
 // backup store)
-func (s *YubiKeyStore) RemoveKey(keyID string) error {
+func (s *YubiStore) RemoveKey(keyID string) error {
 	ctx, session, err := SetupHSMEnv(pkcs11Lib, s.libLoader)
 	if err != nil {
 		logrus.Debugf("Failed to initialize PKCS11 environment: %s", err.Error())
@@ -771,13 +790,13 @@ func (s *YubiKeyStore) RemoveKey(keyID string) error {
 }
 
 // ExportKey doesn't work, because you can't export data from a Yubikey
-func (s *YubiKeyStore) ExportKey(keyID string) ([]byte, error) {
-	logrus.Debugf("Attempting to export: %s key inside of YubiKeyStore", keyID)
+func (s *YubiStore) ExportKey(keyID string) ([]byte, error) {
+	logrus.Debugf("Attempting to export: %s key inside of YubiStore", keyID)
 	return nil, errors.New("Keys cannot be exported from a Yubikey.")
 }
 
-// Not yet implemented
-func (s *YubiKeyStore) GetKeyInfo(keyID string) (trustmanager.KeyInfo, error) {
+// GetKeyInfo is not yet implemented
+func (s *YubiStore) GetKeyInfo(keyID string) (trustmanager.KeyInfo, error) {
 	return trustmanager.KeyInfo{}, fmt.Errorf("Not yet implemented")
 }
 
@@ -802,7 +821,7 @@ func SetupHSMEnv(libraryPath string, libLoader pkcs11LibLoader) (
 	IPKCS11Ctx, pkcs11.SessionHandle, error) {
 
 	if libraryPath == "" {
-		return nil, 0, errHSMNotPresent{err: "no library found."}
+		return nil, 0, errHSMNotPresent{err: "no library found"}
 	}
 	p := libLoader(libraryPath)
 
@@ -842,8 +861,8 @@ func SetupHSMEnv(libraryPath string, libLoader pkcs11LibLoader) (
 	return p, session, nil
 }
 
-// YubikeyAccessible returns true if a Yubikey can be accessed
-func YubikeyAccessible() bool {
+// IsAccessible returns true if a Yubikey can be accessed
+func IsAccessible() bool {
 	if pkcs11Lib == "" {
 		return false
 	}


### PR DESCRIPTION
`golint ./...` ignores buildtags and somehow didn't pick up some code in the signer.

This calls golint on every go file in the repo and also fixes some linting
issues, which involves renaming two yubikey functions to avoid stuttering.
