### PR TITLE
Update go in dockerfiles to go 1.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.0
+FROM golang:1.6.1
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/docker/notary",
-	"GoVersion": "go1.6",
+	"GoVersion": "go1.6.1",
 	"Packages": [
 		"./..."
 	],

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ to use `notary` with Docker images.
 
 Prerequisites:
 
-- Go >= 1.6
+- Go >= 1.6.1
 - [godep](https://github.com/tools/godep) installed
 - libtool development headers installed
     - Ubuntu: `apt-get install libtool-dev`

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 
   post:
   # Install many go versions
-    - gvm install go1.6 -B --name=stable
+    - gvm install go1.6.1 -B --name=stable
   # upgrade compose
     - sudo pip install --upgrade docker-compose
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,15 +1,10 @@
-FROM golang:1.6.0-alpine
+FROM golang:1.6.1-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*
 
-# Note that -ldflags "-extldflags -fno-PIC" and the "-extldflags -fno-PIC" below
-# are to get around https://github.com/golang/go/issues/14851#issuecomment-200915770
-# Once the golang alpine image updates, since it's been patched, we can
-# remove the flags
-
-# Install DB migration tool
-RUN go get -ldflags "-extldflags -fno-PIC" github.com/mattes/migrate
+# Install SQL DB migration tool
+RUN go get github.com/mattes/migrate
 
 ENV NOTARYPKG github.com/docker/notary
 
@@ -23,7 +18,7 @@ EXPOSE 4443
 # Install notary-server
 RUN go install \
     -tags pkcs11 \
-    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION` -extldflags -fno-PIC" \
+    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
     ${NOTARYPKG}/cmd/notary-server && apk del git gcc libc-dev
 
 ENTRYPOINT [ "notary-server" ]

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,15 +1,10 @@
-FROM golang:1.6.0-alpine
+FROM golang:1.6.1-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*
 
-# Note that -ldflags "-extldflags -fno-PIC" and the "-extldflags -fno-PIC" below
-# are to get around https://github.com/golang/go/issues/14851#issuecomment-200915770
-# Once the golang alpine image updates, since it's been patched, we can
-# remove the flags
-
-# Install DB migration tool
-RUN go get -ldflags "-extldflags -fno-PIC" github.com/mattes/migrate
+# Install SQL DB migration tool
+RUN go get github.com/mattes/migrate
 
 ENV NOTARYPKG github.com/docker/notary
 
@@ -26,7 +21,7 @@ EXPOSE 4444
 # Install notary-signer
 RUN go install \
     -tags pkcs11 \
-    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION` -extldflags -fno-PIC" \
+    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
     ${NOTARYPKG}/cmd/notary-signer && apk del git gcc libc-dev
 
 ENTRYPOINT [ "notary-signer" ]


### PR DESCRIPTION
Since we want that security update which could affect HTTPS servers.

Also, the golang:1.6.1-alpine image includes the `no-pic` patch so we should no longer need to pass the `-fno-PIC` flag