### PR TITLE
Client should fall back on cache if operating offline when updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 + Output message to CLI when repo changes have been successfully published [#974](https://github.com/docker/notary/pull/974)
 + Improved error messages for client authentication errors and for the witness command [#972](https://github.com/docker/notary/pull/972)
 + Support for finding keys that are anywhere in the notary directory's "private" directory, not just under "private/root_keys" or "private/tuf_keys" [#981](https://github.com/docker/notary/pull/981)
++ Previously, on any error updating, the client would fall back on the cache.  Now we only do so if there is a network error or if the server is unavailable or missing the TUF data. Invalid TUF data will cause the update to fail - for example if there was an invalid root rotation. [#982](https://github.com/docker/notary/pull/982)
 
 ## [v0.4.0](https://github.com/docker/notary/releases/tag/v0.4.0) 9/21/2016
 + Server-managed key rotations [#889](https://github.com/docker/notary/pull/889)

--- a/client/tufclient.go
+++ b/client/tufclient.go
@@ -116,7 +116,7 @@ func (c *TUFClient) downloadTimestamp() error {
 	switch remoteErr.(type) {
 	case nil:
 		return nil
-	case store.ErrMetaNotFound, store.ErrServerUnavailable:
+	case store.ErrMetaNotFound, store.ErrServerUnavailable, store.ErrOffline, store.NetworkError:
 		break
 	default:
 		return remoteErr


### PR DESCRIPTION
If the client is in offline mode, or encounters some kind of network error when downloading a new timestamp, it should fall back on using the version of the repo in the cache.

Since there a huge number of possible network errors, just wrap any errors received when actually making the HTTP request using the remote store in a `NetworkError`.