### PR TITLE
Do not support SIGUSR1 and SIGUSR2 syscall handling in windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 CTIMEVAR=-X $(NOTARY_PKG)/version.GitCommit=$(GITCOMMIT) -X $(NOTARY_PKG)/version.NotaryVersion=$(NOTARY_VERSION)
 GO_LDFLAGS=-ldflags "-w $(CTIMEVAR)"
 GO_LDFLAGS_STATIC=-ldflags "-w $(CTIMEVAR) -extldflags -static"
-GOOSES = darwin linux
+GOOSES = darwin linux windows
 NOTARY_BUILDTAGS ?= pkcs11
 NOTARYDIR := /go/src/github.com/docker/notary
 

--- a/buildscripts/circle_parallelism.sh
+++ b/buildscripts/circle_parallelism.sh
@@ -8,6 +8,7 @@ case $CIRCLE_NODE_INDEX in
    ;;
 2) SKIPENVCHECK=1 make TESTDB=mysql testdb
    SKIPENVCHECK=1 make TESTDB=mysql integration
+   SKIPENVCHECK=1 make cross  # just trying not to exceed 5 builders
    ;;
 3) SKIPENVCHECK=1 make TESTDB=rethink testdb
    SKIPENVCHECK=1 make TESTDB=rethink integration

--- a/buildscripts/covertest.py
+++ b/buildscripts/covertest.py
@@ -32,7 +32,7 @@ def get_coverprofile_filename(pkg, buildtags):
         buildtags = "." + buildtags.replace(' ', '.')
     return pkg.replace('/', '-').replace(' ', '_') + buildtags + ".coverage.txt"
 
-def run_test_with_coverage(buildtags="", coverdir=".cover", pkgs=None, opts="", covermode="count"):
+def run_test_with_coverage(buildtags="", coverdir=".cover", pkgs=None, opts="", covermode="atomic"):
     """
     Run go test with coverage over the the given packages, with the following options
     """

--- a/cmd/notary-server/config.go
+++ b/cmd/notary-server/config.go
@@ -3,12 +3,9 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
-	"os"
-	"os/signal"
 	"path"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -292,32 +289,4 @@ func parseServerConfig(configFilePath string, hRegister healthRegister, doBootst
 		CurrentCacheControlConfig:    currentCache,
 		ConsistentCacheControlConfig: consistentCache,
 	}, nil
-}
-
-func setupSignalTrap() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, notary.NotarySupportedSignals...)
-	go func() {
-		for {
-			signalHandle(<-c)
-		}
-	}()
-}
-
-// signalHandle will increase/decrease the logging level via the signal we get.
-func signalHandle(sig os.Signal) {
-	switch sig {
-	case syscall.SIGUSR1:
-		if err := utils.AdjustLogLevel(true); err != nil {
-			fmt.Printf("Attempt to increase log level failed, will remain at %s level, error: %s\n", logrus.GetLevel(), err)
-			return
-		}
-	case syscall.SIGUSR2:
-		if err := utils.AdjustLogLevel(false); err != nil {
-			fmt.Printf("Attempt to decrease log level failed, will remain at %s level, error: %s\n", logrus.GetLevel(), err)
-			return
-		}
-	}
-
-	fmt.Println("Successfully setting log level to ", logrus.GetLevel())
 }

--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/signal"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/health"
 	"github.com/docker/notary/server"
+	"github.com/docker/notary/utils"
 	"github.com/docker/notary/version"
 )
 
@@ -61,7 +63,10 @@ func main() {
 		logrus.Fatal(err.Error())
 	}
 
