### PR TITLE
Lint and gocyclo fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ else
 endif
 	@test -z "$$(go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 	# gocyclo - we require cyclomatic complexity to be < 16
-	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec "gocyclo -over 15 {}" \; | tee /dev/stderr)"
+	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec gocyclo -over 15 {} \; | tee /dev/stderr)"
 	# misspell - requires that the following be run first:
 	#    go get -u github.com/client9/misspell/cmd/misspell
 	@test -z "$$(find . -type f | grep -v vendor/ | grep -v bin/ | grep -v misc/ | grep -v .git/ | grep -v \.pdf | xargs misspell | tee /dev/stderr)"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -140,7 +140,7 @@ func fullTestServer(t *testing.T) *httptest.Server {
 	ctx = ctxu.WithLogger(ctx, logrus.NewEntry(l))
 
 	cryptoService := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(passphraseRetriever))
-	return httptest.NewServer(server.RootHandler(nil, ctx, cryptoService, nil, nil, nil))
+	return httptest.NewServer(server.RootHandler(ctx, nil, cryptoService, nil, nil, nil))
 }
 
 // server that returns some particular error code all the time

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -77,7 +77,7 @@ func setupServerHandler(metaStore storage.MetaStore) http.Handler {
 	ctx = ctxu.WithLogger(ctx, logrus.NewEntry(l))
 
 	cryptoService := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(passphrase.ConstantRetriever("pass")))
-	return server.RootHandler(nil, ctx, cryptoService, nil, nil, nil)
+	return server.RootHandler(ctx, nil, cryptoService, nil, nil, nil)
 }
 
 // makes a testing notary-server

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -330,7 +330,7 @@ func setUpRepo(t *testing.T, tempBaseDir, gun string, ret notary.PassRetriever) 
 	ctx = ctxu.WithLogger(ctx, logrus.NewEntry(l))
 
 	cryptoService := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(ret))
-	ts := httptest.NewServer(server.RootHandler(nil, ctx, cryptoService, nil, nil, nil))
+	ts := httptest.NewServer(server.RootHandler(ctx, nil, cryptoService, nil, nil, nil))
 
 	repo, err := client.NewFileCachedNotaryRepository(
 		tempBaseDir, gun, ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})

