### PR TITLE
CheckTargetByName for checking if all roles signed a specific target with the same name and hash

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1473,6 +1473,128 @@ func TestListTargetRestrictsDelegationPaths(t *testing.T) {
 	require.Nil(t, tgt)
 }
 
+func TestCheckTarget(t *testing.T) {
+	ts, mux, keys := simpleTestServer(t)
+	defer ts.Close()
+
+	rootType := data.ECDSAKey
+
+	repo, _ := initializeRepo(t, rootType, "docker.com/notary", ts.URL, false)
+	defer os.RemoveAll(repo.baseDir)
+
+	// tests need to manually bootstrap timestamp as client doesn't generate it
+	err := repo.tufRepo.InitTimestamp()
+	require.NoError(t, err, "error creating repository: %s", err)
+
+	// add latest and current to targets role
+	addTarget(t, repo, "latest", "../fixtures/intermediate-ca.crt")
+	addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt")
+
+	// setup delegated targets/level1 role with targets current and other
+	k, err := repo.CryptoService.Create("targets/level1", repo.gun, rootType)
+	require.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
+	require.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1", []string{""}, []string{}, false)
+	require.NoError(t, err)
+	addTarget(t, repo, "current", "../fixtures/root-ca.crt", "targets/level1")
+	addTarget(t, repo, "other", "../fixtures/root-ca.crt", "targets/level1")
+
+	// setup delegated targets/level2 role with targets current and level2
+	k, err = repo.CryptoService.Create("targets/level2", repo.gun, rootType)
+	require.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level2", []data.PublicKey{k}, []string{}, 1)
+	require.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level2", []string{""}, []string{}, false)
+	require.NoError(t, err)
+	addTarget(t, repo, "current", "../fixtures/notary-server.crt", "targets/level2")
+	addTarget(t, repo, "level2", "../fixtures/notary-server.crt", "targets/level2")
+
+	// Apply the changelist. Normally, this would be done by Publish
+
+	// load the changelist for this repo
+	cl, err := changelist.NewFileChangelist(
+		filepath.Join(repo.baseDir, "tuf", filepath.FromSlash(repo.gun), "changelist"))
+	require.NoError(t, err, "could not open changelist")
+
+	// apply the changelist to the repo, then clear it
+	err = applyChangelist(repo.tufRepo, cl)
+	require.NoError(t, err, "could not apply changelist")
+	require.NoError(t, cl.Clear(""))
+
+	_, ok := repo.tufRepo.Targets["targets/level1"].Signed.Targets["current"]
+	require.True(t, ok)
+	_, ok = repo.tufRepo.Targets["targets/level1"].Signed.Targets["other"]
+	require.True(t, ok)
+	_, ok = repo.tufRepo.Targets["targets/level2"].Signed.Targets["level2"]
+	require.True(t, ok)
+
+	// setup delegated targets/level1/level2 role separately, which can only modify paths prefixed with "level2"
+	// add level2 to targets/level1/level2
+	k, err = repo.CryptoService.Create("targets/level1/level2", repo.gun, rootType)
+	require.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationKeys("targets/level1/level2", []data.PublicKey{k}, []string{}, 1)
+	require.NoError(t, err)
+	err = repo.tufRepo.UpdateDelegationPaths("targets/level1/level2", []string{"level2"}, []string{}, false)
+	require.NoError(t, err)
+	addTarget(t, repo, "level2", "../fixtures/notary-signer.crt", "targets/level1/level2")
+	// load the changelist for this repo
+	cl, err = changelist.NewFileChangelist(
+		filepath.Join(repo.baseDir, "tuf", filepath.FromSlash(repo.gun), "changelist"))
+	require.NoError(t, err, "could not open changelist")
+	// apply the changelist to the repo
+	err = applyChangelist(repo.tufRepo, cl)
+	require.NoError(t, err, "could not apply changelist")
+	// check the changelist was applied
+	_, ok = repo.tufRepo.Targets["targets/level1/level2"].Signed.Targets["level2"]
+	require.True(t, ok)
+
+	fakeServerData(t, repo, mux, keys)
+
+	// test default checking, which checks the targets role only
+	ok, err = repo.CheckTargetByName("latest")
+	require.True(t, ok)
+	require.NoError(t, err)
+	ok, err = repo.CheckTargetByName("current")
+	require.True(t, ok)
+	require.NoError(t, err)
+	ok, err = repo.CheckTargetByName("nonexistent")
+	require.False(t, ok)
+	require.Error(t, err)
+	// even though a child role has signed level2, the targets role itself has not
+	ok, err = repo.CheckTargetByName("level2")
+	require.False(t, ok)
+	require.Error(t, err)
+
+	// now also check delegation roles for positive cases
+	// level2 is signed by: targets/level2 and targets/level1/level2
+	ok, err = repo.CheckTargetByName("level2", "targets/level2", "targets/level1/level2")
+	require.True(t, ok)
+	require.NoError(t, err)
+	// current is signed by: targets and targets/level1 and targets/level2
+	ok, err = repo.CheckTargetByName("current", data.CanonicalTargetsRole, "targets/level1", "targets/level2")
+	require.True(t, ok)
+	require.NoError(t, err)
+	// a subset still works
+	ok, err = repo.CheckTargetByName("current", "targets/level1", "targets/level2")
+	require.True(t, ok)
+	require.NoError(t, err)
+	// other is signed by: targets/level1
+	ok, err = repo.CheckTargetByName("other", "targets/level1")
+	require.True(t, ok)
+	require.NoError(t, err)
+
+	// now also check delegation roles for negative cases
+	// targets/level1 never signed level2
+	ok, err = repo.CheckTargetByName("level2", "targets/level2", "targets/level1/level2", "targets/level1")
+	require.False(t, ok)
+	require.Error(t, err)
+	// targets didn't sign level2, and we don't check child roles
+	ok, err = repo.CheckTargetByName("level2")
+	require.False(t, ok)
+	require.Error(t, err)
+}
+
 // TestValidateRootKey verifies that the public data in root.json for the root
 // key is a valid x509 certificate.
 func TestValidateRootKey(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1561,10 +1561,10 @@ func TestCheckTarget(t *testing.T) {
 	ok, err = repo.CheckTargetByName("nonexistent")
 	require.False(t, ok)
 	require.Error(t, err)
-	// even though a child role has signed level2, the targets role itself has not
+	// even though a child role has signed level2, the targets role itself is a parent and so this succeeds
 	ok, err = repo.CheckTargetByName("level2")
-	require.False(t, ok)
-	require.Error(t, err)
+	require.True(t, ok)
+	require.NoError(t, err)
 
 	// now also check delegation roles for positive cases
 	// level2 is signed by: targets/level2 and targets/level1/level2
@@ -1585,12 +1585,16 @@ func TestCheckTarget(t *testing.T) {
 	require.NoError(t, err)
 
 	// now also check delegation roles for negative cases
-	// targets/level1 never signed level2
-	ok, err = repo.CheckTargetByName("level2", "targets/level2", "targets/level1/level2", "targets/level1")
+	// targets/level1/level2 never signed current
+	ok, err = repo.CheckTargetByName("current", "targets/level1/level2")
 	require.False(t, ok)
 	require.Error(t, err)
-	// targets didn't sign level2, and we don't check child roles
-	ok, err = repo.CheckTargetByName("level2")
+	// targets/level1/level2 and targets/level2 never signed other
+	ok, err = repo.CheckTargetByName("other", "targets/level1/level2", "targets/level2")
+	require.False(t, ok)
+	require.Error(t, err)
+	// targets/level1/level2/level3/level4 doesn't even exist
+	ok, err = repo.CheckTargetByName("other", "targets/level1/level2/level3/level4")
 	require.False(t, ok)
 	require.Error(t, err)
 }

--- a/tuf/data/types_test.go
+++ b/tuf/data/types_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/go/canonical/json"
 	"github.com/docker/notary"
 	"github.com/stretchr/testify/require"
+	"strings"
 )
 
 func TestGenerateFileMetaDefault(t *testing.T) {
@@ -175,4 +176,53 @@ func TestCheckValidHashStructures(t *testing.T) {
 	hashes["sha256"], err = hex.DecodeString("1234567890a4f2307e49160fa242db6fb95f071ad81a198eeb7d770e61cd6d8")
 	err = CheckValidHashStructures(hashes)
 	require.IsType(t, ErrInvalidChecksum{}, err)
+}
+
+func TestCompareMultiHashes(t *testing.T) {
+	var err error
+	hashes1 := make(Hashes)
+	hashes2 := make(Hashes)
+
+	// Expected to fail since there are no checksums at all
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.Error(t, err)
+
+	// Expected to fail even though the checksum of sha384 is valid,
+	// because we haven't provided a supported hash algorithm yet (ex: sha256).
+	hashes1["sha384"], err = hex.DecodeString("64becc3c23843942b1040ffd4743d1368d988ddf046d17d448a6e199c02c3044b425a680112b399d4dbe9b35b7ccc989")
+	hashes2["sha384"], err = hex.DecodeString("64becc3c23843942b1040ffd4743d1368d988ddf046d17d448a6e199c02c3044b425a680112b399d4dbe9b35b7ccc989")
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.Error(t, err)
+
+	// Now both have a matching sha256, so this will pass
+	hashes1["sha256"], err = hex.DecodeString("766af0ef090a4f2307e49160fa242db6fb95f071ad81a198eeb7d770e61cd6d8")
+	hashes2["sha256"], err = hex.DecodeString("766af0ef090a4f2307e49160fa242db6fb95f071ad81a198eeb7d770e61cd6d8")
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.NoError(t, err)
+
+	// Because the sha384 algorithm isn't supported, it's treated as an extra key that won't be checked
+	// So even if it doesn't match, that's fine as long as all supported keys match
+	hashes2["sha384"], err = hex.DecodeString(strings.Repeat("a", 96))
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.NoError(t, err)
+
+	// only add a sha512 to hashes1, but comparison will still succeed because there's no mismatch and we have the sha256 match
+	hashes1["sha512"], err = hex.DecodeString("795d9e95db099464b6730844f28effddb010b0d5abae5d5892a6ee04deacb09c9e622f89e816458b5a1a81761278d7d3a6a7c269d9707eff8858b16c51de0315")
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.NoError(t, err)
+
+	// remove sha256 from hashes1, comparison will fail now because there are no matches
+	delete(hashes1, "sha256")
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.Error(t, err)
+
+	// add sha512 to hashes2, comparison will now pass because both have matching sha512s
+	hashes2["sha512"], err = hex.DecodeString("795d9e95db099464b6730844f28effddb010b0d5abae5d5892a6ee04deacb09c9e622f89e816458b5a1a81761278d7d3a6a7c269d9707eff8858b16c51de0315")
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.NoError(t, err)
+
+	// change the sha512 for hashes2, comparison will now fail
+	hashes2["sha512"], err = hex.DecodeString(strings.Repeat("a", notary.Sha512HexSize))
+	err = CompareMultiHashes(hashes1, hashes2)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Add function to client library to check if a set of roles have all signed a particular target with the same name and hash.  Note that if no roles are passed, we default to just checking the targets role (following behavior in `GetTargetByName` and `ListTargets`).

This function will check the specified roles and also its child roles if it cannot find the target.
Ex: if `targets/releases` signs `latest` but `targets` does not, calling `CheckTargetByName("latest", "targets")` will return true.

I kept the error return value in case we wanted it for debugging (if there's an unexpected error during an `Update` call vs. during a walk, or mismatching hashes), but we could remove it if we would prefer to do so.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>