-	setupSignalTrap()
+	c := utils.SetupSignalTrap(utils.LogLevelSignalHandle)
+	if c != nil {
+		defer signal.Stop(c)
+	}
 
 	if flagStorage.doBootstrap {
 		err = bootstrap(ctx)

--- a/cmd/notary-server/main_test.go
+++ b/cmd/notary-server/main_test.go
@@ -6,14 +6,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/health"
 	"github.com/docker/notary"
 	"github.com/docker/notary/server/storage"
@@ -415,31 +412,4 @@ func TestSampleConfig(t *testing.T) {
 
 	// once for the DB, once for the trust service
 	require.Equal(t, registerCalled, 2)
-}
-
-func TestSignalHandle(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "test-signal-handle")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
-	f, err := os.Create(filepath.Join(tempdir, "testSignalHandle.json"))
-	require.NoError(t, err)
-
-	f.WriteString(`{"logging": {"level": "info"}}`)
-
-	v := viper.New()
-	utils.SetupViper(v, "envPrefix")
-	err = utils.ParseViper(v, f.Name())
-	require.NoError(t, err)
-
-	// Info + SIGUSR1 -> Debug
-	signalHandle(syscall.SIGUSR1)
-	require.Equal(t, logrus.GetLevel(), logrus.DebugLevel)
-
-	// Debug + SIGUSR1 -> Debug
-	signalHandle(syscall.SIGUSR1)
-	require.Equal(t, logrus.GetLevel(), logrus.DebugLevel)
-
-	// Debug + SIGUSR2-> Info
-	signalHandle(syscall.SIGUSR2)
-	require.Equal(t, logrus.GetLevel(), logrus.InfoLevel)
 }

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -6,8 +6,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/notary/utils"
 	"github.com/docker/notary/version"
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -64,6 +66,11 @@ func main() {
 
 	if flagStorage.debug {
 		log.Println("RPC server listening on", signerConfig.GRPCAddr)
+	}
+
+	c := utils.SetupSignalTrap(utils.LogLevelSignalHandle)
+	if c != nil {
+		defer signal.Stop(c)
 	}
 
 	grpcServer.Serve(lis)

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -343,10 +344,10 @@ func TestConfigFileTLSCanBeRelativeToConfigOrAbsolute(t *testing.T) {
 		"remote_server": {
 			"url": "%s",
 			"root_ca": "root-ca.crt",
-			"tls_client_cert": "%s",
+			"tls_client_cert": %s,
 			"tls_client_key": "notary-server.key"
 		}
-	}`, s.URL, filepath.Join(tempDir, "notary-server.crt"))
+	}`, s.URL, strconv.Quote(filepath.Join(tempDir, "notary-server.crt")))
 	configFile.Close()
 
 	// copy the certs to be relative to the config directory

--- a/const.go
+++ b/const.go
@@ -1,10 +1,6 @@
 package notary
 
-import (
-	"os"
-	"syscall"
-	"time"
-)
+import "time"
 
 // application wide constants
 const (
@@ -71,12 +67,4 @@ var NotaryDefaultExpiries = map[string]time.Duration{
 	"targets":   NotaryTargetsExpiry,
 	"snapshot":  NotarySnapshotExpiry,
 	"timestamp": NotaryTimestampExpiry,
-}
-
-// NotarySupportedSignals contains the signals we would like to capture:
-// - SIGUSR1, indicates a increment of the log level.
-// - SIGUSR2, indicates a decrement of the log level.
-var NotarySupportedSignals = []os.Signal{
-	syscall.SIGUSR1,
-	syscall.SIGUSR2,
 }

--- a/const_nowindows.go
+++ b/const_nowindows.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package notary
+
+import (
+	"os"
+	"syscall"
+)
+
+// NotarySupportedSignals contains the signals we would like to capture:
+// - SIGUSR1, indicates a increment of the log level.
+// - SIGUSR2, indicates a decrement of the log level.
+var NotarySupportedSignals = []os.Signal{
+	syscall.SIGUSR1,
+	syscall.SIGUSR2,
+}

--- a/const_windows.go
+++ b/const_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package notary
+
+import "os"
+
+// NotarySupportedSignals does not contain any signals, because SIGUSR1/2 are not supported on windows
+var NotarySupportedSignals = []os.Signal{}

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -362,9 +362,11 @@ Example:
 </table>
 
 ## Hot logging level reload
-We don't support completely reloading notary configuration files yet at present. What we support for now is:
+We don't support completely reloading notary configuration files yet at present. What we support for Linux and OSX now is:
 - increase logging level by signaling `SIGUSR1`
 - decrease logging level by signaling `SIGUSR2`
+
+No signals and no dynamic logging level changes are supported for Windows yet.
 
 Example:
 

--- a/docs/reference/signer-config.md
+++ b/docs/reference/signer-config.md
@@ -210,6 +210,44 @@ The environment variables for the older passwords are optional, but Notary
 Signer will not be able to decrypt older keys if they are not provided, and
 attempts to sign data using those keys will fail.
 
+## Hot logging level reload
+We don't support completely reloading notary signer configuration files yet at present. What we support for Linux and OSX now is:
+- increase logging level by signaling `SIGUSR1`
+- decrease logging level by signaling `SIGUSR2`
+
+No signals and no dynamic logging level changes are supported for Windows yet.
+
+Example:
+
+To increase logging level
+```
+$ kill -s SIGUSR1 PID
+
+or
+
+$ docker exec -i CONTAINER_ID kill -s SIGUSR1 PID
+```
+
+To decrease logging level
+```
+$ kill -s SIGUSR2 PID
+
+or
+
+$ docker exec -i CONTAINER_ID kill -s SIGUSR2 PID
+```
+PID is the process id of `notary-signer` and it may not the PID 1 process if you are running
+the container with some kind of wrapper startup script or something.
+
+You can get the PID of `notary-signer` through
+```
+$ docker exec CONTAINER_ID ps aux
+
+or
+
+$ ps aux | grep "notary-signer -config" | grep -v "grep"
+```
+
 
 ## Related information
 

--- a/utils/configuration.go
+++ b/utils/configuration.go
@@ -5,6 +5,8 @@ package utils
 import (
 	"crypto/tls"
 	"fmt"
+	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 
@@ -243,4 +245,21 @@ func AdjustLogLevel(increment bool) error {
 
 	logrus.SetLevel(lvl)
 	return nil
+}
+
+// SetupSignalTrap is a utility to trap supported signals hand handle them (currently by increasing logging)
+func SetupSignalTrap(handler func(os.Signal)) chan os.Signal {
+	if len(notary.NotarySupportedSignals) == 0 {
+		return nil
+
+	}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, notary.NotarySupportedSignals...)
+	go func() {
+		for {
+			handler(<-c)
+		}
+	}()
+
+	return c
 }

--- a/utils/configuration_nowindows.go
+++ b/utils/configuration_nowindows.go
@@ -25,5 +25,5 @@ func LogLevelSignalHandle(sig os.Signal) {
 		}
 	}
 
