### PR TITLE
Ensure that we do not clobber in-memory key id data on delegation list

### DIFF
--- a/client/delegations.go
+++ b/client/delegations.go
@@ -238,7 +238,7 @@ func newDeleteDelegationChange(name string, content []byte) *changelist.TUFChang
 
 // GetDelegationRoles returns the keys and roles of the repository's delegations
 // Also converts key IDs to canonical key IDs to keep consistent with signing prompts
-func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
+func (r *NotaryRepository) GetDelegationRoles() ([]data.Role, error) {
 	// Update state of the repo to latest
 	if err := r.Update(false); err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
 	}
 
 	// make a copy for traversing nested delegations
-	allDelegations := []*data.Role{}
+	allDelegations := []data.Role{}
 
 	// Define a visitor function to populate the delegations list and translate their key IDs to canonical IDs
 	delegationCanonicalListVisitor := func(tgt *data.SignedTargets, validRole data.DelegationRole) interface{} {
@@ -271,20 +271,23 @@ func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
 	return allDelegations, nil
 }
 
-func translateDelegationsToCanonicalIDs(delegationInfo data.Delegations) ([]*data.Role, error) {
-	canonicalDelegations := make([]*data.Role, len(delegationInfo.Roles))
-	copy(canonicalDelegations, delegationInfo.Roles)
+func translateDelegationsToCanonicalIDs(delegationInfo data.Delegations) ([]data.Role, error) {
+	canonicalDelegations := make([]data.Role, len(delegationInfo.Roles))
+	// Do a copy by value to ensure local delegation metadata is untouched
+	for idx, origRole := range delegationInfo.Roles {
+		canonicalDelegations[idx] = *origRole
+	}
 	delegationKeys := delegationInfo.Keys
 	for i, delegation := range canonicalDelegations {
 		canonicalKeyIDs := []string{}
 		for _, keyID := range delegation.KeyIDs {
 			pubKey, ok := delegationKeys[keyID]
 			if !ok {
-				return nil, fmt.Errorf("Could not translate canonical key IDs for %s", delegation.Name)
+				return []data.Role{}, fmt.Errorf("Could not translate canonical key IDs for %s", delegation.Name)
 			}
 			canonicalKeyID, err := utils.CanonicalKeyID(pubKey)
 			if err != nil {
-				return nil, fmt.Errorf("Could not translate canonical key IDs for %s: %v", delegation.Name, err)
+				return []data.Role{}, fmt.Errorf("Could not translate canonical key IDs for %s: %v", delegation.Name, err)
 			}
 			canonicalKeyIDs = append(canonicalKeyIDs, canonicalKeyID)
 		}

--- a/cmd/notary/prettyprint.go
+++ b/cmd/notary/prettyprint.go
@@ -140,7 +140,7 @@ func (t targetsSorter) Less(i, j int) bool {
 
 // --- pretty printing roles ---
 
-type roleSorter []*data.Role
+type roleSorter []data.Role
 
 func (r roleSorter) Len() int      { return len(r) }
 func (r roleSorter) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
@@ -173,7 +173,7 @@ func prettyPrintTargets(ts []*client.TargetWithRole, writer io.Writer) {
 }
 
 // Pretty-prints the list of provided Roles
-func prettyPrintRoles(rs []*data.Role, writer io.Writer, roleType string) {
+func prettyPrintRoles(rs []data.Role, writer io.Writer, roleType string) {
 	if len(rs) == 0 {
 		writer.Write([]byte(fmt.Sprintf("\nNo %s present in this repository.\n\n", roleType)))
 		return

--- a/cmd/notary/prettyprint_test.go
+++ b/cmd/notary/prettyprint_test.go
@@ -205,7 +205,7 @@ func TestPrettyPrintSortedTargets(t *testing.T) {
 // are no roles.
 func TestPrettyPrintZeroRoles(t *testing.T) {
 	var b bytes.Buffer
-	prettyPrintRoles([]*data.Role{}, &b, "delegations")
+	prettyPrintRoles([]data.Role{}, &b, "delegations")
 	text, err := ioutil.ReadAll(&b)
 	require.NoError(t, err)
 
@@ -218,7 +218,7 @@ func TestPrettyPrintZeroRoles(t *testing.T) {
 func TestPrettyPrintSortedRoles(t *testing.T) {
 	var err error
 
-	unsorted := []*data.Role{
+	unsorted := []data.Role{
 		{Name: "targets/zebra", Paths: []string{"stripes", "black", "white"}, RootRole: data.RootRole{KeyIDs: []string{"101"}, Threshold: 1}},
 		{Name: "targets/aardvark/unicorn/pony", Paths: []string{"rainbows"}, RootRole: data.RootRole{KeyIDs: []string{"135"}, Threshold: 1}},
 		{Name: "targets/bee", Paths: []string{"honey"}, RootRole: data.RootRole{KeyIDs: []string{"246"}, Threshold: 1}},


### PR DESCRIPTION
Brought up by @HuKeping in https://github.com/docker/notary/issues/852#issuecomment-234137903, I noticed that `translateDelegationsToCanonicalIDs` was mistakenly editing in-memory metadata by replacing TUF key IDs with canonical key IDs, which would cause nested delegations to have issues when building into `data.DelegationRole` structs.

Changed pass-by-reference to pass-by-value and added a test that publishes a nested delegation and ensures that `delegation list` behaves as expected.