### PR TITLE
Do not use trailing punctuation in errors, also no caps where possible

### DIFF
--- a/cmd/notary-server/bootstrap.go
+++ b/cmd/notary-server/bootstrap.go
@@ -16,7 +16,7 @@ func bootstrap(ctx context.Context) error {
 	}
 	store, ok := s.(storage.Bootstrapper)
 	if !ok {
-		return fmt.Errorf("Store does not support bootstrapping.")
+		return fmt.Errorf("store does not support bootstrapping")
 	}
 	return store.Bootstrap()
 }

--- a/cmd/notary-signer/config.go
+++ b/cmd/notary-signer/config.go
@@ -244,7 +244,7 @@ func getAddrAndTLSConfig(configuration *viper.Viper) (string, *tls.Config, error
 func bootstrap(s interface{}) error {
 	store, ok := s.(storage.Bootstrapper)
 	if !ok {
-		return fmt.Errorf("Store does not support bootstrapping.")
+		return fmt.Errorf("store does not support bootstrapping")
 	}
 	return store.Bootstrap()
 }

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -3,21 +3,21 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/docker/notary"
 	notaryclient "github.com/docker/notary/client"
 	"github.com/docker/notary/cryptoservice"
 	store "github.com/docker/notary/storage"
 	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/utils"
 
-	"github.com/docker/notary"
-	"github.com/docker/notary/tuf/data"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
 )
 
 var cmdKeyTemplate = usageTemplate{
@@ -264,7 +264,7 @@ func removeKeyInteractively(keyStores []trustmanager.KeyStore, keyID string,
 	}
 
 	if len(foundKeys) == 0 {
-		return fmt.Errorf("No key with ID %s found.", keyID)
+		return fmt.Errorf("No key with ID %s found", keyID)
 	}
 
 	if len(foundKeys) > 1 {

--- a/cryptoservice/certificate.go
+++ b/cryptoservice/certificate.go
@@ -15,7 +15,7 @@ import (
 func GenerateCertificate(rootKey data.PrivateKey, gun string, startTime, endTime time.Time) (*x509.Certificate, error) {
 	signer := rootKey.CryptoSigner()
 	if signer == nil {
-		return nil, fmt.Errorf("key type not supported for Certificate generation: %s\n", rootKey.Algorithm())
+		return nil, fmt.Errorf("key type not supported for Certificate generation: %s", rootKey.Algorithm())
 	}
 
 	return generateCertificate(signer, gun, startTime, endTime)

--- a/signer/keydbstore/cachedcryptoservice_test.go
+++ b/signer/keydbstore/cachedcryptoservice_test.go
@@ -50,7 +50,7 @@ type unAddableKeyService struct {
 }
 
 func (u unAddableKeyService) AddKey(_, _ string, _ data.PrivateKey) error {
-	return fmt.Errorf("Can't add to keyservice!")
+	return fmt.Errorf("can't add to keyservice")
 }
 
 type unRemoveableKeyService struct {
@@ -60,7 +60,7 @@ type unRemoveableKeyService struct {
 
 func (u unRemoveableKeyService) RemoveKey(keyID string) error {
 	if u.failToRemove {
-		return fmt.Errorf("Can't remove from keystore!")
+		return fmt.Errorf("can't remove from keystore")
 	}
 	return u.CryptoService.RemoveKey(keyID)
 }

--- a/trustmanager/yubikey/yubikeystore.go
+++ b/trustmanager/yubikey/yubikeystore.go
@@ -208,7 +208,7 @@ func (y *YubiPrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts
 			return sig, nil
 		}
 	}
-	return nil, errors.New("Failed to generate signature on Yubikey.")
+	return nil, errors.New("failed to generate signature on Yubikey")
 }
 
 // If a byte array is less than the number of bytes specified by
@@ -460,7 +460,7 @@ func yubiListKeys(ctx IPKCS11Ctx, session pkcs11.SessionHandle) (keys map[string
 	}
 
 	if len(objs) == 0 {
-		return nil, errors.New("No keys found in yubikey.")
+		return nil, errors.New("no keys found in yubikey")
 	}
 	logrus.Debugf("Found %d objects matching list filters", len(objs))
 	for _, obj := range objs {
@@ -621,7 +621,7 @@ func getNextEmptySlot(ctx IPKCS11Ctx, session pkcs11.SessionHandle) ([]byte, err
 			return []byte{byte(loc)}, nil
 		}
 	}
-	return nil, errors.New("Yubikey has no available slots.")
+	return nil, errors.New("yubikey has no available slots")
 }
 
 // YubiStore is a KeyStore for private keys inside a Yubikey

--- a/trustmanager/yubikey/yubikeystore_test.go
+++ b/trustmanager/yubikey/yubikeystore_test.go
@@ -256,7 +256,7 @@ type nonworkingBackup struct {
 
 // AddKey stores the contents of a PEM-encoded private key as a PEM block
 func (s *nonworkingBackup) AddKey(keyInfo trustmanager.KeyInfo, privKey data.PrivateKey) error {
-	return errors.New("Nope!")
+	return errors.New("nope")
 }
 
 // If, when adding a key to the Yubikey, we can't back up the key, it should

--- a/trustpinning/trustpin.go
+++ b/trustpinning/trustpin.go
@@ -3,9 +3,10 @@ package trustpinning
 import (
 	"crypto/x509"
 	"fmt"
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary/tuf/utils"
-	"strings"
 )
 
 // TrustPinConfig represents the configuration under the trust_pinning section of the config file
@@ -115,7 +116,7 @@ func getPinnedCAFilepathByPrefix(gun string, t TrustPinConfig) (string, error) {
 		}
 	}
 	if !foundCA {
-		return "", fmt.Errorf("could not find pinned CA for GUN: %s\n", gun)
+		return "", fmt.Errorf("could not find pinned CA for GUN: %s", gun)
 	}
 	return specificCAFilepath, nil
 }

--- a/tuf/data/keys.go
+++ b/tuf/data/keys.go
@@ -376,7 +376,7 @@ func NewECDSAPrivateKey(public PublicKey, private []byte) (*ECDSAPrivateKey, err
 	switch public.(type) {
 	case *ECDSAPublicKey, *ECDSAx509PublicKey:
 	default:
-		return nil, errors.New("Invalid public key type provided to NewECDSAPrivateKey")
+		return nil, errors.New("invalid public key type provided to NewECDSAPrivateKey")
 	}
 	ecdsaPrivKey, err := x509.ParseECPrivateKey(private)
 	if err != nil {
@@ -394,7 +394,7 @@ func NewRSAPrivateKey(public PublicKey, private []byte) (*RSAPrivateKey, error) 
 	switch public.(type) {
 	case *RSAPublicKey, *RSAx509PublicKey:
 	default:
-		return nil, errors.New("Invalid public key type provided to NewRSAPrivateKey")
+		return nil, errors.New("invalid public key type provided to NewRSAPrivateKey")
 	}
 	rsaPrivKey, err := x509.ParsePKCS1PrivateKey(private)
 	if err != nil {
@@ -445,7 +445,7 @@ type ecdsaSig struct {
 func (k ECDSAPrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	ecdsaPrivKey, ok := k.CryptoSigner().(*ecdsa.PrivateKey)
 	if !ok {
-		return nil, errors.New("Signer was based on the wrong key type")
+		return nil, errors.New("signer was based on the wrong key type")
 	}
 	hashed := sha256.Sum256(msg)
 	sigASN1, err := ecdsaPrivKey.Sign(rand, hashed[:], opts)
@@ -492,7 +492,7 @@ func (k ED25519PrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOp
 // Sign on an UnknownPrivateKey raises an error because the client does not
 // know how to sign with this key type.
 func (k UnknownPrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (signature []byte, err error) {
-	return nil, errors.New("Unknown key type, cannot sign.")
+	return nil, errors.New("unknown key type, cannot sign")
 }
 
 // SignatureAlgorithm returns the SigAlgorithm for a ECDSAPrivateKey

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -98,11 +98,11 @@ func VerifySignature(msg []byte, sig *data.Signature, pk data.PublicKey) error {
 	method := sig.Method
 	verifier, ok := Verifiers[method]
 	if !ok {
-		return fmt.Errorf("signing method is not supported: %s\n", sig.Method)
+		return fmt.Errorf("signing method is not supported: %s", sig.Method)
 	}
 
 	if err := verifier.Verify(pk, sig.Signature, msg); err != nil {
-		return fmt.Errorf("signature was invalid\n")
+		return fmt.Errorf("signature was invalid")
 	}
 	sig.IsValid = true
 	return nil


### PR DESCRIPTION
Removes unnecessary trailing punctuation and newlines from errors, which is now enforced in golint: https://github.com/golang/lint/commit/206c0f020eba0f7fbcfbc467a5eb808037df2ed6

I also removed caps from the beginning of errors in the same files where I found them, though this is not being actively enforced at present.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>