### PR TITLE
We are returning a pointer to an error rather than an error itself.

### DIFF
--- a/server/storage/memory.go
+++ b/server/storage/memory.go
@@ -57,7 +57,7 @@ func (st *MemStorage) UpdateCurrent(gun string, update MetaUpdate) error {
 	if space, ok := st.tufMeta[id]; ok {
 		for _, v := range space {
 			if v.version >= update.Version {
-				return &ErrOldVersion{}
+				return ErrOldVersion{}
 			}
 		}
 	}
@@ -88,7 +88,7 @@ func (st *MemStorage) UpdateMany(gun string, updates []MetaUpdate) error {
 
 		// prevent duplicate versions of the same role
 		if _, ok := versioner[u.Role][u.Version]; ok {
-			return &ErrOldVersion{}
+			return ErrOldVersion{}
 		}
 		if _, ok := versioner[u.Role]; !ok {
 			versioner[u.Role] = make(map[int]struct{})
@@ -98,7 +98,7 @@ func (st *MemStorage) UpdateMany(gun string, updates []MetaUpdate) error {
 		if space, ok := st.tufMeta[id]; ok {
 			for _, v := range space {
 				if v.version >= u.Version {
-					return &ErrOldVersion{}
+					return ErrOldVersion{}
 				}
 			}
 		}

--- a/server/storage/rethinkdb.go
+++ b/server/storage/rethinkdb.go
@@ -165,7 +165,7 @@ func (rdb RethinkDB) UpdateCurrent(gun string, update MetaUpdate) error {
 		},
 	).RunWrite(rdb.sess)
 	if err != nil && gorethink.IsConflictErr(err) {
-		return &ErrOldVersion{}
+		return ErrOldVersion{}
 	}
 	return err
 }
@@ -195,7 +195,7 @@ func (rdb RethinkDB) UpdateCurrentWithTSChecksum(gun, tsChecksum string, update 
 		},
 	).RunWrite(rdb.sess)
 	if err != nil && gorethink.IsConflictErr(err) {
-		return &ErrOldVersion{}
+		return ErrOldVersion{}
 	}
 	return err
 }

--- a/server/storage/sqldb.go
+++ b/server/storage/sqldb.go
@@ -37,7 +37,7 @@ func translateOldVersionError(err error) error {
 		// 1022 = Can't write; duplicate key in table '%s'
 		// 1062 = Duplicate entry '%s' for key %d
 		if err.Number == 1022 || err.Number == 1062 {
-			return &ErrOldVersion{}
+			return ErrOldVersion{}
 		}
 	}
 	return err
@@ -52,7 +52,7 @@ func (db *SQLStorage) UpdateCurrent(gun string, update MetaUpdate) error {
 		gun, update.Role, update.Version).First(&TUFFile{})
 
 	if !exists.RecordNotFound() {
-		return &ErrOldVersion{}
+		return ErrOldVersion{}
 	}
 	checksum := sha256.Sum256(update.Data)
 	return translateOldVersionError(db.Create(&TUFFile{
@@ -92,7 +92,7 @@ func (db *SQLStorage) UpdateMany(gun string, updates []MetaUpdate) error {
 			gun, update.Role, update.Version).First(&TUFFile{})
 
 		if !query.RecordNotFound() {
-			return rollback(&ErrOldVersion{})
+			return rollback(ErrOldVersion{})
 		}
 
 		var row TUFFile
@@ -110,7 +110,7 @@ func (db *SQLStorage) UpdateMany(gun string, updates []MetaUpdate) error {
 		// it's previously been added, which means it's a duplicate entry
 		// in the same transaction
 		if _, ok := added[row.ID]; ok {
-			return rollback(&ErrOldVersion{})
+			return rollback(ErrOldVersion{})
 		}
 		added[row.ID] = true
 	}

--- a/server/storage/storage_test.go
+++ b/server/storage/storage_test.go
@@ -118,7 +118,7 @@ func testUpdateCurrentVersionCheck(t *testing.T, s MetaStore, oldVersionExists b
 	tufObj := SampleCustomTUFObj(gun, role, version, nil)
 	err := s.UpdateCurrent(gun, MakeUpdate(tufObj))
 	require.Error(t, err, "Error should not be nil")
-	require.IsType(t, &ErrOldVersion{}, err,
+	require.IsType(t, ErrOldVersion{}, err,
 		"Expected ErrOldVersion error type, got: %v", err)
 
 	assertExpectedTUFMetaInStore(t, s, expected[:2], false)
@@ -199,14 +199,14 @@ func testUpdateManyConflictRollback(t *testing.T, s MetaStore) []StoredTUFMeta {
 
 	err := s.UpdateMany(gun, updates)
 	require.Error(t, err)
-	require.IsType(t, &ErrOldVersion{}, err)
+	require.IsType(t, ErrOldVersion{}, err)
 
 	// self-conflicting, in that it's a duplicate, but otherwise no DB conflicts
 	duplicate := SampleCustomTUFObj(gun, data.CanonicalTimestampRole, 3, []byte("duplicate"))
 	duplicateUpdate := MakeUpdate(duplicate)
 	err = s.UpdateMany(gun, []MetaUpdate{duplicateUpdate, duplicateUpdate})
 	require.Error(t, err)
-	require.IsType(t, &ErrOldVersion{}, err)
+	require.IsType(t, ErrOldVersion{}, err)
 
 	assertExpectedTUFMetaInStore(t, s, successBatch, true)
 


### PR DESCRIPTION
Fixes #898 

Here I'm just changing this to return the concrete type everywhere.  We could instead just change the type we compare against in https://github.com/docker/notary/blob/master/server/handlers/default.go#L108 to be a pointer instead of a concrete type.