### PR TITLE
Don't refer to /tmp in any of the tests

### DIFF
--- a/client/changelist/file_changelist_test.go
+++ b/client/changelist/file_changelist_test.go
@@ -3,7 +3,7 @@ package changelist
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,7 +51,7 @@ func TestErrorConditions(t *testing.T) {
 
 	cl, err := NewFileChangelist(tmpDir)
 	// Attempt to unmarshall a bad JSON file. Note: causes a WARN on the console.
-	ioutil.WriteFile(path.Join(tmpDir, "broken_file.change"), []byte{5}, 0644)
+	ioutil.WriteFile(filepath.Join(tmpDir, "broken_file.change"), []byte{5}, 0644)
 	noItems := cl.List()
 	require.Len(t, noItems, 0, "List returns zero items on bad JSON file error")
 
@@ -154,7 +154,7 @@ func TestFileChangeIterator(t *testing.T) {
 
 	// negative test case: bad JSON file to unmarshall via Next()
 	cl.Clear("")
-	ioutil.WriteFile(path.Join(tmpDir, "broken_file.change"), []byte{5}, 0644)
+	ioutil.WriteFile(filepath.Join(tmpDir, "broken_file.change"), []byte{5}, 0644)
 	it, err = cl.NewIterator()
 	require.Nil(t, err, "Error initializing iterator")
 	for it.HasNext() {

--- a/client/changelist/file_changelist_test.go
+++ b/client/changelist/file_changelist_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "test")
+	tmpDir, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -43,7 +43,7 @@ func TestAdd(t *testing.T) {
 
 }
 func TestErrorConditions(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "test")
+	tmpDir, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -64,7 +64,7 @@ func TestErrorConditions(t *testing.T) {
 }
 
 func TestListOrder(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "test")
+	tmpDir, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -98,7 +98,7 @@ func TestListOrder(t *testing.T) {
 }
 
 func TestFileChangeIterator(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "test")
+	tmpDir, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -235,7 +235,7 @@ func newRepoToTestRepo(t *testing.T, existingRepo *NotaryRepository, newDir bool
 // role will fail.
 func TestInitRepositoryManagedRolesIncludingRoot(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -255,7 +255,7 @@ func TestInitRepositoryManagedRolesIncludingRoot(t *testing.T) {
 // invalid role will fail.
 func TestInitRepositoryManagedRolesInvalidRole(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -272,7 +272,7 @@ func TestInitRepositoryManagedRolesInvalidRole(t *testing.T) {
 // targets role will fail.
 func TestInitRepositoryManagedRolesIncludingTargets(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -289,7 +289,7 @@ func TestInitRepositoryManagedRolesIncludingTargets(t *testing.T) {
 // timestamp key is fine - that's what it already does, so no error.
 func TestInitRepositoryManagedRolesIncludingTimestamp(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -307,7 +307,7 @@ func TestInitRepositoryManagedRolesIncludingTimestamp(t *testing.T) {
 
 func TestInitRepositoryMultipleRootKeys(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -333,7 +333,7 @@ func TestInitRepositoryMultipleRootKeys(t *testing.T) {
 // the snapshot key is available
 func TestInitRepositoryNeedsRemoteTimestampKey(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -355,7 +355,7 @@ func TestInitRepositoryNeedsRemoteTimestampKey(t *testing.T) {
 // the snapshot key, even if the timestamp key is available
 func TestInitRepositoryNeedsRemoteSnapshotKey(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory")
 	defer os.RemoveAll(tempBaseDir)
 
@@ -1986,7 +1986,7 @@ func testPublishBadMetadata(t *testing.T, roleName string, repo *NotaryRepositor
 // If the repo is not initialized, calling repo.Publish() should return ErrRepoNotInitialized
 func TestNotInitializedOnPublish(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
@@ -2015,7 +2015,7 @@ func (cs cannotCreateKeys) Create(_, _, _ string) (data.PublicKey, error) {
 // remote key.
 func TestPublishSnapshotLocalKeysCreatedFirst(t *testing.T) {
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	gun := "docker.com/notary"
@@ -2923,7 +2923,7 @@ func TestRotateRootKey(t *testing.T) {
 
 // If there is no local cache, notary operations return the remote error code
 func TestRemoteServerUnavailableNoLocalCache(t *testing.T) {
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"syscall"
@@ -289,7 +290,7 @@ func TestGetTrustServiceTLSFailure(t *testing.T) {
 
 // Just to ensure that errors are propagated
 func TestGetStoreInvalid(t *testing.T) {
-	config := `{"storage": {"backend": "asdf", "db_url": "/tmp/1234"}}`
+	config := `{"storage": {"backend": "asdf", "db_url": "doesnt_matter_what_value_this_is"}}`
 
 	var registerCalled = 0
 
@@ -301,7 +302,7 @@ func TestGetStoreInvalid(t *testing.T) {
 }
 
 func TestGetStoreDBStore(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("/tmp", "sqlite3")
+	tmpFile, err := ioutil.TempFile("", "sqlite3")
 	require.NoError(t, err)
 	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
@@ -417,8 +418,10 @@ func TestSampleConfig(t *testing.T) {
 }
 
 func TestSignalHandle(t *testing.T) {
-	f, err := os.Create("/tmp/testSignalHandle.json")
-	defer os.Remove(f.Name())
+	tempdir, err := ioutil.TempDir("", "test-signal-handle")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+	f, err := os.Create(filepath.Join(tempdir, "testSignalHandle.json"))
 	require.NoError(t, err)
 
 	f.WriteString(`{"logging": {"level": "info"}}`)

--- a/cmd/notary-signer/main_test.go
+++ b/cmd/notary-signer/main_test.go
@@ -82,7 +82,7 @@ func TestGetAddrAndTLSConfigSuccess(t *testing.T) {
 
 // If a default alias is not provided to a DB backend, an error is returned.
 func TestSetupCryptoServicesDBStoreNoDefaultAlias(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("/tmp", "sqlite3")
+	tmpFile, err := ioutil.TempFile("", "sqlite3")
 	require.NoError(t, err)
 	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
@@ -145,7 +145,7 @@ func TestSetupCryptoServicesRethinkDBStoreConnectionFails(t *testing.T) {
 // separately, so this doesn't test all the possible cases of storage
 // success/failure).
 func TestSetupCryptoServicesDBStoreSuccess(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("/tmp", "sqlite3")
+	tmpFile, err := ioutil.TempFile("", "sqlite3")
 	require.NoError(t, err)
 	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())

--- a/cmd/notary/delegations_test.go
+++ b/cmd/notary/delegations_test.go
@@ -26,7 +26,7 @@ func setup(trustDir string) *delegationCommander {
 }
 
 func TestPurgeDelegationKeys(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 
@@ -45,7 +45,7 @@ func TestPurgeDelegationKeys(t *testing.T) {
 
 func TestAddInvalidDelegationName(t *testing.T) {
 	// Setup certificate
-	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
+	tempFile, err := ioutil.TempFile("", "pemfile")
 	require.NoError(t, err)
 	cert, _, err := generateValidTestCert()
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestAddInvalidDelegationName(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)
@@ -67,7 +67,7 @@ func TestAddInvalidDelegationName(t *testing.T) {
 
 func TestAddInvalidDelegationCert(t *testing.T) {
 	// Setup certificate
-	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
+	tempFile, err := ioutil.TempFile("", "pemfile")
 	require.NoError(t, err)
 	cert, _, err := generateExpiredTestCert()
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestAddInvalidDelegationCert(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)
@@ -89,7 +89,7 @@ func TestAddInvalidDelegationCert(t *testing.T) {
 
 func TestAddInvalidShortPubkeyCert(t *testing.T) {
 	// Setup certificate
-	tempFile, err := ioutil.TempFile("/tmp", "pemfile")
+	tempFile, err := ioutil.TempFile("", "pemfile")
 	require.NoError(t, err)
 	cert, _, err := generateShortRSAKeyTestCert()
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestAddInvalidShortPubkeyCert(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)
@@ -111,7 +111,7 @@ func TestAddInvalidShortPubkeyCert(t *testing.T) {
 
 func TestRemoveInvalidDelegationName(t *testing.T) {
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)
@@ -123,7 +123,7 @@ func TestRemoveInvalidDelegationName(t *testing.T) {
 
 func TestRemoveAllInvalidDelegationName(t *testing.T) {
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)
@@ -135,7 +135,7 @@ func TestRemoveAllInvalidDelegationName(t *testing.T) {
 
 func TestAddInvalidNumArgs(t *testing.T) {
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)
@@ -147,7 +147,7 @@ func TestAddInvalidNumArgs(t *testing.T) {
 
 func TestListInvalidNumArgs(t *testing.T) {
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)
@@ -159,7 +159,7 @@ func TestListInvalidNumArgs(t *testing.T) {
 
 func TestRemoveInvalidNumArgs(t *testing.T) {
 	// Setup commander
-	tmpDir, err := ioutil.TempDir("/tmp", "notary-cmd-test-")
+	tmpDir, err := ioutil.TempDir("", "notary-cmd-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	commander := setup(tmpDir)

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -1336,7 +1336,7 @@ func TestClientKeyPassphraseChange(t *testing.T) {
 	defer server.Close()
 
 	target := "sdgkadga"
-	tempFile, err := ioutil.TempFile("/tmp", "targetfile")
+	tempFile, err := ioutil.TempFile("", "targetfile")
 	require.NoError(t, err)
 	tempFile.Close()
 	defer os.Remove(tempFile.Name())

--- a/cmd/notary/keys_nonpkcs11_test.go
+++ b/cmd/notary/keys_nonpkcs11_test.go
@@ -4,6 +4,11 @@ package main
 
 import (
 	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/docker/notary"
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/passphrase"
@@ -13,18 +18,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func TestImportKeysNoYubikey(t *testing.T) {
 	setUp(t)
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
-	input, err := ioutil.TempFile("/tmp", "notary-test-import-")
+	input, err := ioutil.TempFile("", "notary-test-import-")
 	require.NoError(t, err)
 	defer os.RemoveAll(input.Name())
 	k := &keyCommander{
@@ -84,10 +85,10 @@ func TestImportKeysNoYubikey(t *testing.T) {
 
 func TestExportImportKeysNoYubikey(t *testing.T) {
 	setUp(t)
-	exportTempDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	exportTempDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(exportTempDir)
-	tempfile, err := ioutil.TempFile("/tmp", "notary-test-import-")
+	tempfile, err := ioutil.TempFile("", "notary-test-import-")
 	require.NoError(t, err)
 	tempfile.Close()
 	defer os.RemoveAll(tempfile.Name())
@@ -122,7 +123,7 @@ func TestExportImportKeysNoYubikey(t *testing.T) {
 
 	exportCommander.exportKeys(&cobra.Command{}, nil)
 
-	importTempDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	importTempDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(importTempDir)
 	importCommander := &keyCommander{

--- a/cmd/notary/keys_pkcs11_test.go
+++ b/cmd/notary/keys_pkcs11_test.go
@@ -26,10 +26,10 @@ func TestImportWithYubikey(t *testing.T) {
 		t.Skip("Must have Yubikey access.")
 	}
 	setUp(t)
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
-	input, err := ioutil.TempFile("/tmp", "notary-test-import-")
+	input, err := ioutil.TempFile("", "notary-test-import-")
 	require.NoError(t, err)
 	defer os.RemoveAll(input.Name())
 	k := &keyCommander{
@@ -99,7 +99,7 @@ func TestGetImporters(t *testing.T) {
 	if !yubikey.IsAccessible() {
 		t.Skip("Must have Yubikey access.")
 	}
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 	importers, err := getImporters(tempBaseDir, passphrase.ConstantRetriever("pass"))

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
+	"path/filepath"
+
 	"github.com/docker/notary"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/cryptoservice"
@@ -30,7 +32,6 @@ import (
 	"github.com/docker/notary/trustpinning"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/utils"
-	"path/filepath"
 )
 
 var ret = passphrase.ConstantRetriever("pass")
@@ -353,7 +354,7 @@ func TestRotateKeyRemoteServerManagesKey(t *testing.T) {
 	for _, role := range []string{data.CanonicalSnapshotRole, data.CanonicalTimestampRole} {
 		setUp(t)
 		// Temporary directory where test files will be created
-		tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+		tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 		defer os.RemoveAll(tempBaseDir)
 		require.NoError(t, err, "failed to create a temporary directory: %s", err)
 		gun := "docker.com/notary"
@@ -408,7 +409,7 @@ func TestRotateKeyRemoteServerManagesKey(t *testing.T) {
 func TestRotateKeyBothKeys(t *testing.T) {
 	setUp(t)
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	gun := "docker.com/notary"
@@ -467,7 +468,7 @@ func TestRotateKeyBothKeys(t *testing.T) {
 func TestRotateKeyRootIsInteractive(t *testing.T) {
 	setUp(t)
 	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	defer os.RemoveAll(tempBaseDir)
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	gun := "docker.com/notary"
@@ -539,10 +540,10 @@ func TestChangeKeyPassphraseNonexistentID(t *testing.T) {
 
 func TestExportKeys(t *testing.T) {
 	setUp(t)
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
-	output, err := ioutil.TempFile("/tmp", "notary-test-import-")
+	output, err := ioutil.TempFile("", "notary-test-import-")
 	require.NoError(t, err)
 	defer os.RemoveAll(output.Name())
 	k := &keyCommander{
@@ -607,10 +608,10 @@ func TestExportKeys(t *testing.T) {
 
 func TestExportKeysByGUN(t *testing.T) {
 	setUp(t)
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
-	output, err := ioutil.TempFile("/tmp", "notary-test-import-")
+	output, err := ioutil.TempFile("", "notary-test-import-")
 	require.NoError(t, err)
 	defer os.RemoveAll(output.Name())
 	k := &keyCommander{
@@ -688,10 +689,10 @@ func TestExportKeysByGUN(t *testing.T) {
 
 func TestExportKeysByID(t *testing.T) {
 	setUp(t)
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
-	output, err := ioutil.TempFile("/tmp", "notary-test-import-")
+	output, err := ioutil.TempFile("", "notary-test-import-")
 	require.NoError(t, err)
 	defer os.RemoveAll(output.Name())
 	k := &keyCommander{
@@ -749,10 +750,10 @@ func TestExportKeysByID(t *testing.T) {
 
 func TestExportKeysBadFlagCombo(t *testing.T) {
 	setUp(t)
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
-	output, err := ioutil.TempFile("/tmp", "notary-test-import-")
+	output, err := ioutil.TempFile("", "notary-test-import-")
 	require.NoError(t, err)
 	defer os.RemoveAll(output.Name())
 	k := &keyCommander{
@@ -774,7 +775,7 @@ func TestExportKeysBadFlagCombo(t *testing.T) {
 
 func TestImportKeysNonexistentFile(t *testing.T) {
 	setUp(t)
-	tempBaseDir, err := ioutil.TempDir("/tmp", "notary-test-")
+	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempBaseDir)
 	require.NoError(t, err)

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -525,10 +525,34 @@ func TestConfigFileTrustPinning(t *testing.T) {
 	require.Equal(t, "root-ca.crt", trustPin.CA["repo4"])
 }
 
+// sets the env vars to empty, and returns a function to reset them at the end
+func cleanupAndSetEnvVars() func() {
+	orig := map[string]string{
+		"NOTARY_ROOT_PASSPHRASE":       "",
+		"NOTARY_TARGETS_PASSPHRASE":    "",
+		"NOTARY_SNAPSHOT_PASSPHRASE":   "",
+		"NOTARY_DELEGATION_PASSPHRASE": "",
+	}
+	for envVar := range orig {
+		orig[envVar] = os.Getenv(envVar)
+		os.Setenv(envVar, "")
+	}
+
+	return func() {
+		for envVar, value := range orig {
+			if value == "" {
+				os.Unsetenv(envVar)
+			} else {
+				os.Setenv(envVar, value)
+			}
+		}
+	}
+}
+
 func TestPassphraseRetrieverCaching(t *testing.T) {
+	defer cleanupAndSetEnvVars()()
 	// Only set up one passphrase environment var first for root
 	require.NoError(t, os.Setenv("NOTARY_ROOT_PASSPHRASE", "root_passphrase"))
-	defer os.Clearenv()
 
 	// Check that root is cached
 	retriever := getPassphraseRetriever()
@@ -581,9 +605,9 @@ func TestPassphraseRetrieverCaching(t *testing.T) {
 }
 
 func TestPassphraseRetrieverDelegationRoleCaching(t *testing.T) {
+	defer cleanupAndSetEnvVars()()
 	// Only set up one passphrase environment var first for delegations
 	require.NoError(t, os.Setenv("NOTARY_DELEGATION_PASSPHRASE", "delegation_passphrase"))
-	defer os.Clearenv()
 
 	// Check that any delegation role is cached
 	retriever := getPassphraseRetriever()

--- a/storage/filestore.go
+++ b/storage/filestore.go
@@ -2,18 +2,18 @@ package storage
 
 import (
 	"fmt"
-	"github.com/docker/notary"
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/docker/notary"
 )
 
 // NewFilesystemStore creates a new store in a directory tree
 func NewFilesystemStore(baseDir, subDir, extension string) (*FilesystemStore, error) {
-	baseDir = path.Join(baseDir, subDir)
+	baseDir = filepath.Join(baseDir, subDir)
 
 	return NewFileStore(baseDir, extension, notary.PrivKeyPerms)
 }

--- a/storage/filestore_test.go
+++ b/storage/filestore_test.go
@@ -9,17 +9,19 @@ import (
 
 	"crypto/rand"
 	"fmt"
+	"strconv"
+
 	"github.com/docker/notary"
 	"github.com/stretchr/testify/require"
-	"strconv"
 )
 
-const testDir = "/tmp/testFilesystemStore/"
-
 func TestNewFilesystemStore(t *testing.T) {
-	_, err := NewFilesystemStore(testDir, "metadata", "json")
-	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
+
+	_, err = NewFilesystemStore(testDir, "metadata", "json")
+	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 
 	info, err := os.Stat(path.Join(testDir, "metadata"))
 	require.Nil(t, err, "Error attempting to stat metadata dir: %v", err)
@@ -28,6 +30,10 @@ func TestNewFilesystemStore(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
@@ -43,6 +49,10 @@ func TestSet(t *testing.T) {
 }
 
 func TestSetWithNoParentDirectory(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
@@ -59,6 +69,10 @@ func TestSetWithNoParentDirectory(t *testing.T) {
 
 // if something already existed there, remove it first and write a new file
 func TestSetRemovesExistingFileBeforeWriting(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
@@ -76,6 +90,10 @@ func TestSetRemovesExistingFileBeforeWriting(t *testing.T) {
 }
 
 func TestGetSized(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)
@@ -102,6 +120,10 @@ func TestGetSized(t *testing.T) {
 }
 
 func TestGetSizedSet(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	require.NoError(t, err, "Initializing FilesystemStore returned unexpected error", err)
 	defer os.RemoveAll(testDir)
@@ -110,6 +132,10 @@ func TestGetSizedSet(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	require.NoError(t, err, "Initializing FilesystemStore returned unexpected error", err)
 	defer os.RemoveAll(testDir)
@@ -118,6 +144,10 @@ func TestRemove(t *testing.T) {
 }
 
 func TestRemoveAll(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	s, err := NewFilesystemStore(testDir, "metadata", "json")
 	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 	defer os.RemoveAll(testDir)

--- a/storage/filestore_test.go
+++ b/storage/filestore_test.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +22,7 @@ func TestNewFilesystemStore(t *testing.T) {
 	_, err = NewFilesystemStore(testDir, "metadata", "json")
 	require.Nil(t, err, "Initializing FilesystemStore returned unexpected error: %v", err)
 
-	info, err := os.Stat(path.Join(testDir, "metadata"))
+	info, err := os.Stat(filepath.Join(testDir, "metadata"))
 	require.Nil(t, err, "Error attempting to stat metadata dir: %v", err)
 	require.NotNil(t, info, "Nil FileInfo from stat on metadata dir")
 	require.True(t, 0700&info.Mode() != 0, "Metadata directory is not writable")
@@ -43,7 +42,7 @@ func TestSet(t *testing.T) {
 	err = s.Set("testMeta", testContent)
 	require.Nil(t, err, "Set returned unexpected error: %v", err)
 
-	content, err := ioutil.ReadFile(path.Join(testDir, "metadata", "testMeta.json"))
+	content, err := ioutil.ReadFile(filepath.Join(testDir, "metadata", "testMeta.json"))
 	require.Nil(t, err, "Error reading file: %v", err)
 	require.Equal(t, testContent, content, "Content written to file was corrupted.")
 }
@@ -62,7 +61,7 @@ func TestSetWithNoParentDirectory(t *testing.T) {
 	err = s.Set("noexist/"+"testMeta", testContent)
 	require.Nil(t, err, "Set returned unexpected error: %v", err)
 
-	content, err := ioutil.ReadFile(path.Join(testDir, "metadata", "noexist/testMeta.json"))
+	content, err := ioutil.ReadFile(filepath.Join(testDir, "metadata", "noexist/testMeta.json"))
 	require.Nil(t, err, "Error reading file: %v", err)
 	require.Equal(t, testContent, content, "Content written to file was corrupted.")
 }
@@ -84,7 +83,7 @@ func TestSetRemovesExistingFileBeforeWriting(t *testing.T) {
 	err = s.Set("root", testContent)
 	require.NoError(t, err, "Set returned unexpected error: %v", err)
 
-	content, err := ioutil.ReadFile(path.Join(testDir, "metadata", "root.json"))
+	content, err := ioutil.ReadFile(filepath.Join(testDir, "metadata", "root.json"))
 	require.NoError(t, err, "Error reading file: %v", err)
 	require.Equal(t, testContent, content, "Content written to file was corrupted.")
 }
@@ -100,7 +99,7 @@ func TestGetSized(t *testing.T) {
 
 	testContent := []byte("test data")
 
-	ioutil.WriteFile(path.Join(testDir, "metadata", "testMeta.json"), testContent, 0600)
+	ioutil.WriteFile(filepath.Join(testDir, "metadata", "testMeta.json"), testContent, 0600)
 
 	content, err := s.GetSized("testMeta", int64(len(testContent)))
 	require.Nil(t, err, "GetSized returned unexpected error: %v", err)
@@ -155,7 +154,7 @@ func TestRemoveAll(t *testing.T) {
 	testContent := []byte("test data")
 
 	// Write some files in metadata and targets dirs
-	metaPath := path.Join(testDir, "metadata", "testMeta.json")
+	metaPath := filepath.Join(testDir, "metadata", "testMeta.json")
 	ioutil.WriteFile(metaPath, testContent, 0600)
 
 	// Remove all

--- a/tuf/tuf_test.go
+++ b/tuf/tuf_test.go
@@ -109,14 +109,18 @@ func writeRepo(t *testing.T, dir string, repo *Repo) {
 }
 
 func TestInitRepo(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
 	ed25519 := signed.NewEd25519()
 	repo := initRepo(t, ed25519)
-	writeRepo(t, "/tmp/tufrepo", repo)
+	writeRepo(t, testDir, repo)
 	// after signing a new repo, there are only 4 roles: the 4 base roles
 	require.Len(t, repo.Root.Signed.Roles, 4)
 
 	// can't use getBaseRole because it's not a valid real role
-	_, err := repo.Root.BuildBaseRole("root.1")
+	_, err = repo.Root.BuildBaseRole("root.1")
 	require.Error(t, err)
 }
 

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -471,16 +472,19 @@ func TestParseViperWithInvalidFile(t *testing.T) {
 }
 
 func TestParseViperWithValidFile(t *testing.T) {
-	file, err := os.Create("/tmp/Chronicle_Of_Dark_Secrets.json")
+	testDir, err := ioutil.TempDir("", "testdir")
 	require.NoError(t, err)
-	defer os.Remove(file.Name())
+	defer os.RemoveAll(testDir)
+
+	file, err := os.Create(filepath.Join(testDir, "Chronicle_Of_Dark_Secrets.json"))
+	require.NoError(t, err)
 
 	file.WriteString(`{"logging": {"level": "debug"}}`)
 
 	v := viper.New()
 	SetupViper(v, envPrefix)
 
-	err = ParseViper(v, "/tmp/Chronicle_Of_Dark_Secrets.json")
+	err = ParseViper(v, file.Name())
 	require.NoError(t, err)
 
 	require.Equal(t, "debug", v.GetString("logging.level"))


### PR DESCRIPTION
Don't use a temp prefix in any of our `ioutil.TempDir`, etc. calls.

This also creates tempfiles and tempdirs wherever we attempt to directly write to hardcoded location in `/tmp`.

Also change some places that were previously using `path.Join` for file handling to `filepath.Join`.

Addresses a couple of points in #551.