### PR TITLE
update to allow removing pending changes

### DIFF
--- a/client/changelist/changelist.go
+++ b/client/changelist/changelist.go
@@ -21,6 +21,24 @@ func (cl *memChangelist) Add(c Change) error {
 	return nil
 }
 
+// Remove deletes the changes found at the given indices
+func (cl *memChangelist) Remove(idxs []int) error {
+	remove := make(map[int]struct{})
+	for _, i := range idxs {
+		remove[i] = struct{}{}
+	}
+	var keep []Change
+
+	for i, c := range cl.changes {
+		if _, ok := remove[i]; ok {
+			continue
+		}
+		keep = append(keep, c)
+	}
+	cl.changes = keep
+	return nil
+}
+
 // Clear empties the changelist file.
 func (cl *memChangelist) Clear(archive string) error {
 	// appending to a nil list initializes it.

--- a/client/changelist/changelist_test.go
+++ b/client/changelist/changelist_test.go
@@ -64,3 +64,26 @@ func TestMemChangeIterator(t *testing.T) {
 	var iterError IteratorBoundsError
 	require.IsType(t, iterError, err, "IteratorBoundsError type")
 }
+
+func TestMemChangelistRemove(t *testing.T) {
+	cl := memChangelist{}
+	it, err := cl.NewIterator()
+	require.Nil(t, err, "Non-nil error from NewIterator")
+	require.False(t, it.HasNext(), "HasNext returns false for empty ChangeList")
+
+	c1 := NewTUFChange(ActionCreate, "t1", "target1", "test/targ1", []byte{1})
+	cl.Add(c1)
+
+	c2 := NewTUFChange(ActionUpdate, "t2", "target2", "test/targ2", []byte{2})
+	cl.Add(c2)
+
+	c3 := NewTUFChange(ActionUpdate, "t3", "target3", "test/targ3", []byte{3})
+	cl.Add(c3)
+
+	err = cl.Remove([]int{0, 1})
+	require.NoError(t, err)
+
+	chs := cl.List()
+	require.Len(t, chs, 1)
+	require.Equal(t, "t3", chs[0].Scope())
+}

--- a/client/changelist/file_changelist.go
+++ b/client/changelist/file_changelist.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"sort"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/uuid"
+	"path/filepath"
 )
 
 // FileChangelist stores all the changes as files
@@ -52,7 +52,7 @@ func getFileNames(dirName string) ([]os.FileInfo, error) {
 // Read a JSON formatted file from disk; convert to TUFChange struct
 func unmarshalFile(dirname string, f os.FileInfo) (*TUFChange, error) {
 	c := &TUFChange{}
-	raw, err := ioutil.ReadFile(path.Join(dirname, f.Name()))
+	raw, err := ioutil.ReadFile(filepath.Join(dirname, f.Name()))
 	if err != nil {
 		return c, err
 	}
@@ -89,7 +89,29 @@ func (cl FileChangelist) Add(c Change) error {
 		return err
 	}
 	filename := fmt.Sprintf("%020d_%s.change", time.Now().UnixNano(), uuid.Generate())
-	return ioutil.WriteFile(path.Join(cl.dir, filename), cJSON, 0644)
+	return ioutil.WriteFile(filepath.Join(cl.dir, filename), cJSON, 0644)
+}
+
+// Remove deletes the changes found at the given indices
+func (cl FileChangelist) Remove(idxs []int) error {
+	fileInfos, err := getFileNames(cl.dir)
+	if err != nil {
+		return err
+	}
+	sort.Sort(fileChanges(fileInfos))
+	remove := make(map[int]struct{})
+	for _, i := range idxs {
+		remove[i] = struct{}{}
+	}
+	for i, c := range fileInfos {
+		if _, ok := remove[i]; ok {
+			file := filepath.Join(cl.dir, c.Name())
+			if err := os.Remove(file); err != nil {
+				logrus.Errorf("could not remove change %d: %s", i, err.Error())
+			}
+		}
+	}
+	return nil
 }
 
 // Clear clears the change list
@@ -104,7 +126,7 @@ func (cl FileChangelist) Clear(archive string) error {
 		return err
 	}
 	for _, f := range files {
-		os.Remove(path.Join(cl.dir, f.Name()))
+		os.Remove(filepath.Join(cl.dir, f.Name()))
 	}
 	return nil
 }

--- a/client/changelist/file_changelist.go
+++ b/client/changelist/file_changelist.go
@@ -46,6 +46,7 @@ func getFileNames(dirName string) ([]os.FileInfo, error) {
 		}
 		fileInfos = append(fileInfos, f)
 	}
+	sort.Sort(fileChanges(fileInfos))
 	return fileInfos, nil
 }
 
