### PR TITLE
Fix the re-think compose file so that all the rdb nodes join the same cluster

### DIFF
--- a/development.rethink.yml
+++ b/development.rethink.yml
@@ -11,8 +11,6 @@ services:
       links:
         - rdb-proxy:rdb-proxy.rdb
         - signer
-      environment:
-        - SERVICE_NAME=notary_server
       ports:
         - "8080"
         - "4443:4443"
@@ -32,8 +30,6 @@ services:
                 - notarysigner
       links:
         - rdb-proxy:rdb-proxy.rdb
-      environment:
-        - SERVICE_NAME=notary_signer
       entrypoint: /usr/bin/env sh
       command: -c "sh migrations/rethink_migrate.sh && notary-signer -config=fixtures/signer-config.rethink.json"
       depends_on:

--- a/development.yml
+++ b/development.yml
@@ -5,8 +5,6 @@ server:
     - mysql
     - signer
     - signer:notarysigner
-  environment:
-    - SERVICE_NAME=notary_server
   entrypoint: /usr/bin/env sh
   command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
 signer:
@@ -14,8 +12,6 @@ signer:
   dockerfile: signer.Dockerfile
   links:
     - mysql
-  environment:
-    - SERVICE_NAME=notary_signer
   entrypoint: /usr/bin/env sh
   command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
 mysql:

--- a/docker-compose.rethink.yml
+++ b/docker-compose.rethink.yml
@@ -12,7 +12,6 @@ services:
         - rdb-proxy:rdb-proxy.rdb
         - signer
       ports:
-        - "8080"
         - "4443:4443"
       entrypoint: /usr/bin/env sh
       command: -c "sh migrations/rethink_migrate.sh && notary-server -config=fixtures/server-config.rethink.json"
@@ -42,10 +41,8 @@ services:
       networks:
         rdb:
           aliases:
-            - rdb
-            - rdb.rdb
             - rdb-01.rdb
-      command: "--bind all --no-http-admin --server-name rdb_01 --canonical-address rdb-01.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      command: "--bind all --no-http-admin --server-name rdb_01 --canonical-address rdb-01.rdb --directory /var/data/rethinkdb --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
     rdb-02:
       image: jlhawn/rethinkdb:2.3.0
       volumes:
@@ -54,10 +51,10 @@ services:
       networks:
         rdb:
           aliases:
-            - rdb
-            - rdb.rdb
             - rdb-02.rdb
-      command: "--bind all --no-http-admin --server-name rdb_02 --canonical-address rdb-02.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      command: "--bind all --no-http-admin --server-name rdb_02 --canonical-address rdb-02.rdb --directory /var/data/rethinkdb --join rdb-01:29015 --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      depends_on:
+        - rdb-01
     rdb-03:
       image: jlhawn/rethinkdb:2.3.0
       volumes:
@@ -66,10 +63,11 @@ services:
       networks:
         rdb:
           aliases:
-            - rdb
-            - rdb.rdb
             - rdb-03.rdb
-      command: "--bind all --no-http-admin --server-name rdb_03 --canonical-address rdb-03.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      command: "--bind all --no-http-admin --server-name rdb_03 --canonical-address rdb-03.rdb --directory /var/data/rethinkdb --join rdb-02:29015 --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      depends_on:
+        - rdb-01
+        - rdb-02
     rdb-proxy:
       image: jlhawn/rethinkdb:2.3.0
       ports:
@@ -81,7 +79,7 @@ services:
           aliases:
             - rdb-proxy
             - rdb-proxy.rdp
-      command: "proxy --bind all --join rdb.rdb --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      command: "proxy --bind all --join rdb-03:29015 --driver-tls-ca /tls/ca.pem --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
       depends_on:
         - rdb-01
         - rdb-02

--- a/docker-compose.rethink.yml
+++ b/docker-compose.rethink.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
     server:
-      build: 
+      build:
         context: .
         dockerfile: server.Dockerfile
       volumes:
@@ -11,8 +11,6 @@ services:
       links:
         - rdb-proxy:rdb-proxy.rdb
         - signer
-      environment:
-        - SERVICE_NAME=notary_server
       ports:
         - "8080"
         - "4443:4443"
@@ -21,7 +19,7 @@ services:
       depends_on:
         - rdb-proxy
     signer:
-      build: 
+      build:
         context: .
         dockerfile: signer.Dockerfile
       volumes:
@@ -32,8 +30,6 @@ services:
                 - notarysigner
       links:
         - rdb-proxy:rdb-proxy.rdb
-      environment:
-        - SERVICE_NAME=notary_signer
       entrypoint: /usr/bin/env sh
       command: -c "sh migrations/rethink_migrate.sh && notary-signer -config=fixtures/signer-config.rethink.json"
       depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ server:
     - mysql
     - signer
     - signer:notarysigner
-  environment:
-    - SERVICE_NAME=notary_server
   ports:
     - "8080"
     - "4443:4443"
@@ -17,8 +15,6 @@ signer:
   dockerfile: signer.Dockerfile
   links:
     - mysql
-  environment:
-    - SERVICE_NAME=notary_signer
   entrypoint: /usr/bin/env sh
   command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
 mysql:

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -13,6 +13,7 @@ COPY . /go/src/${NOTARYPKG}
 
 WORKDIR /go/src/${NOTARYPKG}
 
+ENV SERVICE_NAME=notary_server
 EXPOSE 4443
 
 # Install notary-server

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -13,6 +13,7 @@ COPY . /go/src/${NOTARYPKG}
 
 WORKDIR /go/src/${NOTARYPKG}
 
+ENV SERVICE_NAME=notary_signer
 ENV NOTARY_SIGNER_DEFAULT_ALIAS="timestamp_1"
 ENV NOTARY_SIGNER_TIMESTAMP_1="testpassword"
 

--- a/storage/rethinkdb/bootstrap.go
+++ b/storage/rethinkdb/bootstrap.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Wait for 60 seconds maximum on Wait() calls for rethink
-var timeoutOpt = gorethink.WaitOpts{Timeout: time.Minute.Seconds()}
+var timeoutOpt = gorethink.WaitOpts{WaitFor: "all_replicas_ready", Timeout: time.Minute.Seconds()}
 
 func makeDB(session *gorethink.Session, name string) error {
 	_, err := gorethink.DBCreate(name).RunWrite(session)


### PR DESCRIPTION
Previously I was running into issues where the server and signer would bootstrap fine, but couldn't connect, so updated the wait options to include "all_replicas_ready", which should be the default already.  But for some reason this seemed to fix the issue for me.  Or it was intermittent, who knows.

But not all the RDB replicas joined the same cluster, when looking at the admin UI - this fixes it for me.