### PR TITLE
Be less strict for password caching for delegation keys 

### DIFF
--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary/passphrase"
-	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/version"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -232,7 +231,9 @@ func getPassphraseRetriever() passphrase.Retriever {
 			return v, numAttempts > 1, nil
 		}
 		// For delegation roles, we can also try the "delegation" alias if it is specified
-		if v := env["delegation"]; v != "" && data.IsDelegation(alias) {
+		// Note that we don't check if the role name is for a delegation to allow for names like "user"
+		// since delegation keys can be shared across repositories
+		if v := env["delegation"]; v != "" {
 			return v, numAttempts > 1, nil
 		}
 		return baseRetriever(keyName, alias, createNew, numAttempts)


### PR DESCRIPTION
Allow for non-delegation names such as `user` to use the `NOTARY_DELEGATION_PASSPHRASE` for usability

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>