### PR TITLE
convert docker-compose.yml and development.yml to compose v2

### DIFF
--- a/development.yml
+++ b/development.yml
@@ -10,6 +10,8 @@ services:
       srv:
         aliases:
           - notary-server
+    environment:
+      - GODEBUG=netdns=cgo
     entrypoint: /usr/bin/env sh
     command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
     depends_on:
@@ -24,6 +26,8 @@ services:
       sig:
         aliases:
           - notarysigner
+    environment:
+      - GODEBUG=netdns=cgo
     entrypoint: /usr/bin/env sh
     command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
     depends_on:
@@ -42,6 +46,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      - GODEBUG=netdns=cgo
     command: buildscripts/testclient.sh
     volumes:
       - ./test_output:/test_output

--- a/development.yml
+++ b/development.yml
@@ -1,36 +1,65 @@
-server:
-  build: .
-  dockerfile: server.Dockerfile
-  links:
-    - mysql
-    - signer
-    - signer:notarysigner
-  environment:
-    - SERVICE_NAME=notary_server
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
-signer:
-  build: .
-  dockerfile: signer.Dockerfile
-  links:
-    - mysql
-  environment:
-    - SERVICE_NAME=notary_signer
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
-mysql:
-  volumes:
-    - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-  image: mariadb:10.1.10
-  environment:
-    - TERM=dumb
-    - MYSQL_ALLOW_EMPTY_PASSWORD="true"
-  command: mysqld --innodb_file_per_table
-client:
-  volumes:
-    - ./test_output:/test_output
-  build: .
-  dockerfile: Dockerfile
-  links:
-    - server:notary-server
-  command: buildscripts/testclient.sh
+version: "2"
+services:
+  server:
+    build:
+      context: .
+      dockerfile: server.Dockerfile
+    networks:
+      rdb:
+      sig:
+      srv:
+        aliases:
+          - notary-server
+    environment:
+      - SERVICE_NAME=notary_server
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
+    depends_on:
+      - mysql
+      - signer
+  signer:
+    build:
+      context: .
+      dockerfile: signer.Dockerfile
+    networks:
+      rdb:
+      sig:
+        aliases:
+          - notarysigner
+    environment:
+      - SERVICE_NAME=notary_signer
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
+    depends_on:
+      - mysql
+  mysql:
+    networks:
+      - rdb
+    volumes:
+      - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    image: mariadb:10.1.10
+    environment:
+      - TERM=dumb
+      - MYSQL_ALLOW_EMPTY_PASSWORD="true"
+    command: mysqld --innodb_file_per_table
+  client:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: buildscripts/testclient.sh
+    volumes:
+      - ./test_output:/test_output
+    networks:
+      - srv
+    depends_on:
+      - server
+volumes:
+  notary_data:
+    external: false
+networks:
+  rdb:
+    external: false
+  sig:
+    external: false
+  srv:
+    external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,55 @@
-server:
-  build: .
-  dockerfile: server.Dockerfile
-  links:
-    - mysql
-    - signer
-    - signer:notarysigner
-  environment:
-    - SERVICE_NAME=notary_server
-  ports:
-    - "8080"
-    - "4443:4443"
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
-signer:
-  build: .
-  dockerfile: signer.Dockerfile
-  links:
-    - mysql
-  environment:
-    - SERVICE_NAME=notary_signer
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
-mysql:
-  volumes:
-    - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-    - notary_data:/var/lib/mysql
-  image: mariadb:10.1.10
-  ports:
-    - "3306:3306"
-  environment:
-    - TERM=dumb
-    - MYSQL_ALLOW_EMPTY_PASSWORD="true"
-  command: mysqld --innodb_file_per_table
+version: "2"
+services:
+  server:
+    build:
+      context: .
+      dockerfile: server.Dockerfile
+    networks:
+      - rdb
+      - sig
+    environment:
+      - SERVICE_NAME=notary_server
+    ports:
+      - "8080"
+      - "4443:4443"
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
+    depends_on:
+      - mysql
+      - signer
+  signer:
+    build:
+      context: .
+      dockerfile: signer.Dockerfile
+    networks:
+      rdb:
+      sig:
+        aliases:
+          - notarysigner
+    environment:
+      - SERVICE_NAME=notary_signer
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
+    depends_on:
+      - mysql
+  mysql:
+    networks:
+      - rdb
+    volumes:
+      - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - notary_data:/var/lib/mysql
+    image: mariadb:10.1.10
+    ports:
+      - "3306:3306"
+    environment:
+      - TERM=dumb
+      - MYSQL_ALLOW_EMPTY_PASSWORD="true"
+    command: mysqld --innodb_file_per_table
+volumes:
+  notary_data:
+    external: false
+networks:
+  rdb:
+    external: false
+  sig:
+    external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     networks:
       - rdb
       - sig
+    environment:
+      - GODEBUG=netdns=cgo
     ports:
       - "8080"
       - "4443:4443"
@@ -24,6 +26,8 @@ services:
       sig:
         aliases:
           - notarysigner
+    environment:
+      - GODEBUG=netdns=cgo
     entrypoint: /usr/bin/env sh
     command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
     depends_on:


### PR DESCRIPTION
Converted the remaining two docker compose files over to the v2 format as suggested in #753 in hopes that the dns server in docker would resolve the hostnames of the containers instead of going off-box for hostname resolution. Unfortunately, this does not work, so I had to add the `GODEBUG=netdns=cgo` environment variable to the compose files.