### PR TITLE
Fixes for delegation purge

### DIFF
--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -124,7 +124,7 @@ func (d *delegationCommander) delegationPurgeKeys(cmd *cobra.Command, args []str
 		gun,
 		strings.Join(d.keyIDs, "\n\t- "),
 	)
-	return nil
+	return maybeAutoPublish(cmd, d.autoPublish, gun, config, d.retriever)
 }
 
 // delegationsList lists all the delegations for a particular GUN
@@ -167,7 +167,7 @@ func (d *delegationCommander) delegationsList(cmd *cobra.Command, args []string)
 	cmd.Println("")
 	prettyPrintRoles(delegationRoles, cmd.Out(), "delegations")
 	cmd.Println("")
-	return maybeAutoPublish(cmd, d.autoPublish, gun, config, d.retriever)
+	return nil
 }
 
 // delegationRemove removes a public key from a specific role in a GUN

--- a/tuf/tuf.go
+++ b/tuf/tuf.go
@@ -472,6 +472,7 @@ func (tr *Repo) PurgeDelegationKeys(role string, removeKeys []string) error {
 				logrus.Warnf("role %s has fewer keys than its threshold of %d; it will not be usable until keys are added to it", role.Name, role.Threshold)
 			}
 		}
+		tgt.Dirty = true
 		return nil
 	}
 	return tr.WalkTargets("", start, purgeKeys)


### PR DESCRIPTION
Fixes a couple of bugs with `notary delegation purge`:
- The role that was being purged of keys was not being marked as dirty for publishing
- The auto-publish flag wasn't actually wired up correctly (it was on `delegation list`)

Also reworks the integration test to check that we can successfully purge a key from multiple delegation roles.

Closes #953 