### PR TITLE
Rework auth

### DIFF
--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -907,7 +907,7 @@ func tokenAuth(trustServerURL string, baseTransport *http.Transport, gun string,
 		return nil, err
 	}
 
-	ps := passwordStore{anonymous: permission == readOnly}
+	ps := passwordStore{anonymous: false}
 
 	var actions []string
 	switch permission {


### PR DESCRIPTION
```
The authentication challenge before a http request is really great to prevent some attacks like DDoS.

But the green channel for some Non-push operation like "notary list" will break that guarantees.

We should challenge all the request which brings data back from the server except "Ping".
#713 add an extra challenge(the basic) for private repo, but as I said above it's not enough, all the request for public repo should be challenged too, otherwise the attacker can create a script with infinite  loop to list the public repo information and we can't know who is doing that.

So I revert the commit in #713 and make all request must be challenged if it was configured as such .

I'm not sure if I have missed anything or any scenarios, please feel free to chime in.

/cc @liron-l 
```
EDIT: The above is not a good comments

The original purpose is about to add a basic authentication check even those not-push operations like `lookup` , `list`, etc.. #713 have done that with an additional RoundTripper which I think is not very necessary.  We can just make the client to ask for token everytime by just setting the `anonymous` to false.