### PR TITLE
Refactor passphrase to cache passphrases individually

### DIFF
--- a/passphrase/passphrase_test.go
+++ b/passphrase/passphrase_test.go
@@ -69,11 +69,9 @@ func TestGetPassphraseForCreatingDelegationKey(t *testing.T) {
 	require.Equal(t, expectedText, lines)
 }
 
-// PromptRetrieverWithInOut, if asked for root, targets, delegation, and
-// snapshot passphrases in that order will only prompt for root, targets, and
-// delegation passphrases because it caches the targets password and uses it
-// for snapshot.
-func TestGetRootTargetsDelegation(t *testing.T) {
+// PromptRetrieverWithInOut, if asked for root, targets, snapshot, and delegation
+// passphrases in that order will cache each of the keys except for the delegation key
+func TestRolePromptingAndCaching(t *testing.T) {
 	var in bytes.Buffer
 	var out bytes.Buffer
 
@@ -81,16 +79,37 @@ func TestGetRootTargetsDelegation(t *testing.T) {
 
 	assertAskOnceForKey(t, &in, &out, retriever, "rootpassword", data.CanonicalRootRole)
 	assertAskOnceForKey(t, &in, &out, retriever, "targetspassword", data.CanonicalTargetsRole)
+	assertAskOnceForKey(t, &in, &out, retriever, "snapshotpassword", data.CanonicalSnapshotRole)
 	assertAskOnceForKey(t, &in, &out, retriever, "delegationpass", "targets/delegation")
 
-	// now ask for snapshot password, but it should already be cached, it
-	// won't ask and  no input necessary.
-	pass, giveUp, err := retriever("repo/0123456789abcdef", data.CanonicalSnapshotRole, false, 0)
+	// ask for root password, but it should already be cached
+	pass, giveUp, err := retriever("repo/0123456789abcdef", data.CanonicalRootRole, false, 0)
+	require.NoError(t, err)
+	require.False(t, giveUp)
+	require.Equal(t, "rootpassword", pass)
+
+	// ask for targets password, but it should already be cached
+	pass, giveUp, err = retriever("repo/0123456789abcdef", data.CanonicalTargetsRole, false, 0)
 	require.NoError(t, err)
 	require.False(t, giveUp)
 	require.Equal(t, "targetspassword", pass)
 
+	// ask for snapshot password, but it should already be cached
+	pass, giveUp, err = retriever("repo/0123456789abcdef", data.CanonicalSnapshotRole, false, 0)
+	require.NoError(t, err)
+	require.False(t, giveUp)
+	require.Equal(t, "snapshotpassword", pass)
+
+	// ask for targets/delegation password, but it should already be cached
+	pass, giveUp, err = retriever("repo/0123456789abcdef", "targets/delegation", false, 0)
+	require.NoError(t, err)
+	require.False(t, giveUp)
+	require.Equal(t, "delegationpass", pass)
+
+	// ask for different delegation password, which should not be cached
+	_, _, err = retriever("repo/0123456789abcdef", "targets/delegation/new", false, 0)
+	require.Error(t, err)
 	text, err := ioutil.ReadAll(&out)
 	require.NoError(t, err)
-	require.Empty(t, text)
+	require.Contains(t, string(text), "Enter passphrase for targets/delegation/new key with ID 0123456 (repo):")
 }


### PR DESCRIPTION
Caches each passphrase in the passphrase retriever separately, such that snapshot and targets passphrases are no longer necessarily shared and that we can also cache delegation role passphrases.

Note from previous discussions about how this affects the docker-client integration: the passphrase refactor will affect old repos since we'll ask for targets and snapshots separately, but it will not affect new repos created with Docker 1.11 since the server handles the snapshot key.  Also,  the environment variables for automation remain the same.

Closes #524, carries #541

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>