-	fmt.Println("Successfully setting log level to ", logrus.GetLevel())
+	fmt.Println("Successfully setting log level to", logrus.GetLevel())
 }

--- a/utils/configuration_nowindows.go
+++ b/utils/configuration_nowindows.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// LogLevelSignalHandle will increase/decrease the logging level via the signal we get.
+func LogLevelSignalHandle(sig os.Signal) {
+	switch sig {
+	case syscall.SIGUSR1:
+		if err := AdjustLogLevel(true); err != nil {
+			fmt.Printf("Attempt to increase log level failed, will remain at %s level, error: %s\n", logrus.GetLevel(), err)
+			return
+		}
+	case syscall.SIGUSR2:
+		if err := AdjustLogLevel(false); err != nil {
+			fmt.Printf("Attempt to decrease log level failed, will remain at %s level, error: %s\n", logrus.GetLevel(), err)
+			return
+		}
+	}
+
+	fmt.Println("Successfully setting log level to ", logrus.GetLevel())
+}

--- a/utils/configuration_nowindows_test.go
+++ b/utils/configuration_nowindows_test.go
@@ -1,0 +1,33 @@
+// +build !windows
+
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogLevelSignalHandle(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "test-signal-handle")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	logrus.SetLevel(logrus.InfoLevel)
+
+	// Info + SIGUSR1 -> Debug
+	LogLevelSignalHandle(syscall.SIGUSR1)
+	require.Equal(t, logrus.GetLevel(), logrus.DebugLevel)
+
+	// Debug + SIGUSR1 -> Debug
+	LogLevelSignalHandle(syscall.SIGUSR1)
+	require.Equal(t, logrus.GetLevel(), logrus.DebugLevel)
+
+	// Debug + SIGUSR2-> Info
+	LogLevelSignalHandle(syscall.SIGUSR2)
+	require.Equal(t, logrus.GetLevel(), logrus.InfoLevel)
+}

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -536,7 +536,7 @@ func TestAdjustLogLevel(t *testing.T) {
 	}
 }
 
-func TestSetSignalTrap(t *testing.T) {
+func testSetSignalTrap(t *testing.T) {
 	var signalsPassedOn map[string]struct{}
 
 	signalHandler := func(s os.Signal) {
@@ -559,4 +559,17 @@ func TestSetSignalTrap(t *testing.T) {
 		require.Len(t, signalsPassedOn, 0)
 		require.NotNil(t, signalsPassedOn[s.String()])
 	}
+}
+
+// TODO: undo this extra indirection, needed for mocking notary.NotarySupportedSignals being empty, when we have
+// a windows CI system running
+func TestSetSignalTrap(t *testing.T) {
+	testSetSignalTrap(t)
+}
+
+func TestSetSignalTrapMockWindows(t *testing.T) {
+	old := notary.NotarySupportedSignals
+	notary.NotarySupportedSignals = nil
+	testSetSignalTrap(t)
+	notary.NotarySupportedSignals = old
 }

--- a/utils/configuration_windows.go
+++ b/utils/configuration_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package utils
+
+import "os"
+
+// LogLevelSignalHandle will do nothing, because we aren't currently supporting signal handling in windows
+func LogLevelSignalHandle(sig os.Signal) {
+}


### PR DESCRIPTION
Since they don't exist in Windows.  While I was at it, since I had to create a bunch of windows-specific and non-windows-specific files, I moved the signal handling code to `utils` so that it can also be used by the signer (that way we don't have windows/non-windows files for both server and signer).

Technically I think the only change that would have been necessary to make the windows client build is the `const.go` change, and I don't think we care about supporting windows for server/signer, but the server and signer changes are added for completeness (and if we want to run full unit tests in windows).

Unfortunately we don't have any windows CI systems yet.  :|  Although I did add at least cross-compiling to windows to our CI runs.

Addresses part of #551.
Fixes #791.

Note: possibly we want to rebase this to 0.4.0 so that it can be added to 0.4.1 