### PR TITLE
Feature: increase/decrease logging level without restarting

### DIFF
--- a/cmd/notary-server/config.go
+++ b/cmd/notary-server/config.go
@@ -3,11 +3,11 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"os"
+	"os/signal"
 	"path"
 	"strconv"
 	"strings"
-	"os"
-	"os/signal"
 	"syscall"
 	"time"
 

--- a/cmd/notary-server/config.go
+++ b/cmd/notary-server/config.go
@@ -309,6 +309,14 @@ func reloadConfig(sig os.Signal, configFile string, oldConfig *viper.Viper, envP
 				fmt.Println("Decrease log level failed, will use the old one, error: ", err)
 				return
 			}
+		case syscall.SIGHUP:
+			// We use SIGHUP to allow people to reset the logging level as their wish.
+			lvl, err := utils.ParseLogLevel(config, logrus.ErrorLevel)
+			if err != nil {
+				fmt.Println("Parse log level failed, will use the old one, error: ", err)
+				return
+			}
+			logrus.SetLevel(lvl)
 		}
 
 		fmt.Println("Successfully setting log level to ", logrus.GetLevel())

--- a/cmd/notary-server/config.go
+++ b/cmd/notary-server/config.go
@@ -297,12 +297,12 @@ func signalHandle(sig os.Signal) {
 	switch sig {
 	case syscall.SIGUSR1:
 		if err := utils.AdjustLogLevel(true); err != nil {
-			fmt.Printf("Attempt to increase log level failed, will remain at %s level, error: %s", logrus.GetLevel(), err)
+			fmt.Printf("Attempt to increase log level failed, will remain at %s level, error: %s\n", logrus.GetLevel(), err)
 			return
 		}
 	case syscall.SIGUSR2:
 		if err := utils.AdjustLogLevel(false); err != nil {
-			fmt.Printf("Attempt to decrease log level failed, will remain at %s level, error: %s", logrus.GetLevel(), err)
+			fmt.Printf("Attempt to decrease log level failed, will remain at %s level, error: %s\n", logrus.GetLevel(), err)
 			return
 		}
 	}

--- a/cmd/notary-server/config.go
+++ b/cmd/notary-server/config.go
@@ -228,7 +228,6 @@ func parseServerConfig(configFilePath string, hRegister healthRegister) (context
 	}
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, "config", config)
 
 	// default is error level
 	lvl, err := utils.ParseLogLevel(config, logrus.ErrorLevel)
@@ -293,7 +292,7 @@ func setupSignalTrap() {
 	}()
 }
 