--- a/server/handlers/default_test.go
+++ b/server/handlers/default_test.go
@@ -50,7 +50,7 @@ func getContext(h handlerState) context.Context {
 }
 
 func TestMainHandlerGet(t *testing.T) {
-	hand := utils.RootHandlerFactory(nil, context.Background(), &signed.Ed25519{})
+	hand := utils.RootHandlerFactory(context.Background(), nil, &signed.Ed25519{})
 	handler := hand(MainHandler)
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
@@ -62,7 +62,7 @@ func TestMainHandlerGet(t *testing.T) {
 }
 
 func TestMainHandlerNotGet(t *testing.T) {
-	hand := utils.RootHandlerFactory(nil, context.Background(), &signed.Ed25519{})
+	hand := utils.RootHandlerFactory(context.Background(), nil, &signed.Ed25519{})
 	handler := hand(MainHandler)
 	ts := httptest.NewServer(handler)
 	defer ts.Close()

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -26,7 +26,7 @@ func TestValidationErrorFormat(t *testing.T) {
 		context.Background(), notary.CtxKeyMetaStore, storage.NewMemStorage())
 	ctx = context.WithValue(ctx, notary.CtxKeyKeyAlgo, data.ED25519Key)
 
-	handler := RootHandler(nil, ctx, signed.NewEd25519(), nil, nil, nil)
+	handler := RootHandler(ctx, nil, signed.NewEd25519(), nil, nil, nil)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 

--- a/server/server.go
+++ b/server/server.go
@@ -80,7 +80,7 @@ func Run(ctx context.Context, conf Config) error {
 	svr := http.Server{
 		Addr: conf.Addr,
 		Handler: RootHandler(
-			ac, ctx, conf.Trust,
+			ctx, ac, conf.Trust,
 			conf.ConsistentCacheControlConfig, conf.CurrentCacheControlConfig,
 			conf.RepoPrefixes),
 	}
@@ -123,7 +123,7 @@ type _serverEndpoint struct {
 
 // RootHandler returns the handler that routes all the paths from / for the
 // server.
-func RootHandler(ac auth.AccessController, ctx context.Context, trust signed.CryptoService,
+func RootHandler(ctx context.Context, ac auth.AccessController, trust signed.CryptoService,
 	consistent, current utils.CacheControlConfig, repoPrefixes []string) http.Handler {
 
 	authWrapper := utils.RootHandlerFactory(ac, ctx, trust)

--- a/server/server.go
+++ b/server/server.go
@@ -126,7 +126,7 @@ type _serverEndpoint struct {
 func RootHandler(ctx context.Context, ac auth.AccessController, trust signed.CryptoService,
 	consistent, current utils.CacheControlConfig, repoPrefixes []string) http.Handler {
 
-	authWrapper := utils.RootHandlerFactory(ac, ctx, trust)
+	authWrapper := utils.RootHandlerFactory(ctx, ac, trust)
 
 	createHandler := func(opts _serverEndpoint) http.Handler {
 		var wrapped http.Handler

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -69,7 +69,7 @@ func TestRepoPrefixMatches(t *testing.T) {
 	snChecksumBytes := sha256.Sum256(meta[data.CanonicalSnapshotRole])
 
 	// successful gets
-	handler := RootHandler(nil, ctx, cs, nil, nil, []string{"docker.io"})
+	handler := RootHandler(ctx, nil, cs, nil, nil, []string{"docker.io"})
 	ts := httptest.NewServer(handler)
 
 	url := fmt.Sprintf("%s/v2/%s/_trust/tuf/", ts.URL, gun)
@@ -110,7 +110,7 @@ func TestRepoPrefixDoesNotMatch(t *testing.T) {
 	snChecksumBytes := sha256.Sum256(meta[data.CanonicalSnapshotRole])
 
 	// successful gets
-	handler := RootHandler(nil, ctx, cs, nil, nil, []string{"nope"})
+	handler := RootHandler(ctx, nil, cs, nil, nil, []string{"nope"})
 	ts := httptest.NewServer(handler)
 
 	url := fmt.Sprintf("%s/v2/%s/_trust/tuf/", ts.URL, gun)
@@ -148,7 +148,7 @@ func TestRepoPrefixDoesNotMatch(t *testing.T) {
 }
 
 func TestMetricsEndpoint(t *testing.T) {
-	handler := RootHandler(nil, context.Background(), signed.NewEd25519(),
+	handler := RootHandler(context.Background(), nil, signed.NewEd25519(),
 		nil, nil, nil)
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
@@ -164,7 +164,7 @@ func TestGetKeysEndpoint(t *testing.T) {
 		context.Background(), notary.CtxKeyMetaStore, storage.NewMemStorage())
 	ctx = context.WithValue(ctx, notary.CtxKeyKeyAlgo, data.ED25519Key)
 
-	handler := RootHandler(nil, ctx, signed.NewEd25519(), nil, nil, nil)
+	handler := RootHandler(ctx, nil, signed.NewEd25519(), nil, nil, nil)
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
@@ -236,7 +236,7 @@ func TestGetRoleByHash(t *testing.T) {
 	ctx = context.WithValue(ctx, notary.CtxKeyKeyAlgo, data.ED25519Key)
 
 	ccc := utils.NewCacheControlConfig(10, false)
-	handler := RootHandler(nil, ctx, signed.NewEd25519(), ccc, ccc, nil)
+	handler := RootHandler(ctx, nil, signed.NewEd25519(), ccc, ccc, nil)
 	serv := httptest.NewServer(handler)
 	defer serv.Close()
 
@@ -280,7 +280,7 @@ func TestGetCurrentRole(t *testing.T) {
 	ctx = context.WithValue(ctx, notary.CtxKeyKeyAlgo, data.ED25519Key)
 
 	ccc := utils.NewCacheControlConfig(10, false)
-	handler := RootHandler(nil, ctx, signed.NewEd25519(), ccc, ccc, nil)
+	handler := RootHandler(ctx, nil, signed.NewEd25519(), ccc, ccc, nil)
 	serv := httptest.NewServer(handler)
 	defer serv.Close()
 
@@ -312,7 +312,7 @@ func TestRotateKeyEndpoint(t *testing.T) {
 	ctx = context.WithValue(ctx, notary.CtxKeyKeyAlgo, data.ED25519Key)
 
 	ccc := utils.NewCacheControlConfig(10, false)
-	handler := RootHandler(nil, ctx, signed.NewEd25519(), ccc, ccc, nil)
+	handler := RootHandler(ctx, nil, signed.NewEd25519(), ccc, ccc, nil)
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 

--- a/utils/http.go
+++ b/utils/http.go
@@ -34,7 +34,7 @@ type rootHandler struct {
 // Context creator and authorizer.  The returned factory allows creating
 // new rootHandlers from the alternate http handler contextHandler and
 // a scope.
-func RootHandlerFactory(auth auth.AccessController, ctx context.Context, trust signed.CryptoService) func(ContextHandler, ...string) *rootHandler {
+func RootHandlerFactory(ctx context.Context, auth auth.AccessController, trust signed.CryptoService) func(ContextHandler, ...string) *rootHandler {
 	return func(handler ContextHandler, actions ...string) *rootHandler {
 		return &rootHandler{
 			handler: handler,

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -25,7 +25,7 @@ func MockBetterErrorHandler(ctx context.Context, w http.ResponseWriter, r *http.
 }
 
 func TestRootHandlerFactory(t *testing.T) {
-	hand := RootHandlerFactory(nil, context.Background(), &signed.Ed25519{})
+	hand := RootHandlerFactory(context.Background(), nil, &signed.Ed25519{})
 	handler := hand(MockContextHandler)
 	if _, ok := interface{}(handler).(http.Handler); !ok {
 		t.Fatalf("A rootHandler must implement the http.Handler interface")
@@ -40,7 +40,7 @@ func TestRootHandlerFactory(t *testing.T) {
 }
 
 func TestRootHandlerError(t *testing.T) {
-	hand := RootHandlerFactory(nil, context.Background(), &signed.Ed25519{})
+	hand := RootHandlerFactory(context.Background(), nil, &signed.Ed25519{})
 	handler := hand(MockBetterErrorHandler)
 
 	ts := httptest.NewServer(handler)


### PR DESCRIPTION
It seems that golint was updated to prefer `context` being the first parameter when being used in a function:
```
./server/server.go:126:1: context.Context should be the first parameter of a function
./utils/http.go:37:1: context.Context should be the first parameter of a function
```

Also, the `find` in our `Makefile` has been acting up on CircleCI when used for `gocyclo`:
```
find: `gocyclo -over 15 ./client/changelist/change.go': No such file or directory
find: `gocyclo -over 15 ./client/changelist/change_test.go': No such file or directory
find: `gocyclo -over 15 ./client/changelist/changelist.go': No such file or directory
find: `gocyclo -over 15 ./client/changelist/changelist_test.go': No such file or directory
...
```
