### PR TITLE
Bump go to version 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.0
+FROM golang:1.7.1
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ to use `notary` with Docker images.
 
 Prerequisites:
 
-- Go >= 1.7.0
+- Go >= 1.7.1
 - [godep](https://github.com/tools/godep) installed
 - libtool development headers installed
     - Ubuntu: `apt-get install libltdl-dev`

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.0-alpine
+FROM golang:1.7.1-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.0-alpine
+FROM golang:1.7.1-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Signed-off-by: Ying Li <ying.li@docker.com>

Brew doesn't have the 1.7.1 formula yet, so can't update the yubikey tester just yet.