### PR TITLE
Pass the netgo tag when building static binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [v0.5.1](https://github.com/docker/notary/releases/tag/v0.5.1) 11/14/2016
 + If no `records` parameter is provided in a request for the changefeed, a default value of 100 is used.
++ Fix build tags for static notary client binaries in linux [#1038](https://github.com/docker/notary/pull/1038)
 
 ## [v0.5.0](https://github.com/docker/notary/releases/tag/v0.5.0) 11/14/2016
 + Non-certificate public keys in PEM format can now be added to delegation roles [#965](https://github.com/docker/notary/pull/965)

--- a/Makefile
+++ b/Makefile
@@ -78,15 +78,15 @@ ${PREFIX}/bin/static/notary:
 else
 ${PREFIX}/bin/static/notary-server: NOTARY_VERSION $(shell find . -type f -name '*.go')
 	@echo "+ $@"
-	@(export CGO_ENABLED=0; go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-server)
+	@(export CGO_ENABLED=0; go build -tags "${NOTARY_BUILDTAGS} netgo" -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-server)
 
 ${PREFIX}/bin/static/notary-signer: NOTARY_VERSION $(shell find . -type f -name '*.go')
 	@echo "+ $@"
-	@(export CGO_ENABLED=0; go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-signer)
+	@(export CGO_ENABLED=0; go build -tags "${NOTARY_BUILDTAGS} netgo" -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-signer)
 
 ${PREFIX}/bin/static/notary:
 	@echo "+ $@"
-	@go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary
+	@go build -tags "${NOTARY_BUILDTAGS} netgo" -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary
 
 endif
 

--- a/buildscripts/cross.sh
+++ b/buildscripts/cross.sh
@@ -40,7 +40,7 @@ for os in "$@"; do
 	go build \
 		-o "${NOTARYDIR}/cross/${GOOS}/${GOARCH}/${OUTFILE}" \
 		-a \
-		-tags "${BUILDTAGS}" \
+		-tags "${BUILDTAGS} netgo" \
 		-ldflags "-w ${CTIMEVAR} ${LDFLAGS}"  \
 		./cmd/notary;
 	set +x;


### PR DESCRIPTION
- When building static binaries with CGO, cgo unix network segfaults
- When building dynamically linked binaries with CGO, everything is fine
- When building static binaries with CGO but with netgo enabled, dns lookups seem fine

So add the netgo tag when building static binaries.

https://github.com/prometheus/alertmanager/issues/304
https://github.com/golang/go/issues/7857