### PR TITLE
Statically compile linux binaries, and try to fix OS X binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,7 @@ shell: notary-dockerfile
 
 cross: notary-dockerfile
 	@rm -rf $(CURDIR)/cross
-	docker run --rm -v $(CURDIR)/cross:$(NOTARYDIR)/cross -e NOTARY_BUILDTAGS=$(NOTARY_BUILDTAGS) notary buildscripts/cross.sh $(GOOSES)
-
+	docker run --rm -v $(CURDIR)/cross:$(NOTARYDIR)/cross -e CTIMEVAR="${CTIMEVAR}" -e NOTARY_BUILDTAGS=$(NOTARY_BUILDTAGS) notary buildscripts/cross.sh $(GOOSES)
 
 clean:
 	@echo "+ $@"


### PR DESCRIPTION
Modify the cross-compile script to statically compile the linux binary (which includes libtool).

This hopefully compiles the OS X binary in such a way as to address #826.