### PR TITLE
Add gas check to make lint, fix unnecessary assignment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd -ms /bin/bash notary \
 	&& pip install codecov \
-	&& go get github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign
+	&& go get github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/HewlettPackard/gas
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,7 @@ endif
 	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)"
 	# gas - requires that the following be run first:
 	#    go get -u github.com/HewlettPackard/gas
-	@gas -skip=vendor -skip=*/*_test.go -skip=*/*/*_test.go -fmt=json -out=gas_output.json ./...
-	ifeq ("$(shell node -p "require('./gas_output.json').metrics.found"), "0")
-		$(error gas issues found: $(shell node -p "require('./gas_output.json').metrics.found"))
-	endif
+	@gas -skip=vendor -skip=*/*_test.go -skip=*/*/*_test.go -fmt=csv -out=gas_output.csv ./... && test -z "$$(cat gas_output.csv | tee /dev/stderr)"
 
 build:
 	@echo "+ $@"

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,12 @@ endif
 	# ineffassign - requires that the following be run first:
 	#    go get -u github.com/gordonklaus/ineffassign
 	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec ineffassign {} \; | tee /dev/stderr)"
+	# gas - requires that the following be run first:
+	#    go get -u github.com/HewlettPackard/gas
+	@gas -skip=vendor -skip=*/*_test.go -skip=*/*/*_test.go -fmt=json -out=gas_output.json ./...
+	ifeq ("$(shell node -p "require('./gas_output.json').metrics.found"), "0")
+		$(error gas issues found: $(shell node -p "require('./gas_output.json').metrics.found"))
+	endif
 
 build:
 	@echo "+ $@"

--- a/client/client.go
+++ b/client/client.go
@@ -776,8 +776,7 @@ func (r *NotaryRepository) saveMetadata(ignoreSnapshot bool) error {
 	}
 
 	for role, blob := range targetsToSave {
-		parentDir := filepath.Dir(role)
-		os.MkdirAll(parentDir, 0755)
+		// If the parent directory does not exist, the cache.Set will create it
 		r.cache.Set(role, blob)
 	}
 


### PR DESCRIPTION
Removes the parent directory creation code from `client.go` because it's already handled by the underlying cache.

Also adds github.com/HewlettPackard/gas to the `make lint` check, though it's a little bit hacky until https://github.com/HewlettPackard/gas/issues/55 and https://github.com/HewlettPackard/gas/issues/50 are resolved. 