### PR TITLE
Include ineffassign in CI, fix ineffassign in code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd -ms /bin/bash notary \
 	&& pip install codecov \
-	&& go get golang.org/x/tools/cmd/cover github.com/golang/lint/golint github.com/client9/misspell/cmd/misspell
+	&& go get golang.org/x/tools/cmd/cover github.com/golang/lint/golint github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,16 @@ misspell:
 	@echo "+ $@"
 	@test -z "$$(find . -name '*' | grep -v vendor/ | grep -v bin/ | grep -v misc/ | grep -v .git/ | xargs misspell | tee /dev/stderr)"
 
+# Requires that the following:
+# go get -u github.com/gordonklaus/ineffassign
+#
+# be run first
+
+# ineffassign target, don't include Godeps, binaries, python tests, or git files
+ineffassign:
+	@echo "+ $@"
+	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)"
+
 build:
 	@echo "+ $@"
 	@go build -tags "${NOTARY_BUILDTAGS}" -v ${GO_LDFLAGS} $(PKGS)

--- a/buildscripts/circle_parallelism.sh
+++ b/buildscripts/circle_parallelism.sh
@@ -10,6 +10,6 @@ case $CIRCLE_NODE_INDEX in
    ;;
 3) SKIPENVCHECK=1 make TESTDB=rethink integration
    ;;
-4) docker run --rm -e NOTARY_BUILDTAGS=pkcs11 notary_client make vet lint fmt misspell
+4) docker run --rm -e NOTARY_BUILDTAGS=pkcs11 notary_client make vet lint fmt misspell ineffassign
    ;;
 esac

--- a/server/handlers/validation_test.go
+++ b/server/handlers/validation_test.go
@@ -604,7 +604,7 @@ func TestRootRotationNotSignedWithOldKeysForOldRole(t *testing.T) {
 
 	sn, err = repo.SignSnapshot(data.DefaultExpires(data.CanonicalSnapshotRole))
 	require.NoError(t, err)
-	root, targets, snapshot, timestamp, err = getUpdates(r, tg, sn, ts)
+	root, _, snapshot, _, err = getUpdates(r, tg, sn, ts)
 	require.NoError(t, err)
 
 	_, err = validateUpdate(serverCrypto, gun, []storage.MetaUpdate{root, snapshot}, store)


### PR DESCRIPTION
Adds the `ineffassign` target to our Makefile and circle tests, indirectly part of #815 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>