### PR TITLE
Nearexpirywarnings for re-signing roles on read or write

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -612,7 +612,7 @@ func (r *NotaryRepository) publish(cl changelist.Changelist) error {
 	// check if our root file is nearing expiry or dirty. Resign if it is.  If
 	// root is not dirty but we are publishing for the first time, then just
 	// publish the existing root we have.
-	if nearExpiry(r.tufRepo.Root) || r.tufRepo.Root.Dirty {
+	if nearExpiry(r.tufRepo.Root.Signed.SignedCommon) || r.tufRepo.Root.Dirty {
 		rootJSON, err := serializeCanonicalRole(r.tufRepo, data.CanonicalRootRole)
 		if err != nil {
 			return err
@@ -781,7 +781,10 @@ func (r *NotaryRepository) Update(forWrite bool) error {
 		}
 		return err
 	}
+	// we can be assured if we are at this stage that the repo we built is good
+	// no need to test the following function call for an error as it will always be fine should the repo be good- it is!
 	r.tufRepo = repo
+	warnRolesNearExpiry(repo)
 	return nil
 }
 

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -1,10 +1,13 @@
 package client
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/json"
 	"testing"
+	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/testutils"
@@ -967,4 +970,52 @@ func TestChangeTargetMetaFailsIfPrefixError(t *testing.T) {
 	// no target in targets or targets/latest
 	require.Empty(t, repo.Targets[data.CanonicalTargetsRole].Signed.Targets)
 	require.Empty(t, repo.Targets["targets/level1"].Signed.Targets)
+}
+
+func TestAllNearExpiry(t *testing.T) {
+	repo, _, err := testutils.EmptyRepo("docker.com/notary")
+	require.NoError(t, err)
+	nearexpdate := time.Now().AddDate(0, 1, 0)
+	repo.Root.Signed.SignedCommon.Expires = nearexpdate
+	repo.Snapshot.Signed.SignedCommon.Expires = nearexpdate
+	repo.Targets["targets"].Signed.Expires = nearexpdate
+	_, err1 := repo.InitTargets("targets/exp")
+	require.NoError(t, err1)
+	repo.Targets["targets/exp"].Signed.Expires = nearexpdate
+	//Reset levels to display warnings through logrus
+	orgLevel := log.GetLevel()
+	log.SetLevel(log.WarnLevel)
+	defer log.SetLevel(orgLevel)
+	b := bytes.NewBuffer(nil)
+	log.SetOutput(b)
+	warnRolesNearExpiry(repo)
+	require.Contains(t, b.String(), "targets metadata is nearing expiry, you should re-sign the role metadata", "targets should show near expiry")
+	require.Contains(t, b.String(), "targets/exp metadata is nearing expiry, you should re-sign the role metadata", "targets/exp should show near expiry")
+	require.Contains(t, b.String(), "root is nearing expiry, you should re-sign the role metadata", "Root should show near expiry")
+	require.Contains(t, b.String(), "snapshot is nearing expiry, you should re-sign the role metadata", "Snapshot should show near expiry")
+	require.NotContains(t, b.String(), "timestamp", "there should be no logrus warnings pertaining to timestamp")
+}
+
+func TestAllNotNearExpiry(t *testing.T) {
+	repo, _, err := testutils.EmptyRepo("docker.com/notary")
+	require.NoError(t, err)
+	notnearexpdate := time.Now().AddDate(0, 10, 0)
+	repo.Root.Signed.SignedCommon.Expires = notnearexpdate
+	repo.Snapshot.Signed.SignedCommon.Expires = notnearexpdate
+	repo.Targets["targets"].Signed.Expires = notnearexpdate
+	_, err1 := repo.InitTargets("targets/noexp")
+	require.NoError(t, err1)
+	repo.Targets["targets/noexp"].Signed.Expires = notnearexpdate
+	//Reset levels to display warnings through logrus
+	orgLevel := log.GetLevel()
+	log.SetLevel(log.WarnLevel)
+	defer log.SetLevel(orgLevel)
+	a := bytes.NewBuffer(nil)
+	log.SetOutput(a)
+	warnRolesNearExpiry(repo)
+	require.NotContains(t, a.String(), "targets metadata is nearing expiry, you should re-sign the role metadata", "targets should not show near expiry")
+	require.NotContains(t, a.String(), "targets/noexp metadata is nearing expiry, you should re-sign the role metadata", "targets/noexp should not show near expiry")
+	require.NotContains(t, a.String(), "root is nearing expiry, you should re-sign the role metadata", "Root should not show near expiry")
+	require.NotContains(t, a.String(), "snapshot is nearing expiry, you should re-sign the role metadata", "Snapshot should not show near expiry")
+	require.NotContains(t, a.String(), "timestamp", "there should be no logrus warnings pertaining to timestamp")
 }

--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -12,8 +12,6 @@ import (
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
-	"github.com/docker/notary/tuf/utils"
-	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 
 	tuf "github.com/docker/notary/tuf"
@@ -140,23 +138,6 @@ func CopyRepoMetadata(from map[string][]byte) map[string][]byte {
 		copied[roleName] = metaBytes
 	}
 	return copied
-}
-
-// AddTarget generates a fake target and adds it to a repo.
-func AddTarget(role string, r *tuf.Repo) (name string, meta data.FileMeta, content []byte, err error) {
-	randness := fuzz.Continue{}
-	content = RandomByteSlice(1024)
-	name = randness.RandString()
-	t := data.FileMeta{
-		Length: int64(len(content)),
-		Hashes: data.Hashes{
-			"sha256": utils.DoHash("sha256", content),
-			"sha512": utils.DoHash("sha512", content),
-		},
-	}
-	files := data.Files{name: t}
-	_, err = r.AddTargets(role, files)
-	return
 }
 
 // RandomByteSlice generates some random data to be used for testing only


### PR DESCRIPTION
Warnings are now output on read and write actions. Should indicate which role will be expiring soon and will need to be re-signed.
Also deleted an unused function in testutils- AddTarget
closes #733 