### PR TITLE
Support passing in root keys on repo initialization

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -167,7 +167,7 @@ func initializeRepo(t *testing.T, rootType, gun, url string,
 
 	repo, rec, rootPubKeyID := createRepoAndKey(t, rootType, tempBaseDir, gun, url)
 
-	err = repo.Initialize(rootPubKeyID, serverManagedRoles...)
+	err = repo.Initialize([]string{rootPubKeyID}, serverManagedRoles...)
 	if err != nil {
 		os.RemoveAll(tempBaseDir)
 	}
@@ -241,7 +241,7 @@ func TestInitRepositoryManagedRolesIncludingRoot(t *testing.T) {
 
 	repo, rec, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", "http://localhost")
-	err = repo.Initialize(rootPubKeyID, data.CanonicalRootRole)
+	err = repo.Initialize([]string{rootPubKeyID}, data.CanonicalRootRole)
 	require.Error(t, err)
 	require.IsType(t, ErrInvalidRemoteRole{}, err)
 	// Just testing the error message here in this one case
@@ -261,7 +261,7 @@ func TestInitRepositoryManagedRolesInvalidRole(t *testing.T) {
 
 	repo, rec, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", "http://localhost")
-	err = repo.Initialize(rootPubKeyID, "randomrole")
+	err = repo.Initialize([]string{rootPubKeyID}, "randomrole")
 	require.Error(t, err)
 	require.IsType(t, ErrInvalidRemoteRole{}, err)
 	// no key creation happened
@@ -278,7 +278,7 @@ func TestInitRepositoryManagedRolesIncludingTargets(t *testing.T) {
 
 	repo, rec, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", "http://localhost")
-	err = repo.Initialize(rootPubKeyID, data.CanonicalTargetsRole)
+	err = repo.Initialize([]string{rootPubKeyID}, data.CanonicalTargetsRole)
 	require.Error(t, err)
 	require.IsType(t, ErrInvalidRemoteRole{}, err)
 	// no key creation happened
@@ -298,10 +298,35 @@ func TestInitRepositoryManagedRolesIncludingTimestamp(t *testing.T) {
 
 	repo, rec, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
-	err = repo.Initialize(rootPubKeyID, data.CanonicalTimestampRole)
+	err = repo.Initialize([]string{rootPubKeyID}, data.CanonicalTimestampRole)
 	require.NoError(t, err)
+
 	// generates the target role, the snapshot role
 	rec.requireCreated(t, []string{data.CanonicalTargetsRole, data.CanonicalSnapshotRole})
+}
+
+func TestInitRepositoryMultipleRootKeys(t *testing.T) {
+	// Temporary directory where test files will be created
+	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	require.NoError(t, err, "failed to create a temporary directory")
+	defer os.RemoveAll(tempBaseDir)
+
+	ts, _, _ := simpleTestServer(t)
+	defer ts.Close()
+
+	repo, rec, rootPubKeyID := createRepoAndKey(
+		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
+	rootPubKey2, err := repo.CryptoService.Create("root", repo.gun, data.ECDSAKey)
+	require.NoError(t, err, "error generating second root key: %s", err)
+
+	err = repo.Initialize([]string{rootPubKeyID, rootPubKey2.ID()}, data.CanonicalTimestampRole)
+	require.NoError(t, err)
+
+	// generates the target role, the snapshot role
+	rec.requireCreated(t, []string{data.CanonicalTargetsRole, data.CanonicalSnapshotRole})
+
+	// has two root keys
+	require.Len(t, repo.tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs, 2)
 }
 
 // Initializing a new repo fails if unable to get the timestamp key, even if
@@ -317,7 +342,7 @@ func TestInitRepositoryNeedsRemoteTimestampKey(t *testing.T) {
 
 	repo, rec, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
-	err = repo.Initialize(rootPubKeyID, data.CanonicalTimestampRole)
+	err = repo.Initialize([]string{rootPubKeyID}, data.CanonicalTimestampRole)
 	require.Error(t, err)
 	require.IsType(t, store.ErrMetaNotFound{}, err)
 
@@ -339,7 +364,7 @@ func TestInitRepositoryNeedsRemoteSnapshotKey(t *testing.T) {
 
 	repo, rec, rootPubKeyID := createRepoAndKey(
 		t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
-	err = repo.Initialize(rootPubKeyID, data.CanonicalSnapshotRole)
+	err = repo.Initialize([]string{rootPubKeyID}, data.CanonicalSnapshotRole)
 	require.Error(t, err)
 	require.IsType(t, store.ErrMetaNotFound{}, err)
 
@@ -516,9 +541,9 @@ func testInitRepoSigningKeys(t *testing.T, rootType string, serverManagesSnapsho
 	repo, rec := newRepoToTestRepo(t, repo, false)
 
 	if serverManagesSnapshot {
-		err = repo.Initialize(rootPubKeyID, data.CanonicalSnapshotRole)
+		err = repo.Initialize([]string{rootPubKeyID}, data.CanonicalSnapshotRole)
 	} else {
-		err = repo.Initialize(rootPubKeyID)
+		err = repo.Initialize([]string{rootPubKeyID})
 	}
 
 	require.NoError(t, err, "error initializing repository")
@@ -563,7 +588,7 @@ func testInitRepoAttemptsExceeded(t *testing.T, rootType string) {
 	// private key unlocking we need a new repo instance.
 	repo, err = NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, retriever, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
-	err = repo.Initialize(rootPubKey.ID())
+	err = repo.Initialize([]string{rootPubKey.ID()})
 	require.EqualError(t, err, trustmanager.ErrAttemptsExceeded{}.Error())
 }
 
@@ -600,7 +625,7 @@ func testInitRepoPasswordInvalid(t *testing.T, rootType string) {
 	// private key unlocking we need a new repo instance.
 	repo, err = NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, giveUpPassphraseRetriever, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
-	err = repo.Initialize(rootPubKey.ID())
+	err = repo.Initialize([]string{rootPubKey.ID()})
 	require.EqualError(t, err, trustmanager.ErrPasswordInvalid{}.Error())
 }
 
@@ -1650,7 +1675,7 @@ func TestPublishUninitializedRepo(t *testing.T) {
 	rootPubKey, err := repo.CryptoService.Create("root", repo.gun, data.ECDSAKey)
 	require.NoError(t, err, "error generating root key: %s", err)
 
-	require.NoError(t, repo.Initialize(rootPubKey.ID()))
+	require.NoError(t, repo.Initialize([]string{rootPubKey.ID()}))
 
 	// now metadata is created
 	requireRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, true)
@@ -2011,7 +2036,7 @@ func TestPublishSnapshotLocalKeysCreatedFirst(t *testing.T) {
 
 	repo.CryptoService = cannotCreateKeys{CryptoService: cs}
 
-	err = repo.Initialize(rootPubKey.ID(), data.CanonicalSnapshotRole)
+	err = repo.Initialize([]string{rootPubKey.ID()}, data.CanonicalSnapshotRole)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Oh no I cannot create keys")
 	require.False(t, requestMade)

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -336,7 +336,7 @@ func setUpRepo(t *testing.T, tempBaseDir, gun string, ret notary.PassRetriever) 
 	rootPubKey, err := repo.CryptoService.Create("root", "", data.ECDSAKey)
 	require.NoError(t, err, "error generating root key: %s", err)
 
-	err = repo.Initialize(rootPubKey.ID())
+	err = repo.Initialize([]string{rootPubKey.ID()})
 	require.NoError(t, err)
 
 	return ts, repo.CryptoService.ListAllKeys()

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -19,6 +20,8 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/docker/notary"
 	notaryclient "github.com/docker/notary/client"
+	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/trustpinning"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/utils"
@@ -86,9 +89,10 @@ type tufCommander struct {
 	retriever    notary.PassRetriever
 
 	// these are for command line parsing - no need to set
-	roles  []string
-	sha256 string
-	sha512 string
+	roles   []string
+	sha256  string
+	sha512  string
+	rootKey string
 
 	input  string
 	output string
@@ -96,7 +100,10 @@ type tufCommander struct {
 }
 
 func (t *tufCommander) AddToCommand(cmd *cobra.Command) {
-	cmd.AddCommand(cmdTUFInitTemplate.ToCommand(t.tufInit))
+	cmdTUFInit := cmdTUFInitTemplate.ToCommand(t.tufInit)
+	cmdTUFInit.Flags().StringVar(&t.rootKey, "rootkey", "", "Root key to initialize the repository with")
+	cmd.AddCommand(cmdTUFInit)
+
 	cmd.AddCommand(cmdTUFStatusTemplate.ToCommand(t.tufStatus))
 	cmd.AddCommand(cmdTUFPublishTemplate.ToCommand(t.tufPublish))
 	cmd.AddCommand(cmdTUFLookupTemplate.ToCommand(t.tufLookup))
@@ -268,7 +275,36 @@ func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rootKeyList := nRepo.CryptoService.ListKeys(data.CanonicalRootRole)
+	var rootKeyList []string
+
+	if t.rootKey != "" {
+		keyFile, err := os.Open(t.rootKey)
+		if err != nil {
+			return fmt.Errorf("Opening file for import: %v", err)
+		}
+		defer keyFile.Close()
+
+		pemBytes, err := ioutil.ReadAll(keyFile)
+		if err != nil {
+			return fmt.Errorf("Error reading input file: %v", err)
+		}
+		if err = cryptoservice.CheckRootKeyIsEncrypted(pemBytes); err != nil {
+			return err
+		}
+
+		privKey, _, err := trustmanager.GetPasswdDecryptBytes(t.retriever, pemBytes, "", data.CanonicalRootRole)
+		if err != nil {
+			return err
+		}
+
+		err = nRepo.CryptoService.AddKey(data.CanonicalRootRole, "", privKey)
+		if err != nil {
+			return fmt.Errorf("Error importing key: %v", err)
+		}
+		rootKeyList = []string{data.PublicKeyFromPrivate(privKey).ID()}
+	} else {
+		rootKeyList = nRepo.CryptoService.ListKeys(data.CanonicalRootRole)
+	}
 
 	var rootKeyID string
 	if len(rootKeyList) < 1 {
@@ -285,7 +321,7 @@ func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {
 		cmd.Printf("Root key found, using: %s\n", rootKeyID)
 	}
 
-	if err = nRepo.Initialize(rootKeyID); err != nil {
+	if err = nRepo.Initialize([]string{rootKeyID}); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This addresses #731 by adding a `--rootkey` flag to `init`.

Example:
```
$ notary init my/collection --rootkey=keys/root.key
```
resulting root.json:
```json
{
	"signed": {
		"_type": "Root",
		"consistent_snapshot": false,
		"expires": "2026-06-21T14:20:03.15135742-04:00",
		"keys": {
			"956fbe52f38738cb5c31b1cbff06842ceda8e429f55164a61349cd233a50813f": {
				"keytype": "ecdsa-x509",
				"keyval": {
					"private": null,
					"public": "..."
				}
			}
			// ...
		},
		"roles": {
			"root": {
				"keyids": [
					"956fbe52f38738cb5c31b1cbff06842ceda8e429f55164a61349cd233a50813f"
				],
				"threshold": 1
			}
			// ...
		},
		"version": 1
	},
	"signatures": [{
		"keyid": "956fbe52f38738cb5c31b1cbff06842ceda8e429f55164a61349cd233a50813f",
		"method": "ecdsa",
		"sig": "70BvEbnWA1bHoc2IjnIE8XFI1N4I1WQxyd2GDNX/Avfmy89Z5J1w0pL507LpLd1DbV6p6CtqPgCdb5oCMeXt5w=="
	}
	}]
}
```

Additionally, the underlying TUF apis are updated to allow multiple root keys and certs, but that is not currently exposed to the CLI.