### PR TITLE
Update go version to 1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.3
+FROM golang:1.7.0
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ GOOSES = darwin linux
 NOTARY_BUILDTAGS ?= pkcs11
 NOTARYDIR := /go/src/github.com/docker/notary
 
-GO_VERSION := $(shell go version | grep "1\.[6-9]\(\.[0-9]+\)*\|devel")
+GO_VERSION := $(shell go version | grep "1\.[7-9]\(\.[0-9]+\)*\|devel")
 # check to make sure we have the right version. development versions of Go are
 # not officially supported, but allowed for building
 
 ifeq ($(strip $(GO_VERSION))$(SKIPENVCHECK),)
-$(error Bad Go version - please install Go >= 1.6)
+$(error Bad Go version - please install Go >= 1.7)
 endif
 
 # check to be sure pkcs11 lib is always imported with a build tag

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ to use `notary` with Docker images.
 
 Prerequisites:
 
-- Go >= 1.6.1
+- Go >= 1.7.0
 - [godep](https://github.com/tools/godep) installed
 - libtool development headers installed
     - Ubuntu: `apt-get install libltdl-dev`

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.3-alpine
+FROM golang:1.7.0-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.3-alpine
+FROM golang:1.7.0-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Bumps to go 1.7.0.

We can replace `golang.org/x/net/context` with `context` in a follow-up PR because we'll have to also bump grpc to a version that also uses `context`

Closes #928 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>