### PR TITLE
Bump to golang 1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.8
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.8.1
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.8
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.8.1
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.8.1-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3-alpine
+FROM golang:1.8-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.8.1-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3-alpine
+FROM golang:1.8-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Currently in beta1, wanted to give it a spin on our CI just in case we find any issues to fix on the notary or golang side (we found one in docker by testing DCT: https://github.com/docker/docker/pull/29030)

We can bump this as new betas are released, and eventually this can be the PR for the final golang 1.8.0 release bump tracked for early 2017.

**Update**: bumped to golang 1.8.1

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>