### PR TITLE
More server DB tests

### DIFF
--- a/buildscripts/dbtests.sh
+++ b/buildscripts/dbtests.sh
@@ -31,7 +31,7 @@ function cleanup {
     fi
 }
 
-clientCmd="make TESTOPTS='-v' test"
+clientCmd="make TESTOPTS='-p 1' test"
 if [[ -z "${CIRCLECI}" ]]; then
     BUILDOPTS="--force-rm"
 else

--- a/buildscripts/dbtests.sh
+++ b/buildscripts/dbtests.sh
@@ -31,7 +31,7 @@ function cleanup {
     fi
 }
 
-clientCmd="make test"
+clientCmd="make TESTOPTS='-v' test"
 if [[ -z "${CIRCLECI}" ]]; then
     BUILDOPTS="--force-rm"
 else

--- a/server/storage/memory_test.go
+++ b/server/storage/memory_test.go
@@ -34,10 +34,19 @@ func TestMemoryUpdateCurrentEmpty(t *testing.T) {
 }
 
 // UpdateCurrent will successfully add a new (higher) version of an existing TUF file,
-// but will return an error if there is an older version of a TUF file.
-func TestMemoryUpdateCurrentVersionCheck(t *testing.T) {
+// but will return an error if the to-be-added version already exists in the DB.
+func TestMemoryUpdateCurrentVersionCheckOldVersionExists(t *testing.T) {
 	s := NewMemStorage()
-	expected := testUpdateCurrentVersionCheck(t, s)
+	expected := testUpdateCurrentVersionCheck(t, s, true)
+	assertExpectedMemoryTUFMeta(t, expected, s)
+}
+
+// UpdateCurrent will successfully add a new (higher) version of an existing TUF file,
+// but will return an error if the to-be-added version does not exist in the DB, but
+// is older than an existing version in the DB.
+func TestMemoryUpdateCurrentVersionCheckOldVersionNotExist(t *testing.T) {
+	s := NewMemStorage()
+	expected := testUpdateCurrentVersionCheck(t, s, false)
 	assertExpectedMemoryTUFMeta(t, expected, s)
 }
 

--- a/server/storage/mysql_test.go
+++ b/server/storage/mysql_test.go
@@ -33,7 +33,7 @@ func init() {
 		if i == 29 {
 			logrus.Fatalf("Unable to connect to %s after 60 seconds", dburl)
 		}
-		time.Sleep(2)
+		time.Sleep(2 * time.Second)
 	}
 
 	sqldbSetup = func(t *testing.T) (*SQLStorage, func()) {

--- a/server/storage/rethink_realdb_test.go
+++ b/server/storage/rethink_realdb_test.go
@@ -121,3 +121,10 @@ func TestRethinkDeleteSuccess(t *testing.T) {
 
 	testDeleteSuccess(t, dbStore)
 }
+
+func TestRethinkTUFMetaStoreGetCurrent(t *testing.T) {
+	dbStore, cleanup := rethinkDBSetup(t)
+	defer cleanup()
+
+	testTUFMetaStoreGetCurrent(t, dbStore)
+}

--- a/server/storage/rethink_realdb_test.go
+++ b/server/storage/rethink_realdb_test.go
@@ -116,14 +116,23 @@ func TestRethinkUpdateCurrentEmpty(t *testing.T) {
 }
 
 // UpdateCurrent will add a new TUF file if the version is higher than previous, but fail
-// if the version is equal to or less than the current, whether or not that previous
-// version exists
-func TestRethinkUpdateCurrentVersionCheck(t *testing.T) {
+// if the version already exists in the DB
+func TestRethinkUpdateCurrentVersionCheckOldVersionExists(t *testing.T) {
+	dbStore, cleanup := rethinkDBSetup(t)
+	defer cleanup()
+
+	testUpdateCurrentVersionCheck(t, dbStore, true)
+}
+
+// UpdateCurrent will successfully add a new (higher) version of an existing TUF file,
+// but will return an error if the to-be-added version does not exist in the DB, but
+// is older than an existing version in the DB.
+func TestRethinkUpdateCurrentVersionCheckOldVersionNotExist(t *testing.T) {
 	t.Skip("Currently rethink only errors if the previous version exists - it doesn't check for strictly increasing")
 	dbStore, cleanup := rethinkDBSetup(t)
 	defer cleanup()
 
-	testUpdateCurrentVersionCheck(t, dbStore)
+	testUpdateCurrentVersionCheck(t, dbStore, false)
 }
 
 // UpdateMany succeeds if the updates do not conflict with each other or with what's

--- a/server/storage/sql_models.go
+++ b/server/storage/sql_models.go
@@ -14,7 +14,6 @@ type TUFFile struct {
 
 // TableName sets a specific table name for TUFFile
 func (g TUFFile) TableName() string {
-	// NOTE: if this value changes, please also change it in SQLStorage.Delete
 	return "tuf_files"
 }
 

--- a/server/storage/sql_models.go
+++ b/server/storage/sql_models.go
@@ -14,6 +14,7 @@ type TUFFile struct {
 
 // TableName sets a specific table name for TUFFile
 func (g TUFFile) TableName() string {
+	// NOTE: if this value changes, please also change it in SQLStorage.Delete
 	return "tuf_files"
 }
 

--- a/server/storage/sqldb.go
+++ b/server/storage/sqldb.go
@@ -153,11 +153,10 @@ func isReadErr(q *gorm.DB, row TUFFile) error {
 	return nil
 }
 
-// Delete deletes all the records for a specific GUN - we have to do a raw execute, because
-// otherwise GORM will do a soft delete, because we have CreatedAt, ModifiedAt, and DeletedAt
-// columns (and we actually use CreatedAt and ModifiedAt)
+// Delete deletes all the records for a specific GUN - we have to do a hard delete using Unscoped
+// otherwise we can't insert for that GUN again
 func (db *SQLStorage) Delete(gun string) error {
-	return db.Exec("DELETE FROM tuf_files WHERE gun = ?", gun).Error
+	return db.Unscoped().Where(&TUFFile{Gun: gun}).Delete(TUFFile{}).Error
 }
 
 // GetKey returns the Public Key data for a gun+role

--- a/server/storage/sqldb.go
+++ b/server/storage/sqldb.go
@@ -153,9 +153,11 @@ func isReadErr(q *gorm.DB, row TUFFile) error {
 	return nil
 }
 
-// Delete deletes all the records for a specific GUN
+// Delete deletes all the records for a specific GUN - we have to do a raw execute, because
+// otherwise GORM will do a soft delete, because we have CreatedAt, ModifiedAt, and DeletedAt
+// columns (and we actually use CreatedAt and ModifiedAt)
 func (db *SQLStorage) Delete(gun string) error {
-	return db.Where(&TUFFile{Gun: gun}).Delete(TUFFile{}).Error
+	return db.Exec("DELETE FROM tuf_files WHERE gun = ?", gun).Error
 }
 
 // GetKey returns the Public Key data for a gun+role

--- a/server/storage/sqldb_test.go
+++ b/server/storage/sqldb_test.go
@@ -283,7 +283,7 @@ func TestSQLDBCheckHealthTableMissing(t *testing.T) {
 	require.Error(t, err, "Cannot access table:")
 }
 
-// TestSQLDBCheckHealthDBCOnnection asserts that if the DB is not connectable, the
+// TestSQLDBCheckHealthDBConnection asserts that if the DB is not connectable, the
 // health check fails.
 func TestSQLDBCheckHealthDBConnectionFail(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)

--- a/server/storage/sqldb_test.go
+++ b/server/storage/sqldb_test.go
@@ -246,9 +246,9 @@ func TestSQLSetKeySameRoleGun(t *testing.T) {
 	dbStore.DB.Close()
 }
 
-// TestDBCheckHealthTableMissing asserts that the health check fails if one or
+// TestSQLDBCheckHealthTableMissing asserts that the health check fails if one or
 // both the tables are missing.
-func TestDBCheckHealthTableMissing(t *testing.T) {
+func TestSQLDBCheckHealthTableMissing(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)
 	defer cleanup()
 
@@ -270,9 +270,9 @@ func TestDBCheckHealthTableMissing(t *testing.T) {
 	require.Error(t, err, "Cannot access table:")
 }
 
-// TestDBCheckHealthDBCOnnection asserts that if the DB is not connectable, the
+// TestSQLDBCheckHealthDBCOnnection asserts that if the DB is not connectable, the
 // health check fails.
-func TestDBCheckHealthDBConnectionFail(t *testing.T) {
+func TestSQLDBCheckHealthDBConnectionFail(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)
 	defer cleanup()
 
@@ -283,9 +283,9 @@ func TestDBCheckHealthDBConnectionFail(t *testing.T) {
 	require.Error(t, err, "Cannot access table:")
 }
 
-// TestDBCheckHealthSuceeds asserts that if the DB is connectable and both
+// TestSQLDBCheckHealthSuceeds asserts that if the DB is connectable and both
 // tables exist, the health check succeeds.
-func TestDBCheckHealthSucceeds(t *testing.T) {
+func TestSQLDBCheckHealthSucceeds(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)
 	defer cleanup()
 
@@ -293,7 +293,7 @@ func TestDBCheckHealthSucceeds(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDBGetChecksum(t *testing.T) {
+func TestSQLDBGetChecksum(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)
 	defer cleanup()
 
@@ -349,7 +349,7 @@ func TestDBGetChecksum(t *testing.T) {
 	require.True(t, cDate.Before(time.Now().Add(5*time.Second)))
 }
 
-func TestDBGetChecksumNotFound(t *testing.T) {
+func TestSQLDBGetChecksumNotFound(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)
 	defer cleanup()
 
@@ -358,7 +358,7 @@ func TestDBGetChecksumNotFound(t *testing.T) {
 	require.IsType(t, ErrNotFound{}, err)
 }
 
-func TestSQLiteTUFMetaStoreGetCurrent(t *testing.T) {
+func TestSQLTUFMetaStoreGetCurrent(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)
 	defer cleanup()
 

--- a/server/storage/sqldb_test.go
+++ b/server/storage/sqldb_test.go
@@ -76,14 +76,27 @@ func TestSQLUpdateCurrentEmpty(t *testing.T) {
 	dbStore.DB.Close()
 }
 
-// TestSQLUpdateCurrentNewVersion asserts that UpdateCurrent will add a
+// TestSQLUpdateCurrentVersionCheckOldVersionExists asserts that UpdateCurrent will add a
 // new (higher) version of an existing TUF file, and that an error is raised if
-// trying to update to an older version of a TUF file.
-func TestSQLUpdateCurrentNewVersion(t *testing.T) {
+// trying to update to an older version of a TUF file that already exists.
+func TestSQLUpdateCurrentVersionCheckOldVersionExists(t *testing.T) {
 	dbStore, cleanup := sqldbSetup(t)
 	defer cleanup()
 
-	expected := testUpdateCurrentVersionCheck(t, dbStore)
+	expected := testUpdateCurrentVersionCheck(t, dbStore, true)
+	assertExpectedGormTUFMeta(t, expected, dbStore.DB)
+
+	dbStore.DB.Close()
+}
+
+// TestSQLUpdateCurrentVersionCheckOldVersionNotExist asserts that UpdateCurrent will add a
+// new (higher) version of an existing TUF file, and that an error is raised if
+// trying to update to an older version of a TUF file that doesn't exist in the DB.
+func TestSQLUpdateCurrentVersionCheckOldVersionNotExist(t *testing.T) {
+	dbStore, cleanup := sqldbSetup(t)
+	defer cleanup()
+
+	expected := testUpdateCurrentVersionCheck(t, dbStore, false)
 	assertExpectedGormTUFMeta(t, expected, dbStore.DB)
 
 	dbStore.DB.Close()

--- a/server/storage/sqlite_test.go
+++ b/server/storage/sqlite_test.go
@@ -1,4 +1,4 @@
-// +build !mysqldb
+// +build !mysqldb,!rethinkdb
 
 // Initializes an SQLlite DBs for testing purposes
 

--- a/signer/keydbstore/mysql_test.go
+++ b/signer/keydbstore/mysql_test.go
@@ -33,7 +33,7 @@ func init() {
 		if i == 29 {
 			logrus.Fatalf("Unable to connect to %s after 60 seconds", dburl)
 		}
-		time.Sleep(2)
+		time.Sleep(2 * time.Second)
 	}
 
 	sqldbSetup = func(t *testing.T) (*SQLKeyDBStore, func()) {


### PR DESCRIPTION
This finishes the refactor in #824 of the server storage tests refactor to take a DB type.

In addition, this fixes:

1.  Deleting a GUN in mysql - previously, we soft-deleted a gun, preventing us from being able to re-use the namespace.  We now hard-delete.
1.  The RethinkDB server health check needs to fail if the session user does not have the correct permissions to access the requisite tables.