### PR TITLE
Also clear local repo changelist on `notary delete`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -996,19 +996,10 @@ func (r *NotaryRepository) rootFileKeyChange(cl changelist.Changelist, role, act
 // DeleteTrustData removes the trust data stored for this repo in the TUF cache on the client side
 // Note that we will not delete any private key material from local storage
 func (r *NotaryRepository) DeleteTrustData(deleteRemote bool) error {
-	// Clear local TUF files and cache
-	if err := r.fileStore.RemoveAll(); err != nil {
+	// Remove the tufRepoPath directory, which includes local TUF metadata files and changelist information
+	if err := os.RemoveAll(r.tufRepoPath); err != nil {
 		return fmt.Errorf("error clearing TUF repo data: %v", err)
 	}
-	// Clear the local changelist for the repo, in case there were staged changes on disk
-	cl, err := changelist.NewFileChangelist(filepath.Join(r.tufRepoPath, "changelist"))
-	if err != nil {
-		return fmt.Errorf("error retrieving changelist to clear TUF repo changelist data: %v", err)
-	}
-	if err := cl.Clear(""); err != nil {
-		return fmt.Errorf("error clearing TUF repo changelist data: %v", err)
-	}
-
 	// Note that this will require admin permission in this NotaryRepository's roundtripper
 	if deleteRemote {
 		remote, err := getRemoteStore(r.baseURL, r.gun, r.roundTrip)

--- a/client/client.go
+++ b/client/client.go
@@ -1000,7 +1000,14 @@ func (r *NotaryRepository) DeleteTrustData(deleteRemote bool) error {
 	if err := r.fileStore.RemoveAll(); err != nil {
 		return fmt.Errorf("error clearing TUF repo data: %v", err)
 	}
-	r.tufRepo = tuf.NewRepo(nil)
+	// Clear the local changelist for the repo, in case there were staged changes on disk
+	cl, err := changelist.NewFileChangelist(filepath.Join(r.tufRepoPath, "changelist"))
+	if err != nil {
+		return fmt.Errorf("error retrieving changelist to clear TUF repo changelist data: %v", err)
+	}
+	if err := cl.Clear(""); err != nil {
+		return fmt.Errorf("error clearing TUF repo changelist data: %v", err)
+	}
 
 	// Note that this will require admin permission in this NotaryRepository's roundtripper
 	if deleteRemote {


### PR DESCRIPTION
As noted by @cyli, it seems desirable to wipe out any staged changes for a repo when running `notary delete`.  This PR accomplishes this by deleting the `<trustDir>/tuf/<GUN>` directory, so that we don't have a dangling metadata directory post-deletion.

Currently, notary will persist the changelist subdirectory  `<trustDir>/tuf/<GUN>/changelist` even if a new repo with the same name is initialized, and the changes will attempt to be applied to the new repo (and it can succeed).

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>