### PR TITLE
notary delete CLI command

### DIFF
--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -166,6 +166,7 @@ var exampleValidCommands = []string{
 	"delegation add repo targets/releases path/to/pem/file.pem",
 	"delegation remove repo targets/releases",
 	"witness gun targets/releases",
+	"delete repo",
 }
 
 // config parsing bugs are propagated in all commands


### PR DESCRIPTION
Wires up `DeleteTrustData` from the client library to a `notary delete` command, which will delete all local TUF metadata by default and additionally the remote metadata if the `--remote` flag is given.

Closes https://github.com/docker/notary/issues/710

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>