### PR TITLE
remove literal copy of sync.Mutex from memory store

### DIFF
--- a/trustmanager/keyfilestore.go
+++ b/trustmanager/keyfilestore.go
@@ -210,10 +210,11 @@ func NewKeyMemoryStore(passphraseRetriever notary.PassRetriever) *KeyMemoryStore
 
 	keyInfoMap := make(keyInfoMap)
 
-	keyStore := &KeyMemoryStore{MemoryFileStore: *memStore,
-		PassRetriever: passphraseRetriever,
-		cachedKeys:    cachedKeys,
-		keyInfoMap:    keyInfoMap,
+	keyStore := &KeyMemoryStore{
+		MemoryFileStore: *memStore,
+		PassRetriever:   passphraseRetriever,
+		cachedKeys:      cachedKeys,
+		keyInfoMap:      keyInfoMap,
 	}
 
 	// Load this keystore's ID --> gun/role map

--- a/trustmanager/memorystore.go
+++ b/trustmanager/memorystore.go
@@ -1,15 +1,11 @@
 package trustmanager
 
-import (
-	"os"
-	"sync"
-)
+import "os"
 
-// MemoryFileStore is an implementation of Storage that keeps
-// the contents in memory.
+// MemoryFileStore is an implementation of Storage that keeps the contents in
+// memory. It is not thread-safe and should be used by a higher-level interface
+// that provides locking.
 type MemoryFileStore struct {
-	sync.Mutex
-
 	files map[string][]byte
 }
 
@@ -22,18 +18,12 @@ func NewMemoryFileStore() *MemoryFileStore {
 
 // Add writes data to a file with a given name
 func (f *MemoryFileStore) Add(name string, data []byte) error {
-	f.Lock()
-	defer f.Unlock()
-
 	f.files[name] = data
 	return nil
 }
 
 // Remove removes a file identified by name
 func (f *MemoryFileStore) Remove(name string) error {
-	f.Lock()
-	defer f.Unlock()
-
 	if _, present := f.files[name]; !present {
 		return os.ErrNotExist
 	}
@@ -44,9 +34,6 @@ func (f *MemoryFileStore) Remove(name string) error {
 
 // Get returns the data given a file name
 func (f *MemoryFileStore) Get(name string) ([]byte, error) {
-	f.Lock()
-	defer f.Unlock()
-
 	fileData, present := f.files[name]
 	if !present {
 		return nil, os.ErrNotExist


### PR DESCRIPTION
Attempted fix of #792. The locks seem to be covered already by the KeyMemoryStore, which is the only place that uses MemoryFileStore.

I think the go vet issue at hand is https://github.com/golang/go/issues/13675#issuecomment-165798626