### PR TITLE
fix lint and circle, edit codecov

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd -ms /bin/bash notary \
 	&& pip install codecov \
-	&& go get golang.org/x/tools/cmd/cover github.com/golang/lint/golint
+	&& go get golang.org/x/tools/cmd/cover github.com/golang/lint/golint github.com/client9/misspell/cmd/misspell
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk

--- a/buildscripts/circle_parallelism.sh
+++ b/buildscripts/circle_parallelism.sh
@@ -1,14 +1,15 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
- case $CIRCLE_NODE_INDEX in
- 0) docker run --rm -e NOTARY_BUILDTAGS=pkcs11 notary_client make vet lint fmt misspell
- 	docker run --rm -e NOTARY_BUILDTAGS=pkcs11 --env-file buildscripts/env.list --user notary notary_client bash -c "make ci && codecov"
-	;;
- 1) docker run --rm -e NOTARY_BUILDTAGS=none notary_client make vet lint fmt misspell
- 	docker run --rm -e NOTARY_BUILDTAGS=none --env-file buildscripts/env.list --user notary notary_client bash -c "make ci && codecov"
-	;;
- 2) SKIPENVCHECK=1 make TESTDB=mysql integration
- 	;;
- 3) SKIPENVCHECK=1 make TESTDB=rethink integration
- 	;;
- esac
+set -e
+case $CIRCLE_NODE_INDEX in
+0) docker run --rm -e NOTARY_BUILDTAGS=pkcs11 --env-file buildscripts/env.list --user notary notary_client bash -c "make ci && codecov"
+   ;;
+1) docker run --rm -e NOTARY_BUILDTAGS=none --env-file buildscripts/env.list --user notary notary_client bash -c "make ci && codecov"
+   ;;
+2) SKIPENVCHECK=1 make TESTDB=mysql integration
+   ;;
+3) SKIPENVCHECK=1 make TESTDB=rethink integration
+   ;;
+4) docker run --rm -e NOTARY_BUILDTAGS=pkcs11 notary_client make vet lint fmt misspell
+   ;;
+esac

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,7 @@ coverage:
     project:
       default:
         target: auto
+        threshold: "0.05%"
     # patch would give us the code coverage of the diff only
     patch: false
     # changes tells us if there are unexpected code coverage changes in other files

--- a/notary.go
+++ b/notary.go
@@ -1,6 +1,6 @@
 package notary
 
-// Retriever is a callback function that should retrieve a passphrase
+// PassRetriever is a callback function that should retrieve a passphrase
 // for a given named key. If it should be treated as new passphrase (e.g. with
 // confirmation), createNew will be true. Attempts is passed in so that implementers
 // decide how many chances to give to a human, for example.


### PR DESCRIPTION
I noticed that we had a slight lint issue and circle wasn't picking it up -- this should fix both the lint error and make sure that errors are reported properly.  This also changes the thresholding on codecov to accept `0.05%` drops in coverage.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>