### PR TITLE
make cache injectable into NotaryRepository

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -86,7 +86,7 @@ func Test0Dot1Migration(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	_, err = NewNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	_, err = NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -133,7 +133,7 @@ func Test0Dot3Migration(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	_, err = NewNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	_, err = NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -189,7 +189,7 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	repo, err := NewNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	repo, err := NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -204,7 +204,7 @@ func Test0Dot1RepoFormat(t *testing.T) {
 
 	// delete the timestamp metadata, since the server will ignore the uploaded
 	// one and try to create a new one from scratch, which will be the wrong version
-	require.NoError(t, repo.fileStore.Remove(data.CanonicalTimestampRole))
+	require.NoError(t, repo.cache.Remove(data.CanonicalTimestampRole))
 
 	// rotate the timestamp key, since the server doesn't have that one
 	err = repo.RotateKey(data.CanonicalTimestampRole, true)
@@ -249,7 +249,7 @@ func Test0Dot3RepoFormat(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	repo, err := NewNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	repo, err := NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -263,7 +263,7 @@ func Test0Dot3RepoFormat(t *testing.T) {
 
 	// delete the timestamp metadata, since the server will ignore the uploaded
 	// one and try to create a new one from scratch, which will be the wrong version
-	require.NoError(t, repo.fileStore.Remove(data.CanonicalTimestampRole))
+	require.NoError(t, repo.cache.Remove(data.CanonicalTimestampRole))
 
 	// rotate the timestamp key, since the server doesn't have that one
 	err = repo.RotateKey(data.CanonicalTimestampRole, true)
@@ -315,7 +315,7 @@ func TestDownloading0Dot1RepoFormat(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(repoDir)
 
-	repo, err := NewNotaryRepository(repoDir, gun, ts.URL, http.DefaultTransport,
+	repo, err := NewFileCachedNotaryRepository(repoDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -340,7 +340,7 @@ func TestDownloading0Dot3RepoFormat(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(repoDir)
 
-	repo, err := NewNotaryRepository(repoDir, gun, ts.URL, http.DefaultTransport,
+	repo, err := NewFileCachedNotaryRepository(repoDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -31,7 +31,7 @@ func newBlankRepo(t *testing.T, url string) *NotaryRepository {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
-	repo, err := NewNotaryRepository(tempBaseDir, "docker.com/notary", url,
+	repo, err := NewFileCachedNotaryRepository(tempBaseDir, "docker.com/notary", url,
 		http.DefaultTransport, passphrase.ConstantRetriever("pass"), trustpinning.TrustPinConfig{})
 	require.NoError(t, err)
 	return repo
@@ -106,12 +106,12 @@ func TestUpdateSucceedsEvenIfCannotWriteNewRepo(t *testing.T) {
 
 	for role := range serverMeta {
 		repo := newBlankRepo(t, ts.URL)
-		repo.fileStore = &unwritableStore{MetadataStore: repo.fileStore, roleToNotWrite: role}
+		repo.cache = &unwritableStore{MetadataStore: repo.cache, roleToNotWrite: role}
 		err := repo.Update(false)
 		require.NoError(t, err)
 
 		for r, expected := range serverMeta {
-			actual, err := repo.fileStore.GetSized(r, store.NoSizeLimit)
+			actual, err := repo.cache.GetSized(r, store.NoSizeLimit)
 			if r == role {
 				require.Error(t, err)
 				require.IsType(t, store.ErrMetaNotFound{}, err,
@@ -144,7 +144,7 @@ func TestUpdateSucceedsEvenIfCannotWriteExistingRepo(t *testing.T) {
 	err := repo.Update(false)
 	require.NoError(t, err)
 
-	origFileStore := repo.fileStore
+	origFileStore := repo.cache
 
 	for role := range serverMeta {
 		for _, forWrite := range []bool{true, false} {
@@ -152,13 +152,13 @@ func TestUpdateSucceedsEvenIfCannotWriteExistingRepo(t *testing.T) {
 			bumpVersions(t, serverSwizzler, 1)
 
 			// update fileStore
-			repo.fileStore = &unwritableStore{MetadataStore: origFileStore, roleToNotWrite: role}
+			repo.cache = &unwritableStore{MetadataStore: origFileStore, roleToNotWrite: role}
 			err := repo.Update(forWrite)
 
 			require.NoError(t, err)
 
 			for r, expected := range serverMeta {
-				actual, err := repo.fileStore.GetSized(r, store.NoSizeLimit)
+				actual, err := repo.cache.GetSized(r, store.NoSizeLimit)
 				require.NoError(t, err, "problem getting repo metadata for %s", r)
 				if role == r {
 					require.False(t, bytes.Equal(expected, actual),
@@ -191,7 +191,7 @@ func TestUpdateInOfflineMode(t *testing.T) {
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 
-	offlineRepo, err := NewNotaryRepository(tempBaseDir, "docker.com/notary", "https://nope",
+	offlineRepo, err := NewFileCachedNotaryRepository(tempBaseDir, "docker.com/notary", "https://nope",
 		nil, passphrase.ConstantRetriever("pass"), trustpinning.TrustPinConfig{})
 	require.NoError(t, err)
 	err = offlineRepo.Update(false)
@@ -202,8 +202,8 @@ func TestUpdateInOfflineMode(t *testing.T) {
 	serverMeta, _, err := testutils.NewRepoMetadata("docker.com/notary", metadataDelegations...)
 	require.NoError(t, err)
 	for name, metaBytes := range serverMeta {
-		require.NoError(t, invalidURLRepo.fileStore.Set(name, metaBytes))
-		require.NoError(t, offlineRepo.fileStore.Set(name, metaBytes))
+		require.NoError(t, invalidURLRepo.cache.Set(name, metaBytes))
+		require.NoError(t, offlineRepo.cache.Set(name, metaBytes))
 	}
 
 	// both of these can read from cache and load repo
@@ -265,7 +265,7 @@ func TestUpdateReplacesCorruptOrMissingMetadata(t *testing.T) {
 
 	// we want to swizzle the local cache, not the server, so create a new one
 	repoSwizzler := testutils.NewMetadataSwizzler("docker.com/notary", serverMeta, cs)
-	repoSwizzler.MetadataCache = repo.fileStore
+	repoSwizzler.MetadataCache = repo.cache
 
 	origMeta := testutils.CopyRepoMetadata(serverMeta)
 
@@ -283,12 +283,12 @@ func TestUpdateReplacesCorruptOrMissingMetadata(t *testing.T) {
 					require.Error(t, err, "%s for %s: expected to error when bootstrapping root", text, role)
 					// revert our original metadata
 					for role := range origMeta {
-						require.NoError(t, repo.fileStore.Set(role, origMeta[role]))
+						require.NoError(t, repo.cache.Set(role, origMeta[role]))
 					}
 				} else {
 					require.NoError(t, err)
 					for r, expected := range serverMeta {
-						actual, err := repo.fileStore.GetSized(r, store.NoSizeLimit)
+						actual, err := repo.cache.GetSized(r, store.NoSizeLimit)
 						require.NoError(t, err, "problem getting repo metadata for %s", role)
 						require.True(t, bytes.Equal(expected, actual),
 							"%s for %s: expected to recover after update", text, role)
@@ -328,7 +328,7 @@ func TestUpdateFailsIfServerRootKeyChangedWithoutMultiSign(t *testing.T) {
 
 	// we want to swizzle the local cache, not the server, so create a new one
 	repoSwizzler := &testutils.MetadataSwizzler{
-		MetadataCache: repo.fileStore,
+		MetadataCache: repo.cache,
 		CryptoService: serverSwizzler.CryptoService,
 		Roles:         serverSwizzler.Roles,
 	}
@@ -337,7 +337,7 @@ func TestUpdateFailsIfServerRootKeyChangedWithoutMultiSign(t *testing.T) {
 		text, messItUp := expt.desc, expt.swizzle
 		for _, forWrite := range []bool{true, false} {
 			require.NoError(t, messItUp(repoSwizzler, data.CanonicalRootRole), "could not fuzz root (%s)", text)
-			messedUpMeta, err := repo.fileStore.GetSized(data.CanonicalRootRole, store.NoSizeLimit)
+			messedUpMeta, err := repo.cache.GetSized(data.CanonicalRootRole, store.NoSizeLimit)
 
 			if _, ok := err.(store.ErrMetaNotFound); ok { // one of the ways to mess up is to delete metadata
 
@@ -346,7 +346,7 @@ func TestUpdateFailsIfServerRootKeyChangedWithoutMultiSign(t *testing.T) {
 				require.NoError(t, err)
 				// revert our original metadata
 				for role := range origMeta {
-					require.NoError(t, repo.fileStore.Set(role, origMeta[role]))
+					require.NoError(t, repo.cache.Set(role, origMeta[role]))
 				}
 			} else {
 
@@ -360,7 +360,7 @@ func TestUpdateFailsIfServerRootKeyChangedWithoutMultiSign(t *testing.T) {
 				// same because it has failed to update.
 				for role, expected := range origMeta {
 					if role != data.CanonicalTimestampRole && role != data.CanonicalSnapshotRole {
-						actual, err := repo.fileStore.GetSized(role, store.NoSizeLimit)
+						actual, err := repo.cache.GetSized(role, store.NoSizeLimit)
 						require.NoError(t, err, "problem getting repo metadata for %s", role)
 
 						if role == data.CanonicalRootRole {
@@ -375,7 +375,7 @@ func TestUpdateFailsIfServerRootKeyChangedWithoutMultiSign(t *testing.T) {
 
 			// revert our original root metadata
 			require.NoError(t,
-				repo.fileStore.Set(data.CanonicalRootRole, origMeta[data.CanonicalRootRole]))
+				repo.cache.Set(data.CanonicalRootRole, origMeta[data.CanonicalRootRole]))
 		}
 	}
 }
@@ -1348,7 +1348,7 @@ func testUpdateLocalAndRemoteRootCorrupt(t *testing.T, forWrite bool, localExpt,
 	require.NoError(t, err)
 	repoSwizzler := &testutils.MetadataSwizzler{
 		Gun:           serverSwizzler.Gun,
-		MetadataCache: repo.fileStore,
+		MetadataCache: repo.cache,
 		CryptoService: serverSwizzler.CryptoService,
 		Roles:         serverSwizzler.Roles,
 	}
@@ -1748,7 +1748,7 @@ func TestRootOnDiskTrustPinning(t *testing.T) {
 	defer os.RemoveAll(repo.baseDir)
 	repo.trustPinning = restrictiveTrustPinning
 	// put root on disk
-	require.NoError(t, repo.fileStore.Set(data.CanonicalRootRole, meta[data.CanonicalRootRole]))
+	require.NoError(t, repo.cache.Set(data.CanonicalRootRole, meta[data.CanonicalRootRole]))
 
 	require.NoError(t, repo.Update(false))
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"fmt"
+)
+
+// ErrRepoNotInitialized is returned when trying to publish an uninitialized
+// notary repository
+type ErrRepoNotInitialized struct{}
+
+func (err ErrRepoNotInitialized) Error() string {
+	return "repository has not been initialized"
+}
+
+// ErrInvalidRemoteRole is returned when the server is requested to manage
+// a key type that is not permitted
+type ErrInvalidRemoteRole struct {
+	Role string
+}
+
+func (err ErrInvalidRemoteRole) Error() string {
+	return fmt.Sprintf(
+		"notary does not permit the server managing the %s key", err.Role)
+}
+
+// ErrInvalidLocalRole is returned when the client wants to manage
+// a key type that is not permitted
+type ErrInvalidLocalRole struct {
+	Role string
+}
+
+func (err ErrInvalidLocalRole) Error() string {
+	return fmt.Sprintf(
+		"notary does not permit the client managing the %s key", err.Role)
+}
+
+// ErrRepositoryNotExist is returned when an action is taken on a remote
+// repository that doesn't exist
+type ErrRepositoryNotExist struct {
+	remote string
+	gun    string
+}
+
+func (err ErrRepositoryNotExist) Error() string {
+	return fmt.Sprintf("%s does not have trust data for %s", err.remote, err.gun)
+}

--- a/client/repo.go
+++ b/client/repo.go
@@ -4,26 +4,15 @@ package client
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/docker/notary"
 	"github.com/docker/notary/trustmanager"
-	"github.com/docker/notary/trustpinning"
 )
 
-// NewNotaryRepository is a helper method that returns a new notary repository.
-// It takes the base directory under where all the trust files will be stored
-// (This is normally defaults to "~/.notary" or "~/.docker/trust" when enabling
-// docker content trust).
-func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
-	retriever notary.PassRetriever, trustPinning trustpinning.TrustPinConfig) (
-	*NotaryRepository, error) {
-
+func getKeyStores(baseDir string, retriever notary.PassRetriever) ([]trustmanager.KeyStore, error) {
 	fileKeyStore, err := trustmanager.NewKeyFileStore(baseDir, retriever)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private key store in directory: %s", baseDir)
 	}
-
-	return repositoryFromKeystores(baseDir, gun, baseURL, rt,
-		[]trustmanager.KeyStore{fileKeyStore}, trustPinning)
+	return []trustmanager.KeyStore{fileKeyStore}, nil
 }

--- a/client/repo_pkcs11.go
+++ b/client/repo_pkcs11.go
@@ -4,21 +4,13 @@ package client
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/docker/notary"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/trustmanager/yubikey"
-	"github.com/docker/notary/trustpinning"
 )
 
-// NewNotaryRepository is a helper method that returns a new notary repository.
-// It takes the base directory under where all the trust files will be stored
-// (usually ~/.docker/trust/).
-func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
-	retriever notary.PassRetriever, trustPinning trustpinning.TrustPinConfig) (
-	*NotaryRepository, error) {
-
+func getKeyStores(baseDir string, retriever notary.PassRetriever) ([]trustmanager.KeyStore, error) {
 	fileKeyStore, err := trustmanager.NewKeyFileStore(baseDir, retriever)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private key store in directory: %s", baseDir)
@@ -29,6 +21,5 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 	if yubiKeyStore != nil {
 		keyStores = []trustmanager.KeyStore{yubiKeyStore, fileKeyStore}
 	}
-
-	return repositoryFromKeystores(baseDir, gun, baseURL, rt, keyStores, trustPinning)
+	return keyStores, nil
 }

--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -103,7 +103,7 @@ func (d *delegationCommander) delegationPurgeKeys(cmd *cobra.Command, args []str
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"),
 		gun,
 		getRemoteTrustServer(config),
@@ -153,7 +153,7 @@ func (d *delegationCommander) delegationsList(cmd *cobra.Command, args []string)
 	}
 
 	// initialize repo with transport to get latest state of the world before listing delegations
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, d.retriever, trustPin)
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func (d *delegationCommander) delegationRemove(cmd *cobra.Command, args []string
 
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, d.retriever, trustPin)
 	if err != nil {
 		return err
@@ -314,7 +314,7 @@ func (d *delegationCommander) delegationAdd(cmd *cobra.Command, args []string) e
 
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, d.retriever, trustPin)
 	if err != nil {
 		return err

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -219,7 +219,7 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config),
 		rt, k.getRetriever(), trustPin)
 	if err != nil {

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -332,7 +332,7 @@ func setUpRepo(t *testing.T, tempBaseDir, gun string, ret notary.PassRetriever) 
 	cryptoService := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(ret))
 	ts := httptest.NewServer(server.RootHandler(nil, ctx, cryptoService, nil, nil, nil))
 
-	repo, err := client.NewNotaryRepository(
+	repo, err := client.NewFileCachedNotaryRepository(
 		tempBaseDir, gun, ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -375,7 +375,7 @@ func TestRotateKeyRemoteServerManagesKey(t *testing.T) {
 		}
 		require.NoError(t, k.keysRotate(&cobra.Command{}, []string{gun, role, "-r"}))
 
-		repo, err := client.NewNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
+		repo, err := client.NewFileCachedNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
 		require.NoError(t, err, "error creating repo: %s", err)
 
 		cl, err := repo.GetChangelist()
@@ -429,7 +429,7 @@ func TestRotateKeyBothKeys(t *testing.T) {
 	require.NoError(t, k.keysRotate(&cobra.Command{}, []string{gun, data.CanonicalTargetsRole}))
 	require.NoError(t, k.keysRotate(&cobra.Command{}, []string{gun, data.CanonicalSnapshotRole}))
 
-	repo, err := client.NewNotaryRepository(tempBaseDir, gun, ts.URL, nil, ret, trustpinning.TrustPinConfig{})
+	repo, err := client.NewFileCachedNotaryRepository(tempBaseDir, gun, ts.URL, nil, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
 	cl, err := repo.GetChangelist()
@@ -494,7 +494,7 @@ func TestRotateKeyRootIsInteractive(t *testing.T) {
 
 	require.Contains(t, out.String(), "Aborting action")
 
-	repo, err := client.NewNotaryRepository(tempBaseDir, gun, ts.URL, nil, ret, trustpinning.TrustPinConfig{})
+	repo, err := client.NewFileCachedNotaryRepository(tempBaseDir, gun, ts.URL, nil, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
 	// There should still just be one root key (and one targets and one snapshot)

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -198,7 +198,7 @@ func (t *tufCommander) tufWitness(cmd *cobra.Command, args []string) error {
 
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -271,7 +271,7 @@ func (t *tufCommander) tufAddByHash(cmd *cobra.Command, args []string) error {
 
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -322,7 +322,7 @@ func (t *tufCommander) tufAdd(cmd *cobra.Command, args []string) error {
 
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -370,7 +370,7 @@ func (t *tufCommander) tufDeleteGUN(cmd *cobra.Command, args []string) error {
 		remoteDeleteInfo = " and remote"
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
 
 	if err != nil {
@@ -408,7 +408,7 @@ func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -497,7 +497,7 @@ func (t *tufCommander) tufList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -537,7 +537,7 @@ func (t *tufCommander) tufLookup(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -569,7 +569,7 @@ func (t *tufCommander) tufStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -626,7 +626,7 @@ func (t *tufCommander) tufReset(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -673,7 +673,7 @@ func (t *tufCommander) tufPublish(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -701,7 +701,7 @@ func (t *tufCommander) tufRemove(cmd *cobra.Command, args []string) error {
 
 	// no online operation are performed by remove so the transport argument
 	// should be nil.
-	repo, err := notaryclient.NewNotaryRepository(
+	repo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -745,7 +745,7 @@ func (t *tufCommander) tufVerify(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
 	if err != nil {
 		return err
@@ -1017,7 +1017,7 @@ func maybeAutoPublish(cmd *cobra.Command, doPublish bool, gun string, config *vi
 		return err
 	}
 
-	nRepo, err := notaryclient.NewNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, passRetriever, trustPin)
 	if err != nil {
 		return err


### PR DESCRIPTION
Reasonably minimal changes to make cache injectable while not having to move around much code. Also want to keep and add to "helper" constructors (e.g. `NewFileCachedNotaryRepository`) rather than push too much of that code up the call stack.

Also moved a bunch of errors that were in client/client.go into a new client/errors.go to keep things a little cleaner. client/client.go was a bit messy with a bunch of error types. They're still in the same scope (i.e. in the `client` package) so nothing else had to be changed by moving them.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)