### PR TITLE
Wait for indexes in rethink table.wait

### DIFF
--- a/storage/rethinkdb/bootstrap.go
+++ b/storage/rethinkdb/bootstrap.go
@@ -47,6 +47,16 @@ func (t Table) wait(session *gorethink.Session, dbName string) error {
 		resp.Close()
 	}
 
+	if err != nil {
+		return err
+	}
+
+	// also try waiting for all table indices
+	resp, err = t.term(dbName).IndexWait().Run(session)
+
+	if resp != nil {
+		resp.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
We should call [indexWait](https://rethinkdb.com/api/javascript/index_wait/) in addition to just the table [wait](https://rethinkdb.com/api/javascript/wait/) to ensure that all indexes for the table are ready.

I can add unit-tests to the infrastructure in #824, though the rethink integration test checks out

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>