-// signalHandle will increase/descrease the logging level via the signal we get.
+// signalHandle will increase/decrease the logging level via the signal we get.
 func signalHandle(sig os.Signal) {
 	switch sig {
 	case syscall.SIGUSR1:

--- a/cmd/notary-server/config.go
+++ b/cmd/notary-server/config.go
@@ -301,19 +301,19 @@ func reloadConfig(sig os.Signal, configFile string, oldConfig *viper.Viper, envP
 		switch sig {
 		case syscall.SIGUSR1:
 			if err := utils.AdjustLogLevel(true); err != nil {
-				fmt.Println("Increase log level failed, will use the old one, error: ", err)
+				fmt.Printf("Attempt to increase log level failed, will remain at %s level, error: %s", logrus.GetLevel(), err)
 				return
 			}
 		case syscall.SIGUSR2:
 			if err := utils.AdjustLogLevel(false); err != nil {
-				fmt.Println("Decrease log level failed, will use the old one, error: ", err)
+				fmt.Printf("Attempt to decrease log level failed, will remain at %s level, error: %s", logrus.GetLevel(), err)
 				return
 			}
 		case syscall.SIGHUP:
 			// We use SIGHUP to allow people to reset the logging level as their wish.
 			lvl, err := utils.ParseLogLevel(config, logrus.ErrorLevel)
 			if err != nil {
-				fmt.Println("Parse log level failed, will use the old one, error: ", err)
+				fmt.Printf("Attempt to reset log level failed, will remain at %s level, error: %s", logrus.GetLevel(), err)
 				return
 			}
 			logrus.SetLevel(lvl)

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/distribution/health"
 	"github.com/docker/notary/server"
 	"github.com/docker/notary/version"
+	"github.com/spf13/viper"
 )
 
 // DebugAddress is the debug server address to listen on
@@ -56,6 +57,12 @@ func main() {
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}
+
+	config, ok := ctx.Value("config").(*viper.Viper)
+	if !ok {
+		logrus.Fatalf("parse config failed")
+	}
+	setupConfigReloadTrap(config, configFile, envPrefix)
 
 	if doBootstrap {
 		err = bootstrap(ctx)

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/distribution/health"
 	"github.com/docker/notary/server"
 	"github.com/docker/notary/version"
-	"github.com/spf13/viper"
 )
 
 // DebugAddress is the debug server address to listen on
@@ -58,11 +57,7 @@ func main() {
 		logrus.Fatal(err.Error())
 	}
 
-	config, ok := ctx.Value("config").(*viper.Viper)
-	if !ok {
-		logrus.Fatalf("parse config failed")
-	}
-	setupConfigReloadTrap(config, configFile, envPrefix)
+	setupSignalTrap()
 
 	if doBootstrap {
 		err = bootstrap(ctx)

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -416,8 +416,8 @@ func TestSampleConfig(t *testing.T) {
 	require.Equal(t, registerCalled, 2)
 }
 
-func TestReloadConfig(t *testing.T) {
-	f, err := os.Create("/tmp/testReloadConfig.json")
+func TestSignalHandle(t *testing.T) {
+	f, err := os.Create("/tmp/testSignalHandle.json")
 	defer os.Remove(f.Name())
 	require.NoError(t, err)
 
@@ -429,19 +429,14 @@ func TestReloadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Info + SIGUSR1 -> Debug
-	reloadConfig(syscall.SIGUSR1, f.Name(), v, "envPrefix")
+	signalHandle(syscall.SIGUSR1)
 	require.Equal(t, logrus.GetLevel(), logrus.DebugLevel)
 
 	// Debug + SIGUSR1 -> Debug
-	reloadConfig(syscall.SIGUSR1, f.Name(), v, "envPrefix")
+	signalHandle(syscall.SIGUSR1)
 	require.Equal(t, logrus.GetLevel(), logrus.DebugLevel)
 
 	// Debug + SIGUSR2-> Info
-	reloadConfig(syscall.SIGUSR2, f.Name(), v, "envPrefix")
+	signalHandle(syscall.SIGUSR2)
 	require.Equal(t, logrus.GetLevel(), logrus.InfoLevel)
-
-	// SIGHUP + x -> x
-	f.WriteAt([]byte(`{"logging": {"level": "error"}}`), 0)
-	reloadConfig(syscall.SIGHUP, f.Name(), v, "envPrefix")
-	require.Equal(t, logrus.GetLevel(), logrus.ErrorLevel)
 }

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -425,7 +425,6 @@ func TestReloadConfig(t *testing.T) {
 
 	v := viper.New()
 	utils.SetupViper(v, "envPrefix")
-	//v.SetConfigType("json")
 	err = utils.ParseViper(v, f.Name())
 	require.NoError(t, err)
 

--- a/const.go
+++ b/const.go
@@ -72,9 +72,7 @@ var NotaryDefaultExpiries = map[string]time.Duration{
 // NotarySupportedSignals contains the signals we would like to capture:
 // - SIGUSR1, indicates a increment of the log level.
 // - SIGUSR2, indicates a decrement of the log level.
-// - SIGHUP,  indicates a reloading of the configuration.
 var NotarySupportedSignals = []os.Signal{
 	syscall.SIGUSR1,
 	syscall.SIGUSR2,
-	syscall.SIGHUP,
 }

--- a/const.go
+++ b/const.go
@@ -1,6 +1,8 @@
 package notary
 
 import (
+	"os"
+	"syscall"
 	"time"
 )
 
@@ -66,3 +68,8 @@ var NotaryDefaultExpiries = map[string]time.Duration{
 	"snapshot":  NotarySnapshotExpiry,
 	"timestamp": NotaryTimestampExpiry,
 }
+
+// NotarySupportedSignals contains the signals we would like to capture:
+// - SIGUSR1, indicates a increment of the log level.
+// - SIGUSR2, indicates a decrement of the log level.
+var NotarySupportedSignals = []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2}

--- a/const.go
+++ b/const.go
@@ -72,4 +72,9 @@ var NotaryDefaultExpiries = map[string]time.Duration{
 // NotarySupportedSignals contains the signals we would like to capture:
 // - SIGUSR1, indicates a increment of the log level.
 // - SIGUSR2, indicates a decrement of the log level.
-var NotarySupportedSignals = []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2}
+// - SIGHUP,  indicates a reloading of the configuration.
+var NotarySupportedSignals = []os.Signal{
+	syscall.SIGUSR1,
+	syscall.SIGUSR2,
+	syscall.SIGHUP,
+}

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -363,9 +363,9 @@ Example:
 
 ## Hot configuration reload
 We don't support to hot reload everything at present. What we support for now is:
-- increase logging level by signal `SIGUSR1`
-- decrease logging level by signal `SIGUSR2`
-- hot reload logging level from the config file by signal `SIGHUP`
+- increase logging level by signaling `SIGUSR1`
+- decrease logging level by signaling `SIGUSR2`
+- hot reload logging level from the config file by signaling `SIGHUP`
 
 Example:
 

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -370,12 +370,31 @@ Example:
 
 To increase logging level
 ```
-$ kill -s SIGUSR1 `ps aux | grep "notary-server -config" | grep -v "grep" | awk '{print $2}'`
+$ kill -s SIGUSR1 PID
+
+or
+
+$ docker exec -i CONTAINER_ID kill -s SIGUSR1 PID
 ```
 
 To decrease logging level
 ```
-$ kill -s SIGUSR2 `ps aux | grep "notary-server -config" | grep -v "grep" | awk '{print $2}'`
+$ kill -s SIGUSR2 PID
+
+or
+
+$ docker exec -i CONTAINER_ID kill -s SIGUSR2 PID
+```
+PID is the process id of `notary-server` and it may not the PID 1 process if you are running
+the container with some kind of wrapper startup script or something.
+
+You can get the PID of `notary-server` through
+```
+$ docker exec CONTAINER_ID ps aux
+
+or
+
+$ ps aux | grep "notary-server -config" | grep -v "grep"
 ```
 
 ## Related information

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -19,6 +19,8 @@ A configuration file is required by Notary server, and the path to the
 configuration file must be specified using the `-config` option on the command
 line.
 
+Notary server also allows you to [hot-reload](server-config.md#hot-configuration-reload) the configuration without having to restart.
+
 Here is a full server configuration file example; please click on the top level JSON keys to
 learn more about the configuration section corresponding to that key:
 
@@ -358,6 +360,30 @@ Example:
 		</td>
 	</tr>
 </table>
+
+## Hot configuration reload
+We don't support to hot reload everything at present. What we support for now is:
+- increase logging level by signal `SIGUSR1`
+- decrease logging level by signal `SIGUSR2`
+- hot reload logging level from the config file by signal `SIGHUP`
+
+Example:
+
+To increase logging level
+```
+$ kill -s SIGUSR1 `ps aux | grep "notary-server -config" | grep -v "grep" | awk '{print $2}'`
+```
+
+To decrease logging level
+```
+$ kill -s SIGUSR2 `ps aux | grep "notary-server -config" | grep -v "grep" | awk '{print $2}'`
+```
+
+To reset logging level
+```
+$ #edit the config file and then
+$ kill -s SIGHUP `ps aux | grep "notary-server -config" | grep -v "grep" | awk '{print $2}'`
+```
 
 ## Related information
 

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -362,7 +362,7 @@ Example:
 </table>
 
 ## Hot logging level reload
-We don't support to completely reload the whole configuration yet at present. What we support for now is:
+We don't support completely reloading notary configuration files yet at present. What we support for now is:
 - increase logging level by signaling `SIGUSR1`
 - decrease logging level by signaling `SIGUSR2`
 
@@ -376,12 +376,6 @@ $ kill -s SIGUSR1 `ps aux | grep "notary-server -config" | grep -v "grep" | awk 
 To decrease logging level
 ```
 $ kill -s SIGUSR2 `ps aux | grep "notary-server -config" | grep -v "grep" | awk '{print $2}'`
-```
-
-To reset logging level
-```
-$ #edit the config file and then
-$ kill -s SIGHUP `ps aux | grep "notary-server -config" | grep -v "grep" | awk '{print $2}'`
 ```
 
 ## Related information

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -19,7 +19,7 @@ A configuration file is required by Notary server, and the path to the
 configuration file must be specified using the `-config` option on the command
 line.
 
-Notary server also allows you to [hot-reload](server-config.md#hot-configuration-reload) the configuration without having to restart.
+Notary server also allows you to [increase/decrease](server-config.md#hot-logging-level-reload) the logging level without having to restart.
 
 Here is a full server configuration file example; please click on the top level JSON keys to
 learn more about the configuration section corresponding to that key:
@@ -361,11 +361,10 @@ Example:
 	</tr>
 </table>
 
-## Hot configuration reload
-We don't support to hot reload everything at present. What we support for now is:
+## Hot logging level reload
+We don't support to completely reload the whole configuration yet at present. What we support for now is:
 - increase logging level by signaling `SIGUSR1`
 - decrease logging level by signaling `SIGUSR2`
-- hot reload logging level from the config file by signaling `SIGHUP`
 
 Example:
 

--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -244,3 +244,31 @@ func AdjustLogLevel(increment bool) error {
 	logrus.SetLevel(lvl)
 	return nil
 }
+
+// ReloadConfiguration reads and parse the configuration in the host and do some verification.
+func ReloadConfiguration(oldConfig *viper.Viper, configFile string, envPrefix string, reload func(*viper.Viper)) error {
+	logrus.Infof("Got signal to reload configuration, reloading from: %s", configFile)
+
+	// parse a viper as the new Config
+	newConfig := viper.New()
+	SetupViper(newConfig, envPrefix)
+	if err := ParseViper(newConfig, configFile); err != nil {
+		return err
+	}
+
+	// To check if there was anything wrong
+	if err := validateConfiguration(oldConfig, newConfig); err != nil {
+		return err
+	}
+
+	reload(newConfig)
+	return nil
+}
+
+// Reserved for future use, we can use it to validate some specific configs when necessary.
+// For example:
+// - to check if there are conflicts.
+// - to do some sanity check maybe.
+func validateConfiguration(oldConfig, newConfig *viper.Viper) error {
+	return nil
+}

--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -222,3 +222,25 @@ func ParseViper(v *viper.Viper, configFile string) error {
 	}
 	return nil
 }
+
+// AdjustLogLevel increases/decreases the log level, return error if the operation is invaild.
+func AdjustLogLevel(increment bool) error {
+	lvl := logrus.GetLevel()
+
+	// The log level seems not possible, in the foreseeable future,
+	// out of range [Panic, Debug]
+	if increment {
+		if lvl == logrus.DebugLevel {
+			return fmt.Errorf("log level can not be set higher than %s", "Debug")
+		}
+		lvl++
+	} else {
+		if lvl == logrus.PanicLevel {
+			return fmt.Errorf("log level can not be set lower than %s", "Panic")
+		}
+		lvl--
+	}
+
+	logrus.SetLevel(lvl)
+	return nil
+}

--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -244,31 +244,3 @@ func AdjustLogLevel(increment bool) error {
 	logrus.SetLevel(lvl)
 	return nil
 }
-
-// ReloadConfiguration reads and parse the configuration in the host and do some verification.
-func ReloadConfiguration(oldConfig *viper.Viper, configFile string, envPrefix string, reload func(*viper.Viper)) error {
-	logrus.Infof("Got signal to reload configuration, reloading from: %s", configFile)
-
-	// parse a viper as the new Config
-	newConfig := viper.New()
-	SetupViper(newConfig, envPrefix)
-	if err := ParseViper(newConfig, configFile); err != nil {
-		return err
-	}
-
-	// To check if there was anything wrong
-	if err := validateConfiguration(oldConfig, newConfig); err != nil {
-		return err
-	}
-
-	reload(newConfig)
-	return nil
-}
-
-// Reserved for future use, we can use it to validate some specific configs when necessary.
-// For example:
-// - to check if there are conflicts.
-// - to do some sanity check maybe.
-func validateConfiguration(oldConfig, newConfig *viper.Viper) error {
-	return nil
-}

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -485,3 +485,74 @@ func TestParseViperWithValidFile(t *testing.T) {
 
 	require.Equal(t, "debug", v.GetString("logging.level"))
 }
+
+func TestAdjustLogLevel(t *testing.T) {
+
+	// To indicate increment or decrement the logging level
+	optIncrement := true
+	optDecrement := false
+
+	// Debug is the highest level for now, so we expected a error here
+	logrus.SetLevel(logrus.DebugLevel)
+	err := AdjustLogLevel(optIncrement)
+	require.Error(t, err)
+	// Debug -> Info
+	logrus.SetLevel(logrus.DebugLevel)
+	err = AdjustLogLevel(optDecrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.InfoLevel, logrus.GetLevel())
+
+	// Info -> Debug
+	logrus.SetLevel(logrus.InfoLevel)
+	err = AdjustLogLevel(optIncrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.DebugLevel, logrus.GetLevel())
+	// Info -> Warn
+	logrus.SetLevel(logrus.InfoLevel)
+	err = AdjustLogLevel(optDecrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.WarnLevel, logrus.GetLevel())
+
+	// Warn -> Info
+	logrus.SetLevel(logrus.WarnLevel)
+	err = AdjustLogLevel(optIncrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.InfoLevel, logrus.GetLevel())
+	// Warn -> Error
+	logrus.SetLevel(logrus.WarnLevel)
+	err = AdjustLogLevel(optDecrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.ErrorLevel, logrus.GetLevel())
+
+	// Error -> Warn
+	logrus.SetLevel(logrus.ErrorLevel)
+	err = AdjustLogLevel(optIncrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.WarnLevel, logrus.GetLevel())
+	// Error -> Fatal
+	logrus.SetLevel(logrus.ErrorLevel)
+	err = AdjustLogLevel(optDecrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.FatalLevel, logrus.GetLevel())
+
+	// Fatal -> Error
+	logrus.SetLevel(logrus.FatalLevel)
+	err = AdjustLogLevel(optIncrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.ErrorLevel, logrus.GetLevel())
+	// Fatal -> Panic
+	logrus.SetLevel(logrus.FatalLevel)
+	err = AdjustLogLevel(optDecrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.PanicLevel, logrus.GetLevel())
+
+	// Panic -> Fatal
+	logrus.SetLevel(logrus.PanicLevel)
+	err = AdjustLogLevel(optIncrement)
+	require.NoError(t, err)
+	require.Equal(t, logrus.FatalLevel, logrus.GetLevel())
+	// Panic is the lowest level for now, so we expected a error here
+	logrus.SetLevel(logrus.PanicLevel)
+	err = AdjustLogLevel(optDecrement)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Part of #633 

As discussed with the team of notary, it might not make sense to completely reload the configuration yet. 

With this patch set, we can send SIGUSR1/SIGUSR2 to increase/decrease the logging level of notary-server.

Signed-off-by: Hu Keping <hukeping@huawei.com>