### PR TITLE
Remove a redundant ErrChecksumMismatch error in tuf/client

### DIFF
--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustpinning"
-	"github.com/docker/notary/tuf/client"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
@@ -753,7 +752,7 @@ func testUpdateRemoteFileChecksumWrong(t *testing.T, opts updateOpts, errExpecte
 		if opts.role == data.CanonicalTimestampRole {
 			_, rightError = err.(store.ErrMaliciousServer)
 		} else {
-			_, isErrChecksum := err.(client.ErrChecksumMismatch)
+			_, isErrChecksum := err.(data.ErrMismatchedChecksum)
 			_, isErrMaliciousServer := err.(store.ErrMaliciousServer)
 			rightError = isErrChecksum || isErrMaliciousServer
 		}
@@ -924,7 +923,7 @@ func waysToMessUpServerNonRootPerRole(t *testing.T) map[string][]swizzleExpectat
 	}
 	perRoleSwizzling[data.CanonicalTargetsRole] = []swizzleExpectations{{
 		desc:       fmt.Sprintf("target missing delegations data"),
-		expectErrs: []interface{}{client.ErrChecksumMismatch{}},
+		expectErrs: []interface{}{data.ErrMismatchedChecksum{}},
 		swizzle: func(s *testutils.MetadataSwizzler, role string) error {
 			return s.MutateTargets(func(tg *data.Targets) {
 				tg.Delegations.Roles = tg.Delegations.Roles[1:]

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -512,7 +512,7 @@ func (t *tufCommander) tufVerify(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error retrieving target by name:%s, error:%v", targetName, err)
 	}
 
-	if err := data.CheckHashes(payload, target.Hashes); err != nil {
+	if err := data.CheckHashes(payload, targetName, target.Hashes); err != nil {
 		return fmt.Errorf("data not present in the trusted collection, %v", err)
 	}
 

--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -124,7 +124,8 @@ func timestampExpired(ts *data.SignedTimestamp) bool {
 func snapshotExpired(ts *data.SignedTimestamp, snapshot []byte) bool {
 	// If this check failed, it means the current snapshot was not exactly what we expect
 	// via the timestamp. So we can consider it to be "expired."
-	return data.CheckHashes(snapshot, ts.Signed.Meta[data.CanonicalSnapshotRole].Hashes) != nil
+	return data.CheckHashes(snapshot, data.CanonicalSnapshotRole,
+		ts.Signed.Meta[data.CanonicalSnapshotRole].Hashes) != nil
 }
 
 // CreateTimestamp creates a new timestamp. If a prev timestamp is provided, it

--- a/tuf/client/client.go
+++ b/tuf/client/client.go
@@ -98,7 +98,7 @@ func (c Client) checkRoot() error {
 		return err
 	}
 
-	if err := data.CheckHashes(raw, expectedHashes); err != nil {
+	if err := data.CheckHashes(raw, role, expectedHashes); err != nil {
 		return fmt.Errorf("Cached root hashes did not match snapshot root hashes")
 	}
 
@@ -160,7 +160,7 @@ func (c *Client) downloadRoot() error {
 		logrus.Debug("didn't find a cached root, must download")
 		download = true
 	} else {
-		if err := data.CheckHashes(cachedRoot, expectedHashes); err != nil {
+		if err := data.CheckHashes(cachedRoot, role, expectedHashes); err != nil {
 			logrus.Debug("cached root's hash didn't match expected, must download")
 			download = true
 		}
@@ -343,7 +343,7 @@ func (c *Client) downloadSnapshot() error {
 		download = true
 	} else {
 		// file may have been tampered with on disk. Always check the hash!
-		if err := data.CheckHashes(raw, expectedHashes); err != nil {
+		if err := data.CheckHashes(raw, role, expectedHashes); err != nil {
 			logrus.Debug("hash of snapshot in cache did not match expected hash, must download")
 			download = true
 		}
@@ -454,8 +454,8 @@ func (c *Client) downloadSigned(role string, size int64, expectedHashes data.Has
 	}
 
 	if expectedHashes != nil {
-		if err := data.CheckHashes(raw, expectedHashes); err != nil {
-			return nil, nil, ErrChecksumMismatch{role: role}
+		if err := data.CheckHashes(raw, role, expectedHashes); err != nil {
+			return nil, nil, data.ErrMismatchedChecksum{}
 		}
 	}
 
@@ -488,7 +488,7 @@ func (c Client) getTargetsFile(role string, snapshotMeta data.Files, consistent 
 		download = true
 	} else {
 		// file may have been tampered with on disk. Always check the hash!
-		if err := data.CheckHashes(raw, expectedHashes); err != nil {
+		if err := data.CheckHashes(raw, role, expectedHashes); err != nil {
 			download = true
 		}
 

--- a/tuf/client/client_test.go
+++ b/tuf/client/client_test.go
@@ -259,7 +259,7 @@ func TestChecksumMismatch(t *testing.T) {
 	remoteStorage.SetMeta("targets", orig)
 
 	_, _, err = client.downloadSigned("targets", int64(len(orig)), origHashes)
-	require.IsType(t, ErrChecksumMismatch{}, err)
+	require.IsType(t, data.ErrMismatchedChecksum{}, err)
 }
 
 func TestChecksumMatch(t *testing.T) {
@@ -300,7 +300,7 @@ func TestSizeMismatchLong(t *testing.T) {
 	_, _, err = client.downloadSigned("targets", l, origHashes)
 	// size just limits the data received, the error is caught
 	// either during checksum verification or during json deserialization
-	require.IsType(t, ErrChecksumMismatch{}, err)
+	require.IsType(t, data.ErrMismatchedChecksum{}, err)
 }
 
 func TestSizeMismatchShort(t *testing.T) {
@@ -322,7 +322,7 @@ func TestSizeMismatchShort(t *testing.T) {
 	_, _, err = client.downloadSigned("targets", l, origHashes)
 	// size just limits the data received, the error is caught
 	// either during checksum verification or during json deserialization
-	require.IsType(t, ErrChecksumMismatch{}, err)
+	require.IsType(t, data.ErrMismatchedChecksum{}, err)
 }
 
 func TestDownloadTargetsHappy(t *testing.T) {
@@ -500,7 +500,7 @@ func TestDownloadTargetChecksumMismatch(t *testing.T) {
 	repo.Snapshot = &snap
 
 	err = client.downloadTargets("targets")
-	require.IsType(t, ErrChecksumMismatch{}, err)
+	require.IsType(t, data.ErrMismatchedChecksum{}, err)
 }
 
 // TestDownloadTargetsNoChecksum: it's never valid to download any targets
@@ -615,7 +615,7 @@ func TestUpdateDownloadRootBadChecksum(t *testing.T) {
 	require.NoError(t, err)
 
 	err = client.downloadRoot()
-	require.IsType(t, ErrChecksumMismatch{}, err)
+	require.IsType(t, data.ErrMismatchedChecksum{}, err)
 }
 
 func TestUpdateDownloadRootChecksumNotFound(t *testing.T) {

--- a/tuf/client/errors.go
+++ b/tuf/client/errors.go
@@ -4,15 +4,6 @@ import (
 	"fmt"
 )
 
-// ErrChecksumMismatch - a checksum failed verification
-type ErrChecksumMismatch struct {
-	role string
-}
-
-func (e ErrChecksumMismatch) Error() string {
-	return fmt.Sprintf("tuf: checksum for %s did not match", e.role)
-}
-
 // ErrCorruptedCache - local data is incorrect
 type ErrCorruptedCache struct {
 	file string

--- a/tuf/data/errors.go
+++ b/tuf/data/errors.go
@@ -12,13 +12,14 @@ func (e ErrInvalidMetadata) Error() string {
 	return fmt.Sprintf("%s type metadata invalid: %s", e.role, e.msg)
 }
 
-// ErrMissingMeta - couldn't find the FileMeta object for a role or target
+// ErrMissingMeta - couldn't find the FileMeta object for the given Role, or
+// the FileMeta object contained no supported checksums
 type ErrMissingMeta struct {
 	Role string
 }
 
 func (e ErrMissingMeta) Error() string {
-	return fmt.Sprintf("tuf: sha256 checksum required for %s", e.Role)
+	return fmt.Sprintf("no checksums for supported algorithms were provided for %s", e.Role)
 }
 
 // ErrInvalidChecksum is the error to be returned when checksum is invalid
@@ -32,9 +33,12 @@ func (e ErrInvalidChecksum) Error() string {
 
 // ErrMismatchedChecksum is the error to be returned when checksum is mismatched
 type ErrMismatchedChecksum struct {
-	alg string
+	alg      string
+	name     string
+	expected string
 }
 
 func (e ErrMismatchedChecksum) Error() string {
-	return fmt.Sprintf("%s checksum mismatched", e.alg)
+	return fmt.Sprintf("%s checksum for %s did not match: expected %s", e.alg, e.name,
+		e.expected)
 }

--- a/tuf/data/snapshot.go
+++ b/tuf/data/snapshot.go
@@ -126,7 +126,9 @@ func (sp *SignedSnapshot) AddMeta(role string, meta FileMeta) {
 // not found
 func (sp *SignedSnapshot) GetMeta(role string) (*FileMeta, error) {
 	if meta, ok := sp.Signed.Meta[role]; ok {
-		return &meta, nil
+		if _, ok := meta.Hashes["sha256"]; ok {
+			return &meta, nil
+		}
 	}
 	return nil, ErrMissingMeta{Role: role}
 }


### PR DESCRIPTION
Since we already have a ErrMismatchedChecksum in tuf/data/errors.

Also, have the CheckHashes function take a role name so that the
`ErrMismatchedChecksum` error can include the role name.

This is split out from #580 to make it a little smaller.