### PR TITLE
Introduce `notary reset` command from `notary status` flags

### DIFF
--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -1605,7 +1605,7 @@ func TestWitness(t *testing.T) {
 	// 12. check non-targets base roles all fail
 	for _, role := range []string{data.CanonicalRootRole, data.CanonicalSnapshotRole, data.CanonicalTimestampRole} {
 		// clear any pending changes to ensure errors are only related to the specific role we're trying to witness
-		_, err = runCommand(t, tempDir, "reset", "gun")
+		_, err = runCommand(t, tempDir, "reset", "gun", "--all")
 		require.NoError(t, err)
 
 		_, err = runCommand(t, tempDir, "witness", "gun", role)
@@ -1618,7 +1618,7 @@ func TestWitness(t *testing.T) {
 	// 13. test auto-publish functionality (just for witness)
 
 	// purge the old staged witness
-	_, err = runCommand(t, tempDir, "reset", "gun")
+	_, err = runCommand(t, tempDir, "reset", "gun", "--all")
 	require.NoError(t, err)
 
 	// remove key2 and add back key1

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -1605,7 +1605,7 @@ func TestWitness(t *testing.T) {
 	// 12. check non-targets base roles all fail
 	for _, role := range []string{data.CanonicalRootRole, data.CanonicalSnapshotRole, data.CanonicalTimestampRole} {
 		// clear any pending changes to ensure errors are only related to the specific role we're trying to witness
-		_, err = runCommand(t, tempDir, "status", "gun", "--reset")
+		_, err = runCommand(t, tempDir, "reset", "gun")
 		require.NoError(t, err)
 
 		_, err = runCommand(t, tempDir, "witness", "gun", role)
@@ -1618,7 +1618,7 @@ func TestWitness(t *testing.T) {
 	// 13. test auto-publish functionality (just for witness)
 
 	// purge the old staged witness
-	_, err = runCommand(t, tempDir, "status", "gun", "--reset")
+	_, err = runCommand(t, tempDir, "reset", "gun")
 	require.NoError(t, err)
 
 	// remove key2 and add back key1

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -152,6 +152,7 @@ var exampleValidCommands = []string{
 	"init repo",
 	"list repo",
 	"status repo",
+	"reset repo",
 	"publish repo",
 	"add repo v1 somefile",
 	"addhash repo targetv1 --sha256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 10",

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -152,7 +152,7 @@ var exampleValidCommands = []string{
 	"init repo",
 	"list repo",
 	"status repo",
-	"reset repo",
+	"reset repo --all",
 	"publish repo",
 	"add repo v1 somefile",
 	"addhash repo targetv1 --sha256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 10",

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -77,6 +77,12 @@ var cmdTUFStatusTemplate = usageTemplate{
 	Long:  "Displays status of unpublished changes to the local trusted collection identified by the Globally Unique Name.",
 }
 
+var cmdTUFResetTemplate = usageTemplate{
+	Use:   "reset [ GUN ]",
+	Short: "Resets unpublished changes for the local trusted collection.",
+	Long:  "Resets unpublished changes for the local trusted collection identified by the Globally Unique Name.",
+}
+
 var cmdTUFVerifyTemplate = usageTemplate{
 	Use:   "verify [ GUN ] <target>",
 	Short: "Verifies if the content is included in the remote trusted collection",
@@ -111,7 +117,6 @@ type tufCommander struct {
 	quiet  bool
 
 	deleteIdx         []int
-	reset             bool
 	archiveChangelist string
 
 	deleteRemote bool
@@ -125,10 +130,11 @@ func (t *tufCommander) AddToCommand(cmd *cobra.Command) {
 	cmdTUFInit.Flags().BoolVarP(&t.autoPublish, "publish", "p", false, htAutoPublish)
 	cmd.AddCommand(cmdTUFInit)
 
-	cmdStatus := cmdTUFStatusTemplate.ToCommand(t.tufStatus)
-	cmdStatus.Flags().IntSliceVarP(&t.deleteIdx, "unstage", "u", nil, "Numbers of changes to delete, as shown in status list")
-	cmdStatus.Flags().BoolVar(&t.reset, "reset", false, "Reset the changelist for the GUN by deleting all pending changes")
-	cmd.AddCommand(cmdStatus)
+	cmd.AddCommand(cmdTUFStatusTemplate.ToCommand(t.tufStatus))
+
+	cmdReset := cmdTUFResetTemplate.ToCommand(t.tufReset)
+	cmdReset.Flags().IntSliceVarP(&t.deleteIdx, "unstage", "u", nil, "Numbers of specific changes to exclusively delete, as shown in status list")
+	cmd.AddCommand(cmdReset)
 
 	cmd.AddCommand(cmdTUFPublishTemplate.ToCommand(t.tufPublish))
 	cmd.AddCommand(cmdTUFLookupTemplate.ToCommand(t.tufLookup))
@@ -553,14 +559,6 @@ func (t *tufCommander) tufStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if t.reset {
-		return cl.Clear(t.archiveChangelist)
-	}
-
-	if len(t.deleteIdx) > 0 {
-		return cl.Remove(t.deleteIdx)
-	}
-
 	if len(cl.List()) == 0 {
 		cmd.Printf("No unpublished changes for %s\n", gun)
 		return nil
@@ -584,6 +582,41 @@ func (t *tufCommander) tufStatus(cmd *cobra.Command, args []string) error {
 	}
 	tw.Flush()
 	return nil
+}
+
+func (t *tufCommander) tufReset(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		cmd.Usage()
+		return fmt.Errorf("Must specify a GUN")
+	}
+
+	config, err := t.configGetter()
+	if err != nil {
+		return err
+	}
+	gun := args[0]
+
+	trustPin, err := getTrustPinning(config)
+	if err != nil {
+		return err
+	}
+
+	nRepo, err := notaryclient.NewNotaryRepository(
+		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
+	if err != nil {
+		return err
+	}
+
+	cl, err := nRepo.GetChangelist()
+	if err != nil {
+		return err
+	}
+
+
+	if len(t.deleteIdx) > 0 {
+		return cl.Remove(t.deleteIdx)
+	}
+	return cl.Clear(t.archiveChangelist)
 }
 
 func (t *tufCommander) tufPublish(cmd *cobra.Command, args []string) error {

--- a/cmd/notary/tuf_test.go
+++ b/cmd/notary/tuf_test.go
@@ -136,8 +136,6 @@ func TestStatusUnstageAndReset(t *testing.T) {
 		},
 	}
 
-	tc.reset = true
-
 	// run a reset with an empty changelist and make sure it succeeds
 	err := tc.tufStatus(&cobra.Command{}, []string{"gun"})
 	require.NoError(t, err)
@@ -163,7 +161,7 @@ func TestStatusUnstageAndReset(t *testing.T) {
 	require.Contains(t, out, "test3")
 	require.Contains(t, out, "test4")
 
-	_, err = runCommand(t, tempBaseDir, "status", "gun", "--unstage", "-1,1,3,10")
+	_, err = runCommand(t, tempBaseDir, "reset", "gun", "--unstage", "-1,1,3,10")
 	require.NoError(t, err)
 
 	out, err = runCommand(t, tempBaseDir, "status", "gun")
@@ -173,7 +171,7 @@ func TestStatusUnstageAndReset(t *testing.T) {
 	require.Contains(t, out, "test3")
 	require.NotContains(t, out, "test4")
 
-	_, err = runCommand(t, tempBaseDir, "status", "gun", "--reset")
+	_, err = runCommand(t, tempBaseDir, "reset", "gun")
 	require.NoError(t, err)
 
 	out, err = runCommand(t, tempBaseDir, "status", "gun")
@@ -206,6 +204,7 @@ func TestGetTrustPinningErrors(t *testing.T) {
 		},
 	}
 	require.Error(t, tc.tufStatus(&cobra.Command{}, []string{"gun"}))
+	require.Error(t, tc.tufReset(&cobra.Command{}, []string{"gun"}))
 	require.Error(t, tc.tufDeleteGUN(&cobra.Command{}, []string{"gun"}))
 	require.Error(t, tc.tufInit(&cobra.Command{}, []string{"gun"}))
 	require.Error(t, tc.tufPublish(&cobra.Command{}, []string{"gun"}))

--- a/cmd/notary/tuf_test.go
+++ b/cmd/notary/tuf_test.go
@@ -137,7 +137,8 @@ func TestStatusUnstageAndReset(t *testing.T) {
 	}
 
 	// run a reset with an empty changelist and make sure it succeeds
-	err := tc.tufStatus(&cobra.Command{}, []string{"gun"})
+	tc.resetAll = true
+	err := tc.tufReset(&cobra.Command{}, []string{"gun"})
 	require.NoError(t, err)
 
 	// add some targets
@@ -161,7 +162,7 @@ func TestStatusUnstageAndReset(t *testing.T) {
 	require.Contains(t, out, "test3")
 	require.Contains(t, out, "test4")
 
-	_, err = runCommand(t, tempBaseDir, "reset", "gun", "--unstage", "-1,1,3,10")
+	_, err = runCommand(t, tempBaseDir, "reset", "gun", "-n", "-1,1,3,10")
 	require.NoError(t, err)
 
 	out, err = runCommand(t, tempBaseDir, "status", "gun")
@@ -171,7 +172,7 @@ func TestStatusUnstageAndReset(t *testing.T) {
 	require.Contains(t, out, "test3")
 	require.NotContains(t, out, "test4")
 
-	_, err = runCommand(t, tempBaseDir, "reset", "gun")
+	_, err = runCommand(t, tempBaseDir, "reset", "gun", "--all")
 	require.NoError(t, err)
 
 	out, err = runCommand(t, tempBaseDir, "status", "gun")
@@ -204,6 +205,7 @@ func TestGetTrustPinningErrors(t *testing.T) {
 		},
 	}
 	require.Error(t, tc.tufStatus(&cobra.Command{}, []string{"gun"}))
+	tc.resetAll = true
 	require.Error(t, tc.tufReset(&cobra.Command{}, []string{"gun"}))
 	require.Error(t, tc.tufDeleteGUN(&cobra.Command{}, []string{"gun"}))
 	require.Error(t, tc.tufInit(&cobra.Command{}, []string{"gun"}))

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -69,17 +69,17 @@ $ notary publish <GUN>
 The Notary CLI client stages changes before publishing them to the server.
 These changes are staged locally in files such that the client can request the latest updates from the notary server, attempt to apply the staged changes on top of the new updates (like a `git rebase`), and then finally publish if the changes are still valid.
 
-You can manage the changes that are staged by running:
+You can view staged changes with `notary status` and unstage them with `notary reset`:
 
 ```bash
 # Check what changes are staged
 $ notary status <GUN>
 
 # Unstage a specific change
-$ notary status <GUN> --unstage 0
+$ notary reset <GUN> --unstage 0
 
-# Alternatively, unstage all changes
-$ notary status <GUN> --reset
+# Alternatively, reset all changes
+$ notary reset <GUN>
 ```
 
 When you're ready to publish your changes to the Notary server, run:

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -76,10 +76,10 @@ You can view staged changes with `notary status` and unstage them with `notary r
 $ notary status <GUN>
 
 # Unstage a specific change
-$ notary reset <GUN> --unstage 0
+$ notary reset <GUN> -n 0
 
 # Alternatively, reset all changes
-$ notary reset <GUN>
+$ notary reset <GUN> --all
 ```
 
 When you're ready to publish your changes to the Notary server, run:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -144,7 +144,7 @@ $ notary -s https://notary.docker.io -d ~/.docker/trust  publish docker.io/libra
 
 Note that each row in the status has a number associated with it, found in the first
 column. This number can be used to remove individual changes from the changelist if
-they are no longer desired. This is done using the `reset` command and its `--unstage` flag:
+they are no longer desired. This is done using the `reset` command:
 
 ```
 $ notary -d ~/.docker/trust status docker.io/library/alpine 
@@ -154,7 +154,9 @@ Unpublished changes for docker.io/library/alpine:
 \-  ------    -----     ----        ----
 0  delete    targets   target      2.6
 1  create    targets   target      3.0
-$ notary -d ~/.docker/trust reset docker.io/library/alpine --unstage 0
+
+$ notary -d ~/.docker/trust reset docker.io/library/alpine -n 0
+$ notary -d ~/.docker/trust status docker.io/library/alpine
 Unpublished changes for docker.io/library/alpine:
 
 \#  ACTION    SCOPE     TYPE        PATH
@@ -163,12 +165,12 @@ Unpublished changes for docker.io/library/alpine:
 ```
 
 Pay close attention to how the indices are updated as changes are removed. You may
-pass multiple `--unstage` flags with multiple indices in a single invocation of the 
+pass multiple `-n` flags with multiple indices in a single invocation of the
 `reset` subcommand and they will all be handled correctly within that invocation. Between
 invocations however, you should list the changes again to check which indices you want
 to remove.
 
-It is also possible to completely clear all pending changes by not passing any flags
+It is also possible to completely clear all pending changes by passing the `--all` flag
 to the `reset` subcommand. This deletes all pending changes for the specified GUN.
 
 ## Configure the client

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -144,7 +144,7 @@ $ notary -s https://notary.docker.io -d ~/.docker/trust  publish docker.io/libra
 
 Note that each row in the status has a number associated with it, found in the first
 column. This number can be used to remove individual changes from the changelist if
-they are no longer desired. This is done using the `--unstage` flag:
+they are no longer desired. This is done using the `reset` command and its `--unstage` flag:
 
 ```
 $ notary -d ~/.docker/trust status docker.io/library/alpine 
@@ -154,8 +154,7 @@ Unpublished changes for docker.io/library/alpine:
 \-  ------    -----     ----        ----
 0  delete    targets   target      2.6
 1  create    targets   target      3.0
-$ notary -d ~/.docker/trust status docker.io/library/alpine --unstage 0
-$ notary -d ~/.docker/trust status docker.io/library/alpine
+$ notary -d ~/.docker/trust reset docker.io/library/alpine --unstage 0
 Unpublished changes for docker.io/library/alpine:
 
 \#  ACTION    SCOPE     TYPE        PATH
@@ -165,12 +164,12 @@ Unpublished changes for docker.io/library/alpine:
 
 Pay close attention to how the indices are updated as changes are removed. You may
 pass multiple `--unstage` flags with multiple indices in a single invocation of the 
-`status` subcommand and they will all be handled correctly within that invocation. Between
+`reset` subcommand and they will all be handled correctly within that invocation. Between
 invocations however, you should list the changes again to check which indices you want
 to remove.
 
-It is also possible to completely clear all pending changes by passing the `--reset`
-to the `status` subcommand. This deletes all pending changes for the specified GUN.
+It is also possible to completely clear all pending changes by not passing any flags
+to the `reset` subcommand. This deletes all pending changes for the specified GUN.
 
 ## Configure the client
 


### PR DESCRIPTION
Factors out the `--reset` and `--unstage` flags from `notary status` into a new `notary reset` command.
The `notary status` command now does not have any flags and cannot mutate any state.

- `notary reset <GUN> --all` resets all staged changes for a gun
- `notary reset <GUN> -n 1 -n 2` resets the change items numbered `1` and `2` from `notary status <GUN>`

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>