### PR TITLE
Add note about versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Any security vulnerabilities can be reported to security@docker.com.
 # Getting started with the Notary CLI
 
 Please get the Notary Client CLI binary from [the official releases page](https://github.com/docker/notary/releases) or you can [build one yourself](#building-notary).
-The version of Notary server and signer should be greater than or equal to Notary CLI's version to ensure feature compatibility, and all official releases are associated with GitHub tags.
+The version of Notary server and signer should be greater than or equal to Notary CLI's version to ensure feature compatibility (ex: CLI version 0.2, server/signer version >= 0.2), and all official releases are associated with GitHub tags.
 
 To use the Notary CLI with Docker hub images, please have a look at our
 [getting started docs](docs/getting_started.md).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Any security vulnerabilities can be reported to security@docker.com.
 # Getting started with the Notary CLI
 
 Please get the Notary Client CLI binary from [the official releases page](https://github.com/docker/notary/releases) or you can [build one yourself](#building-notary).
+The version of Notary server and signer should be greater than or equal to Notary CLI's version to ensure feature compatibility, and all official releases are associated with GitHub tags.
 
 To use the Notary CLI with Docker hub images, please have a look at our
 [getting started docs](docs/getting_started.md).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -66,7 +66,7 @@ tell the client which repository server it should communicate with.
 The official Docker Hub Notary servers are located at
 `https://notary.docker.io`. If you would like to use your own Notary server,
 it is important to use the same or a newer <a href="https://github.com/docker/notary/releases">Notary version</a>
-as the client for feature compatibility.
+as the client for feature compatibility (ex: client version 0.2, server/signer version >= 0.2).
 Additionally, Notary stores your own signing keys,
 and a cache of previously downloaded trust metadata in a directory, provided
 with the `-d` flag. When interacting with Docker Hub repositories, you must

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,7 +64,10 @@ are located. So, you must provide the `-s` (or long form `--server`) flag to
 tell the client which repository server it should communicate with.
 
 The official Docker Hub Notary servers are located at
-`https://notary.docker.io`. Additionally, Notary stores your own signing keys,
+`https://notary.docker.io`. If you would like to use your own Notary server,
+it is important to use the same or a newer <a href="https://github.com/docker/notary/releases">Notary version</a>
+as the client for feature compatibility.
+Additionally, Notary stores your own signing keys,
 and a cache of previously downloaded trust metadata in a directory, provided
 with the `-d` flag. When interacting with Docker Hub repositories, you must
 instruct the client to use the associated trust directory, which by default is

--- a/docs/running_a_service.md
+++ b/docs/running_a_service.md
@@ -48,7 +48,8 @@ $ openssl s_client -connect <docker host>:4443 -CAfile fixtures/root-ca.crt -no_
 ```
 
 To connect using the Notary Client CLI, please see [Getting Started](getting_started.md)
-documentation.
+documentation. Please note that the version of Notary server and signer
+should be greater than or equal to that of the Notary Client CLI to ensure feature compatibility.
 
 The self-signed certificate's subject name and subject alternative names are
 `notary-server`, `notaryserver`, and `localhost`, so if your Docker host is not
@@ -225,7 +226,7 @@ look like the below diagram:
 ![Notary server Deployment Diagram](images/service-deployment.svg)
 
 In the diagram, a load balancer routes external traffic to a cluster of Notary server
-instances. These may make requests to Notary signer instaces if either a) signing
+instances. These may make requests to Notary signer instances if either a) signing
 is required, or b) key generation is required. The requests from a Notary server
 to a Notary signer cluster are router via an internal load balancer.
 

--- a/docs/running_a_service.md
+++ b/docs/running_a_service.md
@@ -49,7 +49,9 @@ $ openssl s_client -connect <docker host>:4443 -CAfile fixtures/root-ca.crt -no_
 
 To connect using the Notary Client CLI, please see [Getting Started](getting_started.md)
 documentation. Please note that the version of Notary server and signer
-should be greater than or equal to that of the Notary Client CLI to ensure feature compatibility.
+should be greater than or equal to that of the Notary Client CLI to ensure feature compatibility,
+i.e. if you are using Notary Client CLI 0.2, ensure you are using a server and signer tagged with
+an equal or higher version than 0.2 from the <a href="https://github.com/docker/notary/releases">releases page</a>.
 
 The self-signed certificate's subject name and subject alternative names are
 `notary-server`, `notaryserver`, and `localhost`, so if your Docker host is not


### PR DESCRIPTION
Adding a note to the docs on ensuring that the notary client and server/signer are the same version, also fixed a small typo

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>