### PR TITLE
Some root rotation tests and CLI warnings

### DIFF
--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -800,7 +800,7 @@ var waysToMessUpServer = []swizzleExpectations{
 		swizzle: (*testutils.MetadataSwizzler).ExpireMetadata},
 
 	{desc: "lower metadata version", expectErrs: []interface{}{
-		&trustpinning.ErrValidationFail{}, signed.ErrLowVersion{}},
+		&trustpinning.ErrValidationFail{}, signed.ErrLowVersion{}, data.ErrInvalidMetadata{}},
 		swizzle: func(s *testutils.MetadataSwizzler, role string) error {
 			return s.OffsetMetadataVersion(role, -3)
 		}},
@@ -851,13 +851,6 @@ func TestUpdateRootRemoteCorruptedNoLocalCache(t *testing.T) {
 	}
 
 	for _, testData := range waysToMessUpServerRoot() {
-		if testData.desc == "insufficient signatures" {
-			// Currently if we download the root during the bootstrap phase,
-			// we don't check for enough signatures to meet the threshold.  We
-			// are also not entirely sure if we want to support threshold.
-			continue
-		}
-
 		testUpdateRemoteCorruptValidChecksum(t, updateOpts{
 			forWrite: false,
 			role:     data.CanonicalRootRole,
@@ -1207,12 +1200,6 @@ func TestUpdateLocalAndRemoteRootCorrupt(t *testing.T) {
 				// TODO: bug right now where if the local metadata is invalid, we just download a
 				// new version - we verify the signatures and everything, but don't check the version
 				// against the previous if we can
-				continue
-			}
-			if serverExpt.desc == "insufficient signatures" {
-				// Currently if we download the root during the bootstrap phase,
-				// we don't check for enough signatures to meet the threshold.
-				// We are also not sure if we want to support thresholds.
 				continue
 			}
 			testUpdateLocalAndRemoteRootCorrupt(t, true, localExpt, serverExpt)

--- a/cmd/notary/cert.go
+++ b/cmd/notary/cert.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/x509"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/docker/notary"
@@ -129,7 +130,7 @@ func (c *certCommander) certRemove(cmd *cobra.Command, args []string) error {
 
 	// Ask for confirmation before removing certificates, unless -y is provided
 	if !c.certRemoveYes {
-		confirmed := askConfirm()
+		confirmed := askConfirm(os.Stdin)
 		if !confirmed {
 			return fmt.Errorf("Aborting action.")
 		}

--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	notaryclient "github.com/docker/notary/client"
 	"github.com/docker/notary/passphrase"
@@ -159,7 +160,7 @@ func (d *delegationCommander) delegationRemove(cmd *cobra.Command, args []string
 		cmd.Println("\nAre you sure you want to remove all data for this delegation? (yes/no)")
 		// Ask for confirmation before force removing delegation
 		if !d.forceYes {
-			confirmed := askConfirm()
+			confirmed := askConfirm(os.Stdin)
 			if !confirmed {
 				fatalf("Aborting action.")
 			}

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -432,9 +432,11 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 	}
 
 	if rotateKeyRole == data.CanonicalRootRole {
-		cmd.Println("Warning: you are about to rotate your root key.\n" +
-			"You will still need your old key to sign future root changes\n" +
-			"so that clients who may not be behind can update.\n" +
+		cmd.Print("Warning: you are about to rotate your root key.\n\n" +
+			"You must use your old key to sign this root rotation. We recommend that\n" +
+			"you sign all your future root changes with this key as well, so that\n" +
+			"clients can have a smoother update process. Please do not delete\n" +
+			"this key after rotating.\n\n" +
 			"Are you sure you want to proceed?  (yes/no)  ")
 
 		if !askConfirm(k.input) {

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -74,10 +74,10 @@ func TestRemoveOneKeyAbort(t *testing.T) {
 }
 
 // If there is one key, asking to remove it will ask for confirmation.  Passing
-// 'yes'/'y'/'' response will continue the deletion.
+// 'yes'/'y' response will continue the deletion.
 func TestRemoveOneKeyConfirm(t *testing.T) {
 	setUp(t)
-	yesses := []string{"yes", " Y ", "yE", "   ", ""}
+	yesses := []string{"yes", " Y "}
 
 	for _, yesAnswer := range yesses {
 		store := trustmanager.NewKeyMemoryStore(ret)
@@ -108,7 +108,7 @@ func TestRemoveOneKeyConfirm(t *testing.T) {
 // invalid.
 func TestRemoveMultikeysInvalidInput(t *testing.T) {
 	setUp(t)
-	in := bytes.NewBuffer([]byte("nota number\n9999\n-3\n0"))
+	in := bytes.NewBuffer([]byte("notanumber\n9999\n-3\n0"))
 
 	key, err := trustmanager.GenerateED25519Key(rand.Reader)
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestRemoveMultikeysInvalidInput(t *testing.T) {
 		}
 	}
 	require.Equal(t, rootCount, targetCount)
-	require.Equal(t, 4, rootCount) // for each of the 4 invalid inputs
+	require.Equal(t, 5, rootCount) // original + 1 for each of the 4 invalid inputs
 }
 
 // If there is more than one key, removeKeyInteractively will ask which key to

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -171,6 +171,7 @@ func (n *notaryCommander) GetCommand() *cobra.Command {
 	cmdKeyGenerator := &keyCommander{
 		configGetter: n.parseConfig,
 		getRetriever: n.getRetriever,
+		input:        os.Stdin,
 	}
 
 	cmdDelegationGenerator := &delegationCommander{

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -212,10 +213,9 @@ func fatalf(format string, args ...interface{}) {
 	os.Exit(1)
 }
 
-func askConfirm() bool {
+func askConfirm(input io.Reader) bool {
 	var res string
-	_, err := fmt.Scanln(&res)
-	if err != nil {
+	if _, err := fmt.Fscanln(input, &res); err != nil {
 		return false
 	}
 	if strings.EqualFold(res, "y") || strings.EqualFold(res, "yes") {

--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -417,7 +417,7 @@ func validateRoot(gun string, oldRoot, newRoot []byte) (
 		}
 	}
 
-	if err := signed.VerifyRoot(parsedNewSigned, newRootRole.Threshold, newRootRole.Keys); err != nil {
+	if err := signed.VerifySignatures(parsedNewSigned, newRootRole); err != nil {
 		return nil, validation.ErrBadRoot{Msg: err.Error()}
 	}
 
@@ -440,7 +440,7 @@ func checkAgainstOldRoot(oldRoot []byte, newRootRole data.BaseRole, newSigned *d
 	}
 
 	// Always verify the new root against the old root
-	if err := signed.VerifyRoot(newSigned, oldRootRole.Threshold, oldRootRole.Keys); err != nil {
+	if err := signed.VerifySignatures(newSigned, oldRootRole); err != nil {
 		return validation.ErrBadRoot{Msg: fmt.Sprintf(
 			"rotation detected and new root was not signed with at least %d old keys",
 			oldRootRole.Threshold)}

--- a/server/storage/memory.go
+++ b/server/storage/memory.go
@@ -66,7 +66,9 @@ func (st *MemStorage) UpdateCurrent(gun string, update MetaUpdate) error {
 // UpdateMany updates multiple TUF records
 func (st *MemStorage) UpdateMany(gun string, updates []MetaUpdate) error {
 	for _, u := range updates {
-		st.UpdateCurrent(gun, u)
+		if err := st.UpdateCurrent(gun, u); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/server/storage/memory_test.go
+++ b/server/storage/memory_test.go
@@ -19,6 +19,28 @@ func TestUpdateCurrent(t *testing.T) {
 	require.Equal(t, []byte("test"), v.data, "Data was incorrect")
 }
 
+func TestUpdateMany(t *testing.T) {
+	s := NewMemStorage()
+	require.NoError(t, s.UpdateMany("gun", []MetaUpdate{
+		{"role1", 1, []byte("test1")},
+		{"role2", 1, []byte("test2")},
+	}))
+
+	_, d, err := s.GetCurrent("gun", "role1")
+	require.Nil(t, err, "Expected error to be nil")
+	require.Equal(t, []byte("test1"), d, "Data was incorrect")
+
+	_, d, err = s.GetCurrent("gun", "role2")
+	require.Nil(t, err, "Expected error to be nil")
+	require.Equal(t, []byte("test2"), d, "Data was incorrect")
+
+	// updating even one with an equal version fails
+	require.IsType(t, &ErrOldVersion{}, s.UpdateMany("gun", []MetaUpdate{
+		{"role1", 1, []byte("test1")},
+		{"role2", 2, []byte("test2")},
+	}))
+}
+
 func TestGetCurrent(t *testing.T) {
 	s := NewMemStorage()
 

--- a/tuf/data/root.go
+++ b/tuf/data/root.go
@@ -31,6 +31,11 @@ func isValidRootStructure(r Root) error {
 			role: CanonicalRootRole, msg: fmt.Sprintf("expected type %s, not %s", expectedType, r.Type)}
 	}
 
+	if r.Version < 0 {
+		return ErrInvalidMetadata{
+			role: CanonicalRootRole, msg: "version cannot be negative"}
+	}
+
 	// all the base roles MUST appear in the root.json - other roles are allowed,
 	// but other than the mirror role (not currently supported) are out of spec
 	for _, roleName := range BaseRoles {

--- a/tuf/data/root_test.go
+++ b/tuf/data/root_test.go
@@ -218,3 +218,11 @@ func TestRootFromSignedValidatesRoleType(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Root", sRoot.Signed.Type)
 }
+
+// The version cannot be negative
+func TestRootFromSignedValidatesVersion(t *testing.T) {
+	root := validRootTemplate()
+	root.Signed.Version = -1
+	_, err := rootToSignedAndBack(t, root)
+	require.IsType(t, ErrInvalidMetadata{}, err)
+}

--- a/tuf/data/snapshot.go
+++ b/tuf/data/snapshot.go
@@ -32,6 +32,11 @@ func isValidSnapshotStructure(s Snapshot) error {
 			role: CanonicalSnapshotRole, msg: fmt.Sprintf("expected type %s, not %s", expectedType, s.Type)}
 	}
 
+	if s.Version < 0 {
+		return ErrInvalidMetadata{
+			role: CanonicalSnapshotRole, msg: "version cannot be negative"}
+	}
+
 	for _, role := range []string{CanonicalRootRole, CanonicalTargetsRole} {
 		// Meta is a map of FileMeta, so if the role isn't in the map it returns
 		// an empty FileMeta, which has an empty map, and you can check on keys

--- a/tuf/data/snapshot_test.go
+++ b/tuf/data/snapshot_test.go
@@ -194,6 +194,14 @@ func TestSnapshotFromSignedValidatesRoleType(t *testing.T) {
 	require.Equal(t, TUFTypes[CanonicalSnapshotRole], sSnapshot.Signed.Type)
 }
 
+// The version cannot be negative
+func TestSnapshotFromSignedValidatesVersion(t *testing.T) {
+	sn := validSnapshotTemplate()
+	sn.Signed.Version = -1
+	_, err := snapshotToSignedAndBack(t, sn)
+	require.IsType(t, ErrInvalidMetadata{}, err)
+}
+
 // GetMeta returns the checksum, or an error if it is missing.
 func TestSnapshotGetMeta(t *testing.T) {
 	ts := validSnapshotTemplate()

--- a/tuf/data/targets.go
+++ b/tuf/data/targets.go
@@ -38,6 +38,10 @@ func isValidTargetsStructure(t Targets, roleName string) error {
 			role: roleName, msg: fmt.Sprintf("expected type %s, not %s", expectedType, t.Type)}
 	}
 
+	if t.Version < 0 {
+		return ErrInvalidMetadata{role: roleName, msg: "version cannot be negative"}
+	}
+
 	for _, roleObj := range t.Delegations.Roles {
 		if !IsDelegation(roleObj.Name) || path.Dir(roleObj.Name) != roleName {
 			return ErrInvalidMetadata{

--- a/tuf/data/targets_test.go
+++ b/tuf/data/targets_test.go
@@ -227,3 +227,13 @@ func TestTargetsFromSignedValidatesRoleName(t *testing.T) {
 		require.IsType(t, ErrInvalidRole{}, err)
 	}
 }
+
+// The version cannot be negative
+func TestTargetsFromSignedValidatesVersion(t *testing.T) {
+	tg := validTargetsTemplate()
+	tg.Signed.Version = -1
+	s, err := tg.ToSigned()
+	require.NoError(t, err)
+	_, err = TargetsFromSigned(s, "targets/a")
+	require.IsType(t, ErrInvalidMetadata{}, err)
+}

--- a/tuf/data/timestamp.go
+++ b/tuf/data/timestamp.go
@@ -31,6 +31,11 @@ func isValidTimestampStructure(t Timestamp) error {
 			role: CanonicalTimestampRole, msg: fmt.Sprintf("expected type %s, not %s", expectedType, t.Type)}
 	}
 
+	if t.Version < 0 {
+		return ErrInvalidMetadata{
+			role: CanonicalTimestampRole, msg: "version cannot be negative"}
+	}
+
 	// Meta is a map of FileMeta, so if the role isn't in the map it returns
 	// an empty FileMeta, which has an empty map, and you can check on keys
 	// from an empty map.

--- a/tuf/data/timestamp_test.go
+++ b/tuf/data/timestamp_test.go
@@ -194,6 +194,14 @@ func TestTimestampFromSignedValidatesRoleType(t *testing.T) {
 	require.Equal(t, tsType, sTimestamp.Signed.Type)
 }
 
+// The version cannot be negative
+func TestTimestampFromSignedValidatesVersion(t *testing.T) {
+	ts := validTimestampTemplate()
+	ts.Signed.Version = -1
+	_, err := timestampToSignedAndBack(t, ts)
+	require.IsType(t, ErrInvalidMetadata{}, err)
+}
+
 // GetSnapshot returns the snapshot checksum, or an error if it is missing.
 func TestTimestampGetSnapshot(t *testing.T) {
 	ts := validTimestampTemplate()

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -21,45 +21,6 @@ var (
 	ErrWrongType    = errors.New("tuf: meta file has wrong type")
 )
 
-// VerifyRoot checks if a given root file is valid against a known set of keys.
-// Threshold is always assumed to be 1
-func VerifyRoot(s *data.Signed, minVersion int, keys map[string]data.PublicKey) error {
-	if len(s.Signatures) == 0 {
-		return ErrNoSignatures
-	}
-
-	var decoded map[string]interface{}
-	if err := json.Unmarshal(*s.Signed, &decoded); err != nil {
-		return err
-	}
-	msg, err := json.MarshalCanonical(decoded)
-	if err != nil {
-		return err
-	}
-	for _, sig := range s.Signatures {
-		// method lookup is consistent due to Unmarshal JSON doing lower case for us.
-		method := sig.Method
-		verifier, ok := Verifiers[method]
-		if !ok {
-			logrus.Debugf("continuing b/c signing method is not supported for verify root: %s\n", sig.Method)
-			continue
-		}
-		key, ok := keys[sig.KeyID]
-		if !ok {
-			logrus.Debugf("continuing b/c signing key isn't present in keys: %s\n", sig.KeyID)
-			continue
-		}
-
-		if err := verifier.Verify(key, sig.Signature, msg); err != nil {
-			logrus.Debugf("continuing b/c signature was invalid\n")
-			continue
-		}
-		// threshold of 1 so return on first success
-		return verifyMeta(s, data.CanonicalRootRole, minVersion)
-	}
-	return ErrRoleThreshold{}
-}
-
 // Verify checks the signatures and metadata (expiry, version) for the signed role
 // data
 func Verify(s *data.Signed, role data.BaseRole, minVersion int) error {

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -17,7 +17,9 @@ import (
 	"github.com/docker/notary/tuf/signed"
 )
 
-func createKey(cs signed.CryptoService, gun, role string) (data.PublicKey, error) {
+// CreateKey creates a new key inside the cryptoservice for the given role and gun,
+// returning the public key.  If the role is a root role, create an x509 key.
+func CreateKey(cs signed.CryptoService, gun, role string) (data.PublicKey, error) {
 	key, err := cs.Create(role, gun, data.ECDSAKey)
 	if err != nil {
 		return nil, err
@@ -48,7 +50,7 @@ func EmptyRepo(gun string, delegationRoles ...string) (*tuf.Repo, signed.CryptoS
 
 	baseRoles := map[string]data.BaseRole{}
 	for _, role := range data.BaseRoles {
-		key, err := createKey(cs, gun, role)
+		key, err := CreateKey(cs, gun, role)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -75,7 +77,7 @@ func EmptyRepo(gun string, delegationRoles ...string) (*tuf.Repo, signed.CryptoS
 	sort.Strings(delegationRoles)
 	for _, delgName := range delegationRoles {
 		// create a delegations key and a delegation in the tuf repo
-		delgKey, err := createKey(cs, gun, delgName)
+		delgKey, err := CreateKey(cs, gun, delgName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/tuf/testutils/swizzler.go
+++ b/tuf/testutils/swizzler.go
@@ -269,7 +269,7 @@ func (m *MetadataSwizzler) SignMetadataWithInvalidKey(role string) error {
 
 	// create an invalid key, but not in the existing CryptoService
 	cs := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(passphrase.ConstantRetriever("")))
-	key, err := createKey(cs, m.Gun, role)
+	key, err := CreateKey(cs, m.Gun, role)
 	if err != nil {
 		return err
 	}
@@ -466,7 +466,7 @@ func (m *MetadataSwizzler) RotateKey(role string, key data.PublicKey) error {
 // ChangeRootKey swaps out the root key with a new key, and re-signs the metadata
 // with the new key
 func (m *MetadataSwizzler) ChangeRootKey() error {
-	key, err := createKey(m.CryptoService, m.Gun, data.CanonicalRootRole)
+	key, err := CreateKey(m.CryptoService, m.Gun, data.CanonicalRootRole)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR:

- adds tests to ensure that server validation or client update during root rotation do not care about old saved root roles, just whatever root role was previously pinned
- tests that root rotation validation checks that the old root role is satisfied, not that a particular key's signature has to be there based on the previous root's signatures
- warns users that they can't just throw away the root key if they rotate the root key
- adds support for root threshold validation - this causes `signed.VerifyRoot` to go away since then it would require the exact same functionality as `signed.VerifySignatures`

Closes #404 probably.