### PR TITLE
Try to fix flakey integration tests, also update the definition of notary server health

### DIFF
--- a/buildscripts/testclient.py
+++ b/buildscripts/testclient.py
@@ -315,21 +315,22 @@ def wait_for_server(server, timeout_in_seconds):
     if server is None:
         server = "https://notary-server:4443"
         command = ["curl", "--cacert", os.path.join(reporoot(), "fixtures", "root-ca.crt"),
-                   server]
+                   server + "/_notary_server/health"]
 
     start = time()
-    succeeded = False
+    succeeded = 0
     while time() <= start + timeout_in_seconds:
         proc = Popen(command, stderr=PIPE, stdin=PIPE)
         proc.communicate()
         if proc.poll():
-            sleep(1)
+            sleep(11)
             continue
         else:
-            succeeded = True
-            break
+            succeeded += 1
+            if succeeded > 1:
+                break
 
-    if not succeeded:
+    if succeeded < 2:
         raise Exception(
             "Could not connect to {0} after {2} seconds.".format(server, timeout_in_seconds))
 


### PR DESCRIPTION
Integration tests have been failing lately - it seems it's because the server comes up before the signer, and the integration tests start before the server manages to connect to the signer.

This fix should hopefully cause the tests to wait until the server is healthy for sure, so they might take longer to start.

This also changes the definition of notary server health - previously it was healthy but degraded if the signer is down - not it's just unhealthy, because we cannot do any writes.  

An alternate approach is to just have a separate endpoint to see whether it runs in degraded mode, or use a different health package that supports "warning" or degraded mode without necessarily failing the health check entirely.