@@ -70,7 +71,6 @@ func (cl FileChangelist) List() []Change {
 	if err != nil {
 		return changes
 	}
-	sort.Sort(fileChanges(fileInfos))
 	for _, f := range fileInfos {
 		c, err := unmarshalFile(cl.dir, f)
 		if err != nil {
@@ -98,7 +98,6 @@ func (cl FileChangelist) Remove(idxs []int) error {
 	if err != nil {
 		return err
 	}
-	sort.Sort(fileChanges(fileInfos))
 	remove := make(map[int]struct{})
 	for _, i := range idxs {
 		remove[i] = struct{}{}
@@ -115,6 +114,7 @@ func (cl FileChangelist) Remove(idxs []int) error {
 }
 
 // Clear clears the change list
+// N.B. archiving not currently implemented
 func (cl FileChangelist) Clear(archive string) error {
 	dir, err := os.Open(cl.dir)
 	if err != nil {
@@ -143,7 +143,6 @@ func (cl FileChangelist) NewIterator() (ChangeIterator, error) {
 	if err != nil {
 		return &FileChangeListIterator{}, err
 	}
-	sort.Sort(fileChanges(fileInfos))
 	return &FileChangeListIterator{dirname: cl.dir, collection: fileInfos}, nil
 }
 

--- a/client/changelist/interface.go
+++ b/client/changelist/interface.go
@@ -15,6 +15,9 @@ type Changelist interface {
 	// to save a copy of the changelist in that location
 	Clear(archive string) error
 
+	// Remove deletes the changes corresponding with the indices given
+	Remove(idxs []int) error
+
 	// Close syncronizes any pending writes to the underlying
 	// storage and closes the file/connection
 	Close() error

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -49,10 +49,11 @@ func applyChangelist(repo *tuf.Repo, cl changelist.Changelist) error {
 		default:
 			logrus.Debug("scope not supported: ", c.Scope())
 		}
-		index++
 		if err != nil {
+			logrus.Debugf("error attempting to apply change #%d: %s, on scope: %s path: %s type: %s", index, c.Action(), c.Scope(), c.Path(), c.Type())
 			return err
 		}
+		index++
 	}
 	logrus.Debugf("applied %d change(s)", index)
 	return nil

--- a/cmd/notary/prettyprint.go
+++ b/cmd/notary/prettyprint.go
@@ -13,7 +13,10 @@ import (
 	"github.com/docker/notary/tuf/data"
 )
 
-const fourItemRow = "%s\t%s\t%s\t%s\n"
+const (
+	fourItemRow = "%s\t%s\t%s\t%s\n"
+	fiveItemRow = "%s\t%s\t%s\t%s\t%s\n"
+)
 
 func initTabWriter(columns []string, writer io.Writer) *tabwriter.Writer {
 	tw := tabwriter.NewWriter(writer, 4, 4, 4, ' ', 0)

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -98,8 +98,8 @@ type tufCommander struct {
 	output string
 	quiet  bool
 
-	changes           []int
-	resetStatus       bool
+	deleteIdx         []int
+	reset             bool
 	archiveChangelist string
 }
 
@@ -109,8 +109,8 @@ func (t *tufCommander) AddToCommand(cmd *cobra.Command) {
 	cmd.AddCommand(cmdTUFInit)
 
 	cmdStatus := cmdTUFStatusTemplate.ToCommand(t.tufStatus)
-	cmdStatus.Flags().IntSliceVarP(&t.changes, "unstage", "u", nil, "Numbers of changes to delete, as show in status list")
-	cmdStatus.Flags().BoolVar(&t.resetStatus, "reset", false, "Reset the changelist for the GUN by deleting all pending changes")
+	cmdStatus.Flags().IntSliceVarP(&t.deleteIdx, "unstage", "u", nil, "Numbers of changes to delete, as shown in status list")
+	cmdStatus.Flags().BoolVar(&t.reset, "reset", false, "Reset the changelist for the GUN by deleting all pending changes")
 	cmd.AddCommand(cmdStatus)
 
 	cmd.AddCommand(cmdTUFPublishTemplate.ToCommand(t.tufPublish))
@@ -448,12 +448,12 @@ func (t *tufCommander) tufStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if t.resetStatus {
+	if t.reset {
 		return cl.Clear(t.archiveChangelist)
 	}
 
-	if len(t.changes) > 0 {
-		return cl.Remove(t.changes)
+	if len(t.deleteIdx) > 0 {
+		return cl.Remove(t.deleteIdx)
 	}
 
 	if len(cl.List()) == 0 {

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -98,7 +98,9 @@ type tufCommander struct {
 	output string
 	quiet  bool
 
-	changes []int
+	changes           []int
+	resetStatus       bool
+	archiveChangelist string
 }
 
 func (t *tufCommander) AddToCommand(cmd *cobra.Command) {
@@ -108,6 +110,7 @@ func (t *tufCommander) AddToCommand(cmd *cobra.Command) {
 
 	cmdStatus := cmdTUFStatusTemplate.ToCommand(t.tufStatus)
 	cmdStatus.Flags().IntSliceVarP(&t.changes, "unstage", "u", nil, "Numbers of changes to delete, as show in status list")
+	cmdStatus.Flags().BoolVar(&t.resetStatus, "reset", false, "Reset the changelist for the GUN by deleting all pending changes")
 	cmd.AddCommand(cmdStatus)
 
 	cmd.AddCommand(cmdTUFPublishTemplate.ToCommand(t.tufPublish))
@@ -443,6 +446,10 @@ func (t *tufCommander) tufStatus(cmd *cobra.Command, args []string) error {
 	cl, err := nRepo.GetChangelist()
 	if err != nil {
 		return err
+	}
+
+	if t.resetStatus {
+		return cl.Clear(t.archiveChangelist)
 	}
 
 	if len(t.changes) > 0 {


### PR DESCRIPTION
Needs tests

Partially addresses #596 

Adds `--reset` and `--unstage` flags to `notary status`. `reset` removes all pending changes for the GUN, `unstage` allows specific changes to be removed based on their # as shown in `notary status`

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)