### PR TITLE
Increase timeout for RethinkDB (default is 0), remove extra wait

### DIFF
--- a/storage/rethinkdb/bootstrap.go
+++ b/storage/rethinkdb/bootstrap.go
@@ -18,14 +18,7 @@ func makeDB(session *gorethink.Session, name string) error {
 		if strings.Contains(err.Error(), "already exists") {
 			return nil
 		}
-
-		return err
 	}
-	resp, err := gorethink.DB(name).Wait(timeoutOpt).Run(session)
-	if resp != nil {
-		resp.Close()
-	}
-
 	return err
 }
 

--- a/storage/rethinkdb/bootstrap.go
+++ b/storage/rethinkdb/bootstrap.go
@@ -3,10 +3,14 @@ package rethinkdb
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"gopkg.in/dancannon/gorethink.v2"
 )
+
+// Wait for 60 seconds maximum on Wait() calls for rethink
+var timeoutOpt = gorethink.WaitOpts{Timeout: time.Minute.Seconds()}
 
 func makeDB(session *gorethink.Session, name string) error {
 	_, err := gorethink.DBCreate(name).RunWrite(session)
@@ -17,7 +21,7 @@ func makeDB(session *gorethink.Session, name string) error {
 
 		return err
 	}
-	resp, err := gorethink.DB(name).Wait().Run(session)
+	resp, err := gorethink.DB(name).Wait(timeoutOpt).Run(session)
 	if resp != nil {
 		resp.Close()
 	}
@@ -41,7 +45,7 @@ func (t Table) term(dbName string) gorethink.Term {
 }
 
 func (t Table) wait(session *gorethink.Session, dbName string) error {
-	resp, err := t.term(dbName).Wait().Run(session)
+	resp, err := t.term(dbName).Wait(timeoutOpt).Run(session)
 
 	if resp != nil {
 		resp.Close()


### PR DESCRIPTION
The default timeout for rethinkdb when calling `term.Wait()` is [0 seconds](https://rethinkdb.com/api/javascript/wait/), this bumps it to 60 seconds -- I'd be fine making it shorter as well, but we're checking across all replicas to be ready in this scenario by default.

Also remove extra `.Wait()` after db creation

Tested using the rethinkdb integration test.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>