### PR TITLE
better docs for make binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ Run `make binaries`, which creates the Notary Client CLI binary at `bin/notary`.
 Note that `make binaries` assumes a standard Go directory structure, in which
 Notary is checked out to the `src` directory in your `GOPATH`. For example:
 ```
-GOPATH=$(<path to go/>)
-go/
+$GOPATH/
     src/
         github.com/
             docker/

--- a/README.md
+++ b/README.md
@@ -88,3 +88,13 @@ Prerequisites:
     - Mac OS ([Homebrew](http://brew.sh/)): `brew install libtool`
 
 Run `make binaries`, which creates the Notary Client CLI binary at `bin/notary`.
+Note that `make binaries` assumes a standard Go directory structure, in which
+Notary is checked out to the `src` directory in your `GOPATH`. For example:
+```
+GOPATH=$(<path to go/>)
+go/
+    src/
+        github.com/
+            docker/
+                notary/
+```


### PR DESCRIPTION
Add explicit instructions for the Go directory structure assumed for `make binaries`

Closes #689 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>