### PR TITLE
Add info logging for 400s, error for 500s, adjust timestamp error level on GetCurrent

### DIFF
--- a/server/timestamp/timestamp.go
+++ b/server/timestamp/timestamp.go
@@ -62,7 +62,7 @@ func GetOrCreateTimestamp(gun string, store storage.MetaStore, cryptoService sig
 
 	lastModified, timestampJSON, err := store.GetCurrent(gun, data.CanonicalTimestampRole)
 	if err != nil {
-		logrus.Error("error retrieving timestamp: ", err.Error())
+		logrus.Debug("error retrieving timestamp: ", err.Error())
 		return nil, nil, err
 	}
 

--- a/utils/http.go
+++ b/utils/http.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/auth"
@@ -79,9 +78,19 @@ func (root *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx = authCtx
 	}
 	if err := root.handler(ctx, w, r); err != nil {
+		if httpErr, ok := err.(errcode.ErrorCoder); ok {
+			// info level logging for non-5XX http errors
+			httpErrCode := httpErr.ErrorCode().Descriptor().HTTPStatusCode
+			if (httpErrCode < http.StatusOK || httpErrCode >= http.StatusMultipleChoices) && httpErrCode < http.StatusInternalServerError {
+				log.Info(httpErr)
+			} else if httpErrCode >= http.StatusInternalServerError {
+				// error level logging for 5XX http errors
+				log.Error(httpErr)
+			}
+		}
 		e := errcode.ServeJSON(w, err)
 		if e != nil {
-			logrus.Error(e)
+			log.Error(e)
 		}
 		return
 	}

--- a/utils/http.go
+++ b/utils/http.go
@@ -81,11 +81,11 @@ func (root *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if httpErr, ok := err.(errcode.ErrorCoder); ok {
 			// info level logging for non-5XX http errors
 			httpErrCode := httpErr.ErrorCode().Descriptor().HTTPStatusCode
-			if (httpErrCode < http.StatusOK || httpErrCode >= http.StatusMultipleChoices) && httpErrCode < http.StatusInternalServerError {
-				log.Info(httpErr)
-			} else if httpErrCode >= http.StatusInternalServerError {
+			if httpErrCode >= http.StatusInternalServerError {
 				// error level logging for 5XX http errors
 				log.Error(httpErr)
+			} else {
+				log.Info(httpErr)
 			}
 		}
 		e := errcode.ServeJSON(w, err)


### PR DESCRIPTION
Adds info-level logging for 4XX errors and error-level for 5XX in the server.  Also lowers errors on retrieving timestamps to debug-level.

Closes #766

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>