### PR TITLE
force cgo resolver for name resolution

### DIFF
--- a/development.rethink.yml
+++ b/development.rethink.yml
@@ -13,6 +13,7 @@ services:
         - signer
       environment:
         - SERVICE_NAME=notary_server
+        - GODEBUG=netdns=cgo
       ports:
         - "8080"
         - "4443:4443"
@@ -34,6 +35,7 @@ services:
         - rdb-proxy:rdb-proxy.rdb
       environment:
         - SERVICE_NAME=notary_signer
+        - GODEBUG=netdns=cgo
       entrypoint: /usr/bin/env sh
       command: -c "sh migrations/rethink_migrate.sh && notary-signer -config=fixtures/signer-config.rethink.json"
       depends_on:
@@ -100,6 +102,8 @@ services:
         dockerfile: Dockerfile
       links:
         - server:notary-server
+      environment:
+        - GODEBUG=netdns=cgo
       command: buildscripts/testclient.sh
 volumes:
     rdb-01-data:

--- a/development.yml
+++ b/development.yml
@@ -7,6 +7,7 @@ server:
     - signer:notarysigner
   environment:
     - SERVICE_NAME=notary_server
+    - GODEBUG=netdns=cgo
   entrypoint: /usr/bin/env sh
   command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
 signer:
@@ -16,6 +17,7 @@ signer:
     - mysql
   environment:
     - SERVICE_NAME=notary_signer
+    - GODEBUG=netdns=cgo
   entrypoint: /usr/bin/env sh
   command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
 mysql:
@@ -33,4 +35,6 @@ client:
   dockerfile: Dockerfile
   links:
     - server:notary-server
+  environment:
+    - GODEBUG=netdns=cgo
   command: buildscripts/testclient.sh

--- a/docker-compose.rethink.yml
+++ b/docker-compose.rethink.yml
@@ -13,6 +13,7 @@ services:
         - signer
       environment:
         - SERVICE_NAME=notary_server
+        - GODEBUG=netdns=cgo
       ports:
         - "8080"
         - "4443:4443"
@@ -34,6 +35,7 @@ services:
         - rdb-proxy:rdb-proxy.rdb
       environment:
         - SERVICE_NAME=notary_signer
+        - GODEBUG=netdns=cgo
       entrypoint: /usr/bin/env sh
       command: -c "sh migrations/rethink_migrate.sh && notary-signer -config=fixtures/signer-config.rethink.json"
       depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ server:
     - signer:notarysigner
   environment:
     - SERVICE_NAME=notary_server
+    - GODEBUG=netdns=cgo
   ports:
     - "8080"
     - "4443:4443"
@@ -19,6 +20,7 @@ signer:
     - mysql
   environment:
     - SERVICE_NAME=notary_signer
+    - GODEBUG=netdns=cgo
   entrypoint: /usr/bin/env sh
   command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
 mysql:


### PR DESCRIPTION
By default, the pure Go resolver is used which makes direct DNS
requests first to resolve a hostname before checking /etc/hosts.
If a host on the network has the same name as the linked container,
the host on the network will be used instead of the linked container.

I had a machine on the network with hostname `mysql` and bringing up the containers with `docker-compose` had the `server` and `signer` linked containers trying to connect to to it...

```
$ sudo docker-compose up
...
mysql_1  | 2016-05-19 19:33:29 140622360905664 [Note] mysqld: ready for connections.
mysql_1  | Version: '10.1.10-MariaDB-1~jessie'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
server_1 | waiting for notarymysql to come up.
signer_1 | waiting for notarymysql to come up.
server_1 | waiting for notarymysql to come up.
signer_1 | waiting for notarymysql to come up.
server_1 | waiting for notarymysql to come up.
...
```

Forcing cgo resolver will use C library routines that will honor
values in /etc/hosts first and then fall back on DNS.

From the docs: https://golang.org/pkg/net/#hdr-Name_Resolution

Signed-off-by: Andrew Hsu andrewhsu@acm.org (github: andrewhsu)