### PR TITLE
Validate root rotations against trust pinning where appropriate

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -870,8 +870,9 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*TUFClient, e
 		if err := newBuilder.Load(data.CanonicalRootRole, rootJSON, minVersion, false); err != nil {
 			// Ok, the old root is expired - we want to download a new one.  But we want to use the
 			// old root to verify the new root, so bootstrap a new builder with the old builder
+			// but use the trustpinning to validate the new root
 			minVersion = oldBuilder.GetLoadedVersion(data.CanonicalRootRole)
-			newBuilder = oldBuilder.BootstrapNewBuilder()
+			newBuilder = oldBuilder.BootstrapNewBuilderWithNewTrustpin(r.trustPinning)
 		}
 	}
 

--- a/trustpinning/certs.go
+++ b/trustpinning/certs.go
@@ -107,7 +107,8 @@ func ValidateRoot(prevRoot *data.SignedRoot, root *data.Signed, gun string, trus
 	logrus.Debugf("found %d leaf certs, of which %d are valid leaf certs for %s", len(allLeafCerts), len(certsFromRoot), gun)
 
 	// If we have a previous root, let's try to use it to validate that this new root is valid.
-	if prevRoot != nil {
+	havePrevRoot := prevRoot != nil
+	if havePrevRoot {
 		// Retrieve all the trusted certificates from our previous root
 		// Note that we do not validate expiries here since our originally trusted root might have expired certs
 		allTrustedLeafCerts, allTrustedIntCerts := parseAllCerts(prevRoot)
@@ -133,27 +134,29 @@ func ValidateRoot(prevRoot *data.SignedRoot, root *data.Signed, gun string, trus
 			logrus.Debugf("failed to verify TUF data for: %s, %v", gun, err)
 			return nil, &ErrRootRotationFail{Reason: "failed to validate data with current trusted certificates"}
 		}
-	} else {
-		logrus.Debugf("found no currently valid root certificates for %s, using trust_pinning config to bootstrap trust", gun)
-		trustPinCheckFunc, err := NewTrustPinChecker(trustPinning, gun)
-		if err != nil {
-			return nil, &ErrValidationFail{Reason: err.Error()}
-		}
-
-		validPinnedCerts := map[string]*x509.Certificate{}
-		for id, cert := range certsFromRoot {
-			logrus.Debugf("checking trust-pinning for cert: %s", id)
-			if ok := trustPinCheckFunc(cert, validIntCerts[id]); !ok {
-				logrus.Debugf("trust-pinning check failed for cert: %s", id)
-				continue
-			}
-			validPinnedCerts[id] = cert
-		}
-		if len(validPinnedCerts) == 0 {
-			return nil, &ErrValidationFail{Reason: "unable to match any certificates to trust_pinning config"}
-		}
-		certsFromRoot = validPinnedCerts
 	}
+
+
+	// Regardless of having a previous root or not, confirm that the new root validates against the trust pinning
+	logrus.Debugf("checking root against trust_pinning config", gun)
+	trustPinCheckFunc, err := NewTrustPinChecker(trustPinning, gun, !havePrevRoot)
+	if err != nil {
+		return nil, &ErrValidationFail{Reason: err.Error()}
+	}
+
+	validPinnedCerts := map[string]*x509.Certificate{}
+	for id, cert := range certsFromRoot {
+		logrus.Debugf("checking trust-pinning for cert: %s", id)
+		if ok := trustPinCheckFunc(cert, validIntCerts[id]); !ok {
+			logrus.Debugf("trust-pinning check failed for cert: %s", id)
+			continue
+		}
+		validPinnedCerts[id] = cert
+	}
+	if len(validPinnedCerts) == 0 {
+		return nil, &ErrValidationFail{Reason: "unable to match any certificates to trust_pinning config"}
+	}
+	certsFromRoot = validPinnedCerts
 
 	// Validate the integrity of the new root (does it have valid signatures)
 	// Note that certsFromRoot is guaranteed to be unchanged only if we had prior cert data for this GUN or enabled TOFUS

--- a/trustpinning/certs_test.go
+++ b/trustpinning/certs_test.go
@@ -795,6 +795,200 @@ func testValidateRootRotationMissingNewSig(t *testing.T, keyAlg, rootKeyType str
 	require.Error(t, err, "insufficient signatures on root")
 }
 
+// TestValidateRootRotationTrustPinning runs a full root certificate rotation but ensures that
+// the specified trust pinning is respected with the new root for the Certs and TOFUs settings
+func TestValidateRootRotationTrustPinning(t *testing.T) {
+	// The gun to test
+	gun := "docker.com/notary"
+
+	memKeyStore := trustmanager.NewKeyMemoryStore(passphraseRetriever)
+	cs := cryptoservice.NewCryptoService(memKeyStore)
+
+	// TUF key with PEM-encoded x509 certificate
+	origRootKey, err := testutils.CreateKey(cs, gun, data.CanonicalRootRole, data.RSAKey)
+	require.NoError(t, err)
+
+	origRootRole, err := data.NewRole(data.CanonicalRootRole, 1, []string{origRootKey.ID()}, nil)
+	require.NoError(t, err)
+
+	origTestRoot, err := data.NewRoot(
+		map[string]data.PublicKey{origRootKey.ID(): origRootKey},
+		map[string]*data.RootRole{
+			data.CanonicalRootRole:      &origRootRole.RootRole,
+			data.CanonicalTargetsRole:   &origRootRole.RootRole,
+			data.CanonicalSnapshotRole:  &origRootRole.RootRole,
+			data.CanonicalTimestampRole: &origRootRole.RootRole,
+		},
+		false,
+	)
+	origTestRoot.Signed.Version = 1
+	require.NoError(t, err, "Failed to create new root")
+
+	signedOrigTestRoot, err := origTestRoot.ToSigned()
+	require.NoError(t, err)
+
+	err = signed.Sign(cs, signedOrigTestRoot, []data.PublicKey{origRootKey}, 1, nil)
+	require.NoError(t, err)
+	prevRoot, err := data.RootFromSigned(signedOrigTestRoot)
+	require.NoError(t, err)
+
+	// TUF key with PEM-encoded x509 certificate
+	replRootKey, err := testutils.CreateKey(cs, gun, data.CanonicalRootRole, data.RSAKey)
+	require.NoError(t, err)
+
+	rootRole, err := data.NewRole(data.CanonicalRootRole, 1, []string{replRootKey.ID()}, nil)
+	require.NoError(t, err)
+
+	testRoot, err := data.NewRoot(
+		map[string]data.PublicKey{replRootKey.ID(): replRootKey},
+		map[string]*data.RootRole{
+			data.CanonicalRootRole:      &rootRole.RootRole,
+			data.CanonicalTimestampRole: &rootRole.RootRole,
+			data.CanonicalTargetsRole:   &rootRole.RootRole,
+			data.CanonicalSnapshotRole:  &rootRole.RootRole},
+		false,
+	)
+	testRoot.Signed.Version = 1
+	require.NoError(t, err, "Failed to create new root")
+
+	signedTestRoot, err := testRoot.ToSigned()
+	require.NoError(t, err)
+
+	err = signed.Sign(cs, signedTestRoot, []data.PublicKey{replRootKey, origRootKey}, 2, nil)
+	require.NoError(t, err)
+
+	typedSignedRoot, err := data.RootFromSigned(signedTestRoot)
+	require.NoError(t, err)
+
+	// This call to trustpinning.ValidateRoot will fail due to the trust pinning mismatch in certs
+	invalidCertConfig := trustpinning.TrustPinConfig{
+		Certs: map[string][]string{
+			gun: {origRootKey.ID()},
+		},
+		DisableTOFU: true,
+	}
+	_, err = trustpinning.ValidateRoot(prevRoot, signedTestRoot, gun, invalidCertConfig)
+	require.Error(t, err)
+
+	// This call will succeed since we include the new root cert ID (and the old one)
+	validCertConfig := trustpinning.TrustPinConfig{
+		Certs: map[string][]string{
+			gun: {origRootKey.ID(), replRootKey.ID()},
+		},
+		DisableTOFU: true,
+	}
+	validatedRoot, err := trustpinning.ValidateRoot(prevRoot, signedTestRoot, gun, validCertConfig)
+	require.NoError(t, err)
+	generateRootKeyIDs(typedSignedRoot)
+	require.Equal(t, typedSignedRoot, validatedRoot)
+
+	// This call will also succeed since we only need the new replacement root ID to be pinned
+	validCertConfig = trustpinning.TrustPinConfig{
+		Certs: map[string][]string{
+			gun: {replRootKey.ID()},
+		},
+		DisableTOFU: true,
+	}
+	validatedRoot, err = trustpinning.ValidateRoot(prevRoot, signedTestRoot, gun, validCertConfig)
+	require.NoError(t, err)
+	generateRootKeyIDs(typedSignedRoot)
+	require.Equal(t, typedSignedRoot, validatedRoot)
+
+	// Even if we disable TOFU in the trustpinning, since we have a previously trusted root we should honor a valid rotation
+	validatedRoot, err = trustpinning.ValidateRoot(prevRoot, signedTestRoot, gun, trustpinning.TrustPinConfig{DisableTOFU: true})
+	require.NoError(t, err)
+	generateRootKeyIDs(typedSignedRoot)
+	require.Equal(t, typedSignedRoot, validatedRoot)
+}
+
+// TestValidateRootRotationTrustPinningInvalidCA runs a full root certificate rotation but ensures that
+// the specified trust pinning rejectas the new root for not being signed by the specified CA
+func TestValidateRootRotationTrustPinningInvalidCA(t *testing.T) {
+	gun := "notary-signer"
+	keyAlg := data.RSAKey
+	// Temporary directory where test files will be created
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
+	defer os.RemoveAll(tempBaseDir)
+	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+
+	leafCert, err := trustmanager.LoadCertFromFile("../fixtures/notary-signer.crt")
+	require.NoError(t, err)
+
+	intermediateCert, err := trustmanager.LoadCertFromFile("../fixtures/intermediate-ca.crt")
+	require.NoError(t, err)
+
+	pemChainBytes, err := trustmanager.CertChainToPEM([]*x509.Certificate{leafCert, intermediateCert})
+	require.NoError(t, err)
+
+	origRootKey := data.NewPublicKey(data.RSAx509Key, pemChainBytes)
+
+	rootRole, err := data.NewRole(data.CanonicalRootRole, 1, []string{origRootKey.ID()}, nil)
+	require.NoError(t, err)
+
+	testRoot, err := data.NewRoot(
+		map[string]data.PublicKey{origRootKey.ID(): origRootKey},
+		map[string]*data.RootRole{
+			data.CanonicalRootRole:      &rootRole.RootRole,
+			data.CanonicalTimestampRole: &rootRole.RootRole,
+			data.CanonicalTargetsRole:   &rootRole.RootRole,
+			data.CanonicalSnapshotRole:  &rootRole.RootRole},
+		false,
+	)
+	testRoot.Signed.Version = 1
+	require.NoError(t, err, "Failed to create new root")
+
+	keyReader, err := os.Open("../fixtures/notary-signer.key")
+	require.NoError(t, err, "could not open key file")
+	pemBytes, err := ioutil.ReadAll(keyReader)
+	require.NoError(t, err, "could not read key file")
+	privKey, err := trustmanager.ParsePEMPrivateKey(pemBytes, "")
+	require.NoError(t, err)
+
+	store, err := trustmanager.NewKeyFileStore(tempBaseDir, passphraseRetriever)
+	require.NoError(t, err)
+	cs := cryptoservice.NewCryptoService(store)
+
+	err = store.AddKey(trustmanager.KeyInfo{Role: data.CanonicalRootRole, Gun: gun}, privKey)
+	require.NoError(t, err)
+
+	origSignedTestRoot, err := testRoot.ToSigned()
+	require.NoError(t, err)
+
+	err = signed.Sign(cs, origSignedTestRoot, []data.PublicKey{origRootKey}, 1, nil)
+	require.NoError(t, err)
+	prevRoot, err := data.RootFromSigned(origSignedTestRoot)
+	require.NoError(t, err)
+
+	// generate a new TUF key with PEM-encoded x509 certificate, not signed by our pinned CA
+	replRootKey, err := testutils.CreateKey(cs, gun, data.CanonicalRootRole, keyAlg)
+	require.NoError(t, err)
+
+	_, err = data.NewRole(data.CanonicalRootRole, 1, []string{replRootKey.ID()}, nil)
+	require.NoError(t, err)
+	newRoot, err := data.NewRoot(
+		map[string]data.PublicKey{replRootKey.ID(): replRootKey},
+		map[string]*data.RootRole{
+			data.CanonicalRootRole:      &rootRole.RootRole,
+			data.CanonicalTimestampRole: &rootRole.RootRole,
+			data.CanonicalTargetsRole:   &rootRole.RootRole,
+			data.CanonicalSnapshotRole:  &rootRole.RootRole},
+		false,
+	)
+	newRoot.Signed.Version = 1
+	require.NoError(t, err, "Failed to create new root")
+
+	newSignedTestRoot, err := newRoot.ToSigned()
+	require.NoError(t, err)
+
+	err = signed.Sign(cs, newSignedTestRoot, []data.PublicKey{replRootKey, origRootKey}, 2, nil)
+	require.NoError(t, err)
+
+	// Check that we respect the trust pinning on rotation
+	validCAFilepath := "../fixtures/root-ca.crt"
+	_, err = trustpinning.ValidateRoot(prevRoot, newSignedTestRoot, gun, trustpinning.TrustPinConfig{CA: map[string]string{gun: validCAFilepath}, DisableTOFU: true})
+	require.Error(t, err)
+}
+
 func generateTestingCertificate(rootKey data.PrivateKey, gun string, timeToExpire time.Duration) (*x509.Certificate, error) {
 	startTime := time.Now()
 	return cryptoservice.GenerateCertificate(rootKey, gun, startTime, startTime.Add(timeToExpire))

--- a/trustpinning/certs_test.go
+++ b/trustpinning/certs_test.go
@@ -361,7 +361,11 @@ func TestValidateRootWithPinnedCertAndIntermediates(t *testing.T) {
 		},
 	)
 	require.NoError(t, err, "failed to validate certID with intermediate")
-	typedSignedRoot.Signatures[0].IsValid = true
+	for idx, sig := range typedSignedRoot.Signatures {
+		if sig.KeyID == ecdsax509Key.ID() {
+			typedSignedRoot.Signatures[idx].IsValid = true
+		}
+	}
 	require.Equal(t, typedSignedRoot, validatedRoot)
 }
 
@@ -503,7 +507,11 @@ func TestValidateRootWithPinnedCA(t *testing.T) {
 	// Check that we validate correctly against a pinned CA and provided bundle
 	validatedRoot, err = trustpinning.ValidateRoot(nil, newTestSignedRoot, "notary-signer", trustpinning.TrustPinConfig{CA: map[string]string{"notary-signer": validCAFilepath}, DisableTOFU: true})
 	require.NoError(t, err)
-	newTypedSignedRoot.Signatures[0].IsValid = true
+	for idx, sig := range newTypedSignedRoot.Signatures {
+		if sig.KeyID == newRootKey.ID() {
+			newTypedSignedRoot.Signatures[idx].IsValid = true
+		}
+	}
 	require.Equal(t, newTypedSignedRoot, validatedRoot)
 
 	// Add an expired CA for the same gun to our previous pinned bundle, ensure that we still validate correctly
@@ -525,8 +533,6 @@ func TestValidateRootWithPinnedCA(t *testing.T) {
 	// Check that we validate correctly against a pinned CA and provided bundle
 	validatedRoot, err = trustpinning.ValidateRoot(nil, newTestSignedRoot, "notary-signer", trustpinning.TrustPinConfig{CA: map[string]string{"notary-signer": bundleWithExpiredCertPath}, DisableTOFU: true})
 	require.NoError(t, err)
-	// this extra assignment is necessary because ValidateRoot calls through to a successful VerifySignature which marks IsValid
-	newTypedSignedRoot.Signatures[0].IsValid = true
 	require.Equal(t, newTypedSignedRoot, validatedRoot)
 
 	testPubKey2, err := cryptoService.Create("root", "notary-signer", data.ECDSAKey)
@@ -634,7 +640,11 @@ func testValidateSuccessfulRootRotation(t *testing.T, keyAlg, rootKeyType string
 	// encoded certificate, and have no other certificates for this CN
 	validatedRoot, err := trustpinning.ValidateRoot(prevRoot, signedTestRoot, gun, trustpinning.TrustPinConfig{})
 	require.NoError(t, err)
-	typedSignedRoot.Signatures[0].IsValid = true
+	for idx, sig := range typedSignedRoot.Signatures {
+		if sig.KeyID == replRootKey.ID() {
+			typedSignedRoot.Signatures[idx].IsValid = true
+		}
+	}
 	require.Equal(t, typedSignedRoot, validatedRoot)
 }
 

--- a/trustpinning/certs_test.go
+++ b/trustpinning/certs_test.go
@@ -902,7 +902,7 @@ func TestValidateRootRotationTrustPinning(t *testing.T) {
 }
 
 // TestValidateRootRotationTrustPinningInvalidCA runs a full root certificate rotation but ensures that
-// the specified trust pinning rejectas the new root for not being signed by the specified CA
+// the specified trust pinning rejects the new root for not being signed by the specified CA
 func TestValidateRootRotationTrustPinningInvalidCA(t *testing.T) {
 	gun := "notary-signer"
 	keyAlg := data.RSAKey
@@ -911,13 +911,13 @@ func TestValidateRootRotationTrustPinningInvalidCA(t *testing.T) {
 	defer os.RemoveAll(tempBaseDir)
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
-	leafCert, err := trustmanager.LoadCertFromFile("../fixtures/notary-signer.crt")
+	leafCert, err := utils.LoadCertFromFile("../fixtures/notary-signer.crt")
 	require.NoError(t, err)
 
-	intermediateCert, err := trustmanager.LoadCertFromFile("../fixtures/intermediate-ca.crt")
+	intermediateCert, err := utils.LoadCertFromFile("../fixtures/intermediate-ca.crt")
 	require.NoError(t, err)
 
-	pemChainBytes, err := trustmanager.CertChainToPEM([]*x509.Certificate{leafCert, intermediateCert})
+	pemChainBytes, err := utils.CertChainToPEM([]*x509.Certificate{leafCert, intermediateCert})
 	require.NoError(t, err)
 
 	origRootKey := data.NewPublicKey(data.RSAx509Key, pemChainBytes)
@@ -937,11 +937,9 @@ func TestValidateRootRotationTrustPinningInvalidCA(t *testing.T) {
 	testRoot.Signed.Version = 1
 	require.NoError(t, err, "Failed to create new root")
 
-	keyReader, err := os.Open("../fixtures/notary-signer.key")
-	require.NoError(t, err, "could not open key file")
-	pemBytes, err := ioutil.ReadAll(keyReader)
+	pemBytes, err := ioutil.ReadFile("../fixtures/notary-signer.key")
 	require.NoError(t, err, "could not read key file")
-	privKey, err := trustmanager.ParsePEMPrivateKey(pemBytes, "")
+	privKey, err := utils.ParsePEMPrivateKey(pemBytes, "")
 	require.NoError(t, err)
 
 	store, err := trustmanager.NewKeyFileStore(tempBaseDir, passphraseRetriever)

--- a/trustpinning/trustpin.go
+++ b/trustpinning/trustpin.go
@@ -62,16 +62,10 @@ func NewTrustPinChecker(trustPinConfig TrustPinConfig, gun string, firstBootstra
 		return t.caCheck, nil
 	}
 
-	if !trustPinConfig.DisableTOFU {
-		logrus.Debugf("trust-pinning: using TOFU")
-		return t.tofusCheck, nil
-	}
-
-	// If we already have previous trusted root data for this GUN, disabling TOFUs should not change trust
-	// At this point, we assume that we have already trusted previous root data and so will not perform any
-	// additional trust pinning checks on this new certificate
-	if !firstBootstrap {
-		logrus.Debug("TOFU is disabled but previous root data exists, skipping disable TOFU restriction")
+	// If TOFUs is not disabled or we already have previous trusted root data for this GUN (even with TOFUs disabled),
+	// use TOFUs.  It's ok if we have previous root data with TOFUs disabled because we've already
+	// bootstrapped the first use of trust
+	if !trustPinConfig.DisableTOFU || !firstBootstrap {
 		return t.tofusCheck, nil
 	}
 	return nil, fmt.Errorf("invalid trust pinning specified")

--- a/trustpinning/trustpin.go
+++ b/trustpinning/trustpin.go
@@ -62,13 +62,12 @@ func NewTrustPinChecker(trustPinConfig TrustPinConfig, gun string, firstBootstra
 		return t.caCheck, nil
 	}
 
-	// If TOFUs is not disabled or we already have previous trusted root data for this GUN (even with TOFUs disabled),
-	// use TOFUs.  It's ok if we have previous root data with TOFUs disabled because we've already
-	// bootstrapped the first use of trust
-	if !trustPinConfig.DisableTOFU || !firstBootstrap {
-		return t.tofusCheck, nil
+	// If TOFUs is disabled and we don't have any previous trusted root data for this GUN, we error out
+	if trustPinConfig.DisableTOFU && firstBootstrap {
+		return nil, fmt.Errorf("invalid trust pinning specified")
+
 	}
-	return nil, fmt.Errorf("invalid trust pinning specified")
+	return t.tofusCheck, nil
 }
 
 func (t trustPinChecker) certsCheck(leafCert *x509.Certificate, intCerts []*x509.Certificate) bool {


### PR DESCRIPTION
Check new roots against the trust pinning when performing validation, but do not reject the new root if TOFUs is disabled because we've already trusted a previous root.
 
Closes #735.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>