### PR TITLE
fix misspell find file logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ endif
 	@test -z "$$(go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 	# misspell - requires that the following be run first:
 	#    go get -u github.com/client9/misspell/cmd/misspell
-	@test -z "$$(find . -name '*' | grep -v vendor/ | grep -v bin/ | grep -v misc/ | grep -v .git/ | grep -v \.pdf | xargs misspell | tee /dev/stderr)"
+	@test -z "$$(find . -type f | grep -v vendor/ | grep -v bin/ | grep -v misc/ | grep -v .git/ | grep -v \.pdf | xargs misspell | tee /dev/stderr)"
 	# ineffassign - requires that the following be run first:
 	#    go get -u github.com/gordonklaus/ineffassign
 	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)"


### PR DESCRIPTION
@avaid96 noticed that misspell changed up its recursive directory finding-logic (see: https://github.com/client9/misspell#how-do-you-check-an-entire-folder-recursively)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>