### PR TITLE
Redundant godep vendoring

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -905,41 +905,6 @@
 		{
 			"ImportPath": "golang.org/x/net/lex/httplex",
 			"Rev": "6a513affb38dc9788b449d59ffed099b8de18fa0"
-		},
-		{
-			"ImportPath": "github.com/docker/distribution/vendor/github.com/Sirupsen/logrus",
-			"Comment": "v2.5.1",
-			"Rev": "12acdf0a6c1e56d965ac6eb395d2bce687bf22fc"
-		},
-		{
-			"ImportPath": "github.com/docker/distribution/vendor/github.com/gorilla/mux",
-			"Comment": "v2.5.1",
-			"Rev": "12acdf0a6c1e56d965ac6eb395d2bce687bf22fc"
-		},
-		{
-			"ImportPath": "github.com/docker/distribution/vendor/golang.org/x/net/context",
-			"Comment": "v2.5.1",
-			"Rev": "12acdf0a6c1e56d965ac6eb395d2bce687bf22fc"
-		},
-		{
-			"ImportPath": "github.com/docker/distribution/vendor/github.com/gorilla/context",
-			"Comment": "v2.5.1",
-			"Rev": "12acdf0a6c1e56d965ac6eb395d2bce687bf22fc"
-		},
-		{
-			"ImportPath": "github.com/docker/distribution/vendor/golang.org/x/crypto/bcrypt",
-			"Comment": "v2.5.1",
-			"Rev": "12acdf0a6c1e56d965ac6eb395d2bce687bf22fc"
-		},
-		{
-			"ImportPath": "github.com/docker/distribution/vendor/golang.org/x/crypto/blowfish",
-			"Comment": "v2.5.1",
-			"Rev": "12acdf0a6c1e56d965ac6eb395d2bce687bf22fc"
-		},
-		{
-			"ImportPath": "github.com/docker/distribution/vendor/github.com/docker/libtrust",
-			"Comment": "v2.5.1",
-			"Rev": "12acdf0a6c1e56d965ac6eb395d2bce687bf22fc"
 		}
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/docker/notary",
-	"GoVersion": "go1.6",
+	"GoVersion": "go1.7",
 	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
@@ -325,6 +325,14 @@
 			"Rev": "c3cefd437628a0b7d31b34fe44b3a7a540e98527"
 		},
 		{
+			"ImportPath": "github.com/golang/protobuf/protoc-gen-go/descriptor",
+			"Rev": "c3cefd437628a0b7d31b34fe44b3a7a540e98527"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/ptypes/any",
+			"Rev": "c3cefd437628a0b7d31b34fe44b3a7a540e98527"
+		},
+		{
 			"ImportPath": "github.com/google/gofuzz",
 			"Rev": "bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5"
 		},
@@ -640,6 +648,10 @@
 			"Rev": "6a513affb38dc9788b449d59ffed099b8de18fa0"
 		},
 		{
+			"ImportPath": "golang.org/x/net/lex/httplex",
+			"Rev": "6a513affb38dc9788b449d59ffed099b8de18fa0"
+		},
+		{
 			"ImportPath": "golang.org/x/net/trace",
 			"Rev": "6a513affb38dc9788b449d59ffed099b8de18fa0"
 		},
@@ -802,17 +814,22 @@
 			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
 		},
 		{
-			"ImportPath": "google.golang.org/grpc/interop/client",
+			"ImportPath": "google.golang.org/grpc/health/grpc_health_v1",
+			"Comment": "v1.0.1-GA",
+			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/internal",
+			"Comment": "v1.0.1-GA",
+			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/interop",
 			"Comment": "v1.0.1-GA",
 			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
 		},
 		{
 			"ImportPath": "google.golang.org/grpc/interop/grpc_testing",
-			"Comment": "v1.0.1-GA",
-			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/interop/server",
 			"Comment": "v1.0.1-GA",
 			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
 		},
@@ -823,6 +840,11 @@
 		},
 		{
 			"ImportPath": "google.golang.org/grpc/naming",
+			"Comment": "v1.0.1-GA",
+			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/peer",
 			"Comment": "v1.0.1-GA",
 			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
 		},
@@ -877,34 +899,6 @@
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "bef53efd0c76e49e6de55ead051f886bea7e9420"
-		},
-		{
-			"ImportPath": "github.com/golang/protobuf/ptypes/any",
-			"Rev": "c3cefd437628a0b7d31b34fe44b3a7a540e98527"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/internal",
-			"Comment": "v1.0.1-GA",
-			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/peer",
-			"Comment": "v1.0.1-GA",
-			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/health/grpc_health_v1",
-			"Comment": "v1.0.1-GA",
-			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/interop",
-			"Comment": "v1.0.1-GA",
-			"Rev": "0032a855ba5c8a3c8e0d71c2deef354b70af1584"
-		},
-		{
-			"ImportPath": "golang.org/x/net/lex/httplex",
-			"Rev": "6a513affb38dc9788b449d59ffed099b8de18fa0"
 		}
 	]
 }


### PR DESCRIPTION
I removed redundant dependencies that were somehow picked up by godep inside `docker/distribution`'s vendor directory (like `github.com/docker/distribution/vendor/github.com/Sirupsen/logrus`).

Also bumped the major go version to 1.7 and did a `godep save ./...` that resorted and cleaned up the `Godeps.json` file. 