### PR TITLE
Update error message for adding delegation if file does not exist

### DIFF
--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -296,6 +296,9 @@ func (d *delegationCommander) delegationAdd(cmd *cobra.Command, args []string) e
 			// Read public key bytes from PEM file
 			pubKeyBytes, err := ioutil.ReadFile(pubKeyPath)
 			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("file for public key does not exist: %s", pubKeyPath)
+				}
 				return fmt.Errorf("unable to read public key from file: %s", pubKeyPath)
 			}
 

--- a/cmd/notary/delegations_test.go
+++ b/cmd/notary/delegations_test.go
@@ -85,6 +85,11 @@ func TestAddInvalidDelegationCert(t *testing.T) {
 	// Should error due to expired cert
 	err = commander.delegationAdd(commander.GetCommand(), []string{"gun", "targets/delegation", tempFile.Name(), "--paths", "path"})
 	require.Error(t, err)
+
+	// Should error due to bad path
+	err = commander.delegationAdd(commander.GetCommand(), []string{"gun", "targets/delegation", "nonexistent-pathing", "--paths", "path"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file for public key does not exist")
 }
 
 func TestAddInvalidShortPubkeyCert(t *testing.T) {


### PR DESCRIPTION
From IRL discussion with @endophage, seems reasonable to have specific error messaging if a cert file doesn't exist.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>