### PR TITLE
trustmanager: Minor cosmetic source code fixes

### DIFF
--- a/trustmanager/x509store_test.go
+++ b/trustmanager/x509store_test.go
@@ -133,6 +133,6 @@ func TestVerifyLeafWithNoLeaf(t *testing.T) {
 	// Try to find a valid chain for cert
 	err = Verify(store, "secure.example.com", certList)
 	if err == nil {
-		t.Fatalf("expected error due to no leafs provided")
+		t.Fatalf("expected error due to no leaves provided")
 	}
 }

--- a/trustmanager/x509utils.go
+++ b/trustmanager/x509utils.go
@@ -541,8 +541,8 @@ func CertsToKeys(leafCerts []*x509.Certificate, intCerts map[string][]*x509.Cert
 		if err != nil {
 			continue
 		}
-		if intCertsForLeafs, ok := intCerts[certID]; ok {
-			certBundle = append(certBundle, intCertsForLeafs...)
+		if intCertsForLeaves, ok := intCerts[certID]; ok {
+			certBundle = append(certBundle, intCertsForLeaves...)
 		}
 		certChainPEM, err := CertChainToPEM(certBundle)
 		if err != nil {

--- a/trustmanager/yubikey/yubikeystore.go
+++ b/trustmanager/yubikey/yubikeystore.go
@@ -137,7 +137,7 @@ type YubiPrivateKey struct {
 	libLoader     pkcs11LibLoader
 }
 
-// YubiKeySigner wraps a YubiPrivateKey and implements the crypto.Signer interface
+// yubikeySigner wraps a YubiPrivateKey and implements the crypto.Signer interface
 type yubikeySigner struct {
 	YubiPrivateKey
 }
@@ -344,7 +344,7 @@ func getECDSAKey(ctx IPKCS11Ctx, session pkcs11.SessionHandle, pkcs11KeyID []byt
 	return data.NewECDSAPublicKey(pubBytes), data.CanonicalRootRole, nil
 }
 
-// Sign returns a signature for a given signature request
+// sign returns a signature for a given signature request
 func sign(ctx IPKCS11Ctx, session pkcs11.SessionHandle, pkcs11KeyID []byte, passRetriever passphrase.Retriever, payload []byte) ([]byte, error) {
 	err := login(ctx, session, passRetriever, pkcs11.CKU_USER, UserPin)
 	if err != nil {


### PR DESCRIPTION
Fixing a few things I noticed scrolling through the Notary 0.3.0-RC1 diff.