### PR TITLE
Use an in-memory cache for client tests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1009,6 +1009,11 @@ func (r *NotaryRepository) DeleteTrustData(deleteRemote bool) error {
 	if err := os.RemoveAll(r.tufRepoPath); err != nil {
 		return fmt.Errorf("error clearing TUF repo data: %v", err)
 	}
+	// Because the cache may not stored on disk, clear it too
+	if err := r.cache.RemoveAll(); err != nil {
+		return fmt.Errorf("error clearing TUF repo data: %v", err)
+	}
+
 	// Note that this will require admin permission in this NotaryRepository's roundtripper
 	if deleteRemote {
 		remote, err := getRemoteStore(r.baseURL, r.gun, r.roundTrip)

--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -31,8 +31,8 @@ func newBlankRepo(t *testing.T, url string) *NotaryRepository {
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 
-	repo, err := NewFileCachedNotaryRepository(tempBaseDir, "docker.com/notary", url,
-		http.DefaultTransport, passphrase.ConstantRetriever("pass"), trustpinning.TrustPinConfig{})
+	repo, err := NewNotaryRepository(tempBaseDir, "docker.com/notary", url,
+		http.DefaultTransport, store.NewMemoryStore(nil), passphrase.ConstantRetriever("pass"), trustpinning.TrustPinConfig{})
 	require.NoError(t, err)
 	return repo
 }
@@ -191,8 +191,8 @@ func TestUpdateInOfflineMode(t *testing.T) {
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
 	defer os.RemoveAll(tempBaseDir)
 
-	offlineRepo, err := NewFileCachedNotaryRepository(tempBaseDir, "docker.com/notary", "https://nope",
-		nil, passphrase.ConstantRetriever("pass"), trustpinning.TrustPinConfig{})
+	offlineRepo, err := NewNotaryRepository(tempBaseDir, "docker.com/notary", "https://nope",
+		nil, store.NewMemoryStore(nil), passphrase.ConstantRetriever("pass"), trustpinning.TrustPinConfig{})
 	require.NoError(t, err)
 	err = offlineRepo.Update(false)
 	require.Error(t, err)

--- a/tuf/testutils/corrupt_memorystore.go
+++ b/tuf/testutils/corrupt_memorystore.go
@@ -1,6 +1,8 @@
 package testutils
 
 import (
+	"fmt"
+
 	store "github.com/docker/notary/storage"
 )
 
@@ -68,4 +70,14 @@ func (sm ShortMemoryStore) GetSized(name string, size int64) ([]byte, error) {
 		return nil, err
 	}
 	return d[1:], err
+}
+
+// UnreadableStore returns an error every time GetSized is called
+type UnreadableStore struct {
+	store.MetadataStore
+}
+
+// GetSized returns an error
+func (um UnreadableStore) GetSized(name string, size int64) ([]byte, error) {
+	return nil, fmt.Errorf("unreadable")
 }


### PR DESCRIPTION
This is an attempt to try to speed up some of the CI tests as per #1029.  Just wanted to see if it'd make a difference - I'm guessing if so, not much of one, but pprof says io seems to be one of the higher calls by time.

Ran the following on master:
```
$ go test -c github.com/docker/notary/client
$ ./client.test -test.cpuprofile=cpu.prof
$  go tool pprof client.test cpu.prof 
Entering interactive mode (type "help" for commands)
(pprof) tree
17.59s of 19.87s total (88.53%)
Dropped 621 nodes (cum <= 0.10s)
Showing top 80 nodes out of 372 (cum >= 4.99s)
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                             0.93s 64.16% |   github.com/docker/notary/client.(*TUFClient).downloadTargets
                                             0.34s 23.43% |   crypto/rand.hideAgainReader.Read
                                             0.18s 12.40% |   bufio.(*Writer).flush
     4.90s 24.66% 24.66%      4.91s 24.71%                | syscall.Syscall
----------------------------------------------------------+-------------
                                             3.09s   100% |   math/big.nat.montgomery
     3.09s 15.55% 40.21%      3.09s 15.55%                | math/big.addMulVVW
----------------------------------------------------------+-------------
                                             0.21s 48.48% |   runtime.findrunnable
                                             0.21s 47.03% |   runtime.mallocgc
                                             0.02s  4.49% |   runtime.gcFlushBgCredit
     1.22s  6.14% 46.35%      1.22s  6.14%                | runtime.mach_semaphore_signal
----------------------------------------------------------+-------------
                                             0.50s 54.35% |   math/big.nat.montgomery
                                             0.14s 15.22% |   runtime.gcDrain
                                             0.13s 14.13% |   runtime.typedmemmove
                                             0.09s  9.78% |   runtime.stkbucket
                                             0.04s  4.35% |   bytes.(*Buffer).Write
                                             0.02s  2.17% |   bytes.(*Buffer).grow
     1.05s  5.28% 51.64%      1.05s  5.28%                | runtime.memmove
...
```

And the following on this branch:
```
$ go test -c github.com/docker/notary/client
$ ./client.test -test.cpuprofile=cpu.prof
$  go tool pprof client.test cpu.prof 
Entering interactive mode (type "help" for commands)
(pprof) tree
15.76s of 18.35s total (85.89%)
Dropped 660 nodes (cum <= 0.09s)
Showing top 80 nodes out of 360 (cum >= 0.27s)
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                             3.07s   100% |   math/big.nat.montgomery
     3.07s 16.73% 16.73%      3.07s 16.73%                | math/big.addMulVVW
----------------------------------------------------------+-------------
                                             2.70s 97.85% |   runtime.systemstack
                                             0.06s  2.15% |   runtime.gcFlushBgCredit
     3.06s 16.68% 33.41%      3.06s 16.68%                | runtime.mach_semaphore_signal
----------------------------------------------------------+-------------
                                             0.29s 65.91% |   crypto/rand.hideAgainReader.Read
                                             0.15s 34.09% |   bufio.(*Writer).flush
     1.74s  9.48% 42.89%      1.74s  9.48%                | syscall.Syscall
----------------------------------------------------------+-------------
                                             0.54s 66.67% |   math/big.nat.montgomery
                                             0.09s 11.11% |   runtime.growslice
                                             0.09s 11.11% |   runtime.typedmemmove
                                             0.04s  4.94% |   bytes.(*Buffer).Write
                                             0.03s  3.70% |   runtime.stkbucket
                                             0.02s  2.47% |   bytes.(*Buffer).grow
     0.99s  5.40% 48.28%      0.99s  5.40%                | runtime.memmove
----------------------------------------------------------+-------------
                                             4.45s   100% |   math/big.nat.expNNMontgomery
     0.78s  4.25% 52.53%      4.45s 24.25%                | math/big.nat.montgomery
                                             3.07s 85.04% |   math/big.addMulVVW
                                             0.54s 14.96% |   runtime.memmove
----------------------------------------------------------+-------------
                                             0.10s   100% |   runtime.lock
     0.75s  4.09% 56.62%      0.75s  4.09%                | runtime.usleep
...
```

Probably the next thing to try is to reduce the amount of crypto done, maybe with cached keys.