### PR TITLE
Allow for configurable notary signer db name, check allowed backends

### DIFF
--- a/cmd/notary-signer/main_test.go
+++ b/cmd/notary-signer/main_test.go
@@ -224,6 +224,15 @@ func TestSetupCryptoServicesMemoryStore(t *testing.T) {
 	require.NotNil(t, privKey)
 }
 
+func TestSetupCryptoServicesInvalidStore(t *testing.T) {
+	config := configure(fmt.Sprintf(`{"storage": {"backend": "%s"}}`,
+		"invalid_backend"))
+	_, err := setUpCryptoservices(config,
+		[]string{notary.SQLiteBackend, notary.MemoryBackend, notary.RethinkDBBackend})
+	require.Error(t, err)
+	require.Equal(t, err.Error(), fmt.Sprintf("%s is not an allowed backend, must be one of: %s", "invalid_backend", []string{notary.SQLiteBackend, notary.MemoryBackend, notary.RethinkDBBackend}))
+}
+
 func TestSetupHTTPServer(t *testing.T) {
 	httpServer := setupHTTPServer(":4443", nil, make(signer.CryptoServiceIndex))
 	require.Equal(t, ":4443", httpServer.Addr)


### PR DESCRIPTION
Some small cleanup to allow for a configurable notary signer db name in Rethinkdb (this matches the notary server configuration).

Also added a check to `setUpCryptoservices` to actually check against allowed backends and error out if an invalid backend is specified. 

I've also run this against the Rethinkdb integration test with successful results.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>