### PR TITLE
Tiny rework

### DIFF
--- a/tuf/store/offlinestore.go
+++ b/tuf/store/offlinestore.go
@@ -11,43 +11,41 @@ func (e ErrOffline) Error() string {
 	return "client is offline"
 }
 
-var err = ErrOffline{}
-
 // OfflineStore is to be used as a placeholder for a nil store. It simply
 // returns ErrOffline for every operation
 type OfflineStore struct{}
 
 // GetMeta returns ErrOffline
 func (es OfflineStore) GetMeta(name string, size int64) ([]byte, error) {
-	return nil, err
+	return nil, ErrOffline{}
 }
 
 // SetMeta returns ErrOffline
 func (es OfflineStore) SetMeta(name string, blob []byte) error {
-	return err
+	return ErrOffline{}
 }
 
 // SetMultiMeta returns ErrOffline
 func (es OfflineStore) SetMultiMeta(map[string][]byte) error {
-	return err
+	return ErrOffline{}
 }
 
 // RemoveMeta returns ErrOffline
 func (es OfflineStore) RemoveMeta(name string) error {
-	return err
+	return ErrOffline{}
 }
 
 // GetKey returns ErrOffline
 func (es OfflineStore) GetKey(role string) ([]byte, error) {
-	return nil, err
+	return nil, ErrOffline{}
 }
 
 // GetTarget returns ErrOffline
 func (es OfflineStore) GetTarget(path string) (io.ReadCloser, error) {
-	return nil, err
+	return nil, ErrOffline{}
 }
 
 // RemoveAll return ErrOffline
 func (es OfflineStore) RemoveAll() error {
-	return err
+	return ErrOffline{}
 }


### PR DESCRIPTION
I think it's OK to use the ErrOffline{} directly, we needn't to wrap it here.

The "err" is more likely be used as "err, xxx := foo()"

Signed-off-by: Hu Keping <hukeping@huawei.com>