### PR TITLE
custom autobuild script to create minimal build

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+serverTag="server"
+signerTag="signer"
+
+# build server and signer images
+docker build -t $serverTag -f server.Dockerfile .
+docker build -t $signerTag -f signer.Dockerfile .
+
+mkdir ./bin
+
+# ensure the containers are removed if they already exist
+docker rm -f server signer
+
+# copy binaries out of images
+loc=$(docker run --name=server --entrypoint=which $serverTag notary-server)
+docker cp server:$loc ./bin/notary-server
+docker cp server:/go/bin/migrate ./bin/migrate
+docker cp server:/lib/ld-musl-x86_64.so.1 ./bin/ld-musl-x86_64.so.1
+
+loc=$(docker run --name=signer --entrypoint=which $signerTag notary-signer)
+docker cp signer:$loc ./bin/notary-signer
+
+# build minimal server and signer images
+docker build -t $DOCKER_REPO:${serverTag}-$DOCKER_TAG -f server.minimal.Dockerfile .
+docker build -t $DOCKER_REPO:${signerTag}-$DOCKER_TAG -f signer.minimal.Dockerfile .

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+serverTag="server"
+signerTag="signer"
+
+docker push $DOCKER_REPO:${serverTag}-$DOCKER_TAG 
+docker push $DOCKER_REPO:${signerTag}-$DOCKER_TAG 

--- a/server.minimal.Dockerfile
+++ b/server.minimal.Dockerfile
@@ -1,0 +1,19 @@
+FROM busybox:latest
+MAINTAINER David Lawrence "david.lawrence@docker.com"
+
+# the ln is for compatibility with the docker-compose.yml, making these
+# images a straight swap for the those built in the compose file.
+RUN mkdir -p /usr/bin /var/lib && ln -s /bin/env /usr/bin/env
+
+COPY ./bin/notary-server /usr/bin/notary-server
+COPY ./bin/migrate /usr/bin/migrate
+COPY ./bin/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY ./fixtures /var/lib/notary/fixtures
+COPY ./migrations /var/lib/notary/migrations
+
+WORKDIR /var/lib/notary
+ENV SERVICE_NAME=notary_server
+EXPOSE 4443
+
+ENTRYPOINT [ "/usr/bin/notary-server" ]
+CMD [ "-config=/var/lib/notary/fixtures/server-config-local.json" ]

--- a/signer.minimal.Dockerfile
+++ b/signer.minimal.Dockerfile
@@ -1,0 +1,20 @@
+FROM busybox:latest
+MAINTAINER David Lawrence "david.lawrence@docker.com"
+
+# the ln is for compatibility with the docker-compose.yml, making these
+# images a straight swap for the those built in the compose file.
+RUN mkdir -p /usr/bin /var/lib && ln -s /bin/env /usr/bin/env
+
+COPY ./bin/notary-signer /usr/bin/notary-signer
+COPY ./bin/migrate /usr/bin/migrate
+COPY ./bin/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY ./fixtures /var/lib/notary/fixtures
+COPY ./migrations /var/lib/notary/migrations
+
+WORKDIR /var/lib/notary
+ENV SERVICE_NAME=notary_signer
+ENV NOTARY_SIGNER_DEFAULT_ALIAS="timestamp_1"
+ENV NOTARY_SIGNER_TIMESTAMP_1="testpassword"
+
+ENTRYPOINT [ "/usr/bin/notary-signer" ]
+CMD [ "-config=/var/lib/notary/fixtures/signer-config-local.json" ]


### PR DESCRIPTION
~~I need to test the builds but samples can be found on docker hub under endophage/notaryauto. These minimal images cut us down from ~160MB to ~5MB~~

~~Reminder to self: reset the docker-compose.yml to master's version before submitting this for review. Been using it to test the new images.~~

Tested and reset docker-compose.yml. These new hooks will be used by anyone setting up an autobuild of this on docker hub/cloud. They produce very minimal images based on busy box. Relative sizes are ~25MB each for server and signer vs a little over 500MB for the existing images built from `server.Dockerfile` and `signer.Dockerfile` (N.B. these are the sizes once unpacked on disk, hub shows much smaller sizes still, unsure if this is a miscalculation or they really compress that well).

p.s. as soon as we merge this to master, the dockersecurity/notary_autobuilds on docker hub will start using these images

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)