### PR TITLE
allow devel builds of go to pass make version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ GOOSES = darwin linux
 NOTARY_BUILDTAGS ?= pkcs11
 NOTARYDIR := /go/src/github.com/docker/notary
 
-GO_VERSION := $(shell go version | grep "1\.[6-9]\(\.[0-9]+\)*")
-# check to make sure we have the right version
+GO_VERSION := $(shell go version | grep "1\.[6-9]\(\.[0-9]+\)*\|devel")
+# check to make sure we have the right version. development versions of Go are
+# not officially supported, but allowed for building
 
 ifeq ($(strip $(GO_VERSION))$(SKIPENVCHECK),)
 $(error Bad Go version - please install Go >= 1.6)


### PR DESCRIPTION
I'm sure I'm not the only one who runs these. It's nice to be able to stay on one go version instead of switching for different projects.