### PR TITLE
Use markdown to link to image, so the published result shows it

### DIFF
--- a/docs/reference/client-config.md
+++ b/docs/reference/client-config.md
@@ -132,7 +132,9 @@ but the pinned certificates will take highest priority for validation, followed
 by the pinned CA, followed by TOFUS (TOFU over HTTPS).  The diagram below
 describes this validation flow:
 
-<center><img src="../images/trust-pinning-flow.png" alt="Trust pinning flow" width="400px"/></center>
+<center>
+![Trust pinning flow](../images/trust-pinning-flow.png)
+</center>
 
 Only one trust pinning option will be used to validate a GUN even if multiple
 sections are specified, and any validation failure will result in a failed


### PR DESCRIPTION
The relative paths to link to the image are not the same on the published result to that in GitHub due to our use of implied `/index.html` when publishing. 

This means that to do the right transform, we need to use markdown markup for the linking.

This tests right for me in both cases :)