### PR TITLE
convert docker compose files to v2

### DIFF
--- a/development.mysql.yml
+++ b/development.mysql.yml
@@ -1,32 +1,67 @@
-server:
-  build: .
-  dockerfile: server.Dockerfile
-  links:
-    - mysql
-    - signer
-    - signer:notarysigner
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
-signer:
-  build: .
-  dockerfile: signer.Dockerfile
-  links:
-    - mysql
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
-mysql:
-  volumes:
-    - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-  image: mariadb:10.1.10
-  environment:
-    - TERM=dumb
-    - MYSQL_ALLOW_EMPTY_PASSWORD="true"
-  command: mysqld --innodb_file_per_table
-client:
-  volumes:
-    - ./test_output:/test_output
-  build: .
-  dockerfile: Dockerfile
-  links:
-    - server:notary-server
-  command: buildscripts/testclient.sh
+version: "2"
+services:
+  server:
+    build:
+      context: .
+      dockerfile: server.Dockerfile
+    networks:
+      rdb:
+      sig:
+      srv:
+        aliases:
+          - notary-server
+    environment:
+      - GODEBUG=netdns=cgo
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
+    depends_on:
+      - mysql
+      - signer
+  signer:
+    build:
+      context: .
+      dockerfile: signer.Dockerfile
+    networks:
+      rdb:
+      sig:
+        aliases:
+          - notarysigner
+    environment:
+      - GODEBUG=netdns=cgo
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
+    depends_on:
+      - mysql
+  mysql:
+    networks:
+      - rdb
+    volumes:
+      - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    image: mariadb:10.1.10
+    environment:
+      - TERM=dumb
+      - MYSQL_ALLOW_EMPTY_PASSWORD="true"
+    command: mysqld --innodb_file_per_table
+  client:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - GODEBUG=netdns=cgo
+    command: buildscripts/testclient.sh
+    volumes:
+      - ./test_output:/test_output
+    networks:
+      - srv
+    depends_on:
+      - server
+volumes:
+  notary_data:
+    external: false
+networks:
+  rdb:
+    external: false
+  sig:
+    external: false
+  srv:
+    external: false

--- a/development.mysql.yml
+++ b/development.mysql.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: server.Dockerfile
     networks:
-      rdb:
+      mdb:
       sig:
       srv:
         aliases:
@@ -20,7 +20,7 @@ services:
       context: .
       dockerfile: signer.Dockerfile
     networks:
-      rdb:
+      mdb:
       sig:
         aliases:
           - notarysigner
@@ -30,7 +30,7 @@ services:
       - mysql
   mysql:
     networks:
-      - rdb
+      - mdb
     volumes:
       - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     image: mariadb:10.1.10
@@ -53,7 +53,7 @@ volumes:
   notary_data:
     external: false
 networks:
-  rdb:
+  mdb:
     external: false
   sig:
     external: false

--- a/development.mysql.yml
+++ b/development.mysql.yml
@@ -10,8 +10,6 @@ services:
       srv:
         aliases:
           - notary-server
-    environment:
-      - GODEBUG=netdns=cgo
     entrypoint: /usr/bin/env sh
     command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
     depends_on:
@@ -26,8 +24,6 @@ services:
       sig:
         aliases:
           - notarysigner
-    environment:
-      - GODEBUG=netdns=cgo
     entrypoint: /usr/bin/env sh
     command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
     depends_on:
@@ -46,8 +42,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    environment:
-      - GODEBUG=netdns=cgo
     command: buildscripts/testclient.sh
     volumes:
       - ./test_output:/test_output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,49 @@
-server:
-  build: .
-  dockerfile: server.Dockerfile
-  links:
-    - mysql
-    - signer
-    - signer:notarysigner
-  ports:
-    - "8080"
-    - "4443:4443"
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
-signer:
-  build: .
-  dockerfile: signer.Dockerfile
-  links:
-    - mysql
-  entrypoint: /usr/bin/env sh
-  command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
-mysql:
-  volumes:
-    - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-    - notary_data:/var/lib/mysql
-  image: mariadb:10.1.10
-  environment:
-    - TERM=dumb
-    - MYSQL_ALLOW_EMPTY_PASSWORD="true"
-  command: mysqld --innodb_file_per_table
+version: "2"
+services:
+  server:
+    build:
+      context: .
+      dockerfile: server.Dockerfile
+    networks:
+      - rdb
+      - sig
+    ports:
+      - "8080"
+      - "4443:4443"
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
+    depends_on:
+      - mysql
+      - signer
+  signer:
+    build:
+      context: .
+      dockerfile: signer.Dockerfile
+    networks:
+      rdb:
+      sig:
+        aliases:
+          - notarysigner
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
+    depends_on:
+      - mysql
+  mysql:
+    networks:
+      - rdb
+    volumes:
+      - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - notary_data:/var/lib/mysql
+    image: mariadb:10.1.10
+    environment:
+      - TERM=dumb
+      - MYSQL_ALLOW_EMPTY_PASSWORD="true"
+    command: mysqld --innodb_file_per_table
+volumes:
+  notary_data:
+    external: false
+networks:
+  rdb:
+    external: false
+  sig:
+    external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: server.Dockerfile
     networks:
-      - rdb
+      - mdb
       - sig
     ports:
       - "8080"
@@ -20,7 +20,7 @@ services:
       context: .
       dockerfile: signer.Dockerfile
     networks:
-      rdb:
+      mdb:
       sig:
         aliases:
           - notarysigner
@@ -30,7 +30,7 @@ services:
       - mysql
   mysql:
     networks:
-      - rdb
+      - mdb
     volumes:
       - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       - notary_data:/var/lib/mysql
@@ -43,7 +43,7 @@ volumes:
   notary_data:
     external: false
 networks:
-  rdb:
+  mdb:
     external: false
   sig:
     external: false


### PR DESCRIPTION
Converted the remaining two docker compose files over to the v2 format as suggested in #753 in hopes that the dns server in docker would resolve the hostnames of the containers instead of going off-box for hostname resolution.

Signed-off-by: Andrew Hsu <andrewhsu@acm.org>