### PR TITLE
Move most of the notary server/signer http/grpc server code to subpackages

### DIFF
--- a/cmd/notary-server/main.go
+++ b/cmd/notary-server/main.go
@@ -2,96 +2,16 @@ package main
 
 import (
 	_ "expvar"
-	"flag"
-	"fmt"
-	"net/http"
 	_ "net/http/pprof"
-	"os"
-	"os/signal"
 
-	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/health"
-	"github.com/docker/notary/server"
-	"github.com/docker/notary/utils"
-	"github.com/docker/notary/version"
+	_ "github.com/docker/distribution/registry/auth/htpasswd"
+	_ "github.com/docker/distribution/registry/auth/token"
+	"github.com/docker/notary/cmd/notary-server/runner"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
 )
-
-// DebugAddress is the debug server address to listen on
-const (
-	jsonLogFormat = "json"
-	DebugAddress  = "localhost:8080"
-	envPrefix     = "NOTARY_SERVER"
-)
-
-type cmdFlags struct {
-	debug       bool
-	logFormat   string
-	configFile  string
-	doBootstrap bool
-}
-
-func setupFlags(flagStorage *cmdFlags) {
-	// Setup flags
-	flag.StringVar(&flagStorage.configFile, "config", "", "Path to configuration file")
-	flag.BoolVar(&flagStorage.debug, "debug", false, "Enable the debugging server on localhost:8080")
-	flag.StringVar(&flagStorage.logFormat, "logf", "json", "Set the format of the logs. Only 'json' and 'logfmt' are supported at the moment.")
-	flag.BoolVar(&flagStorage.doBootstrap, "bootstrap", false, "Do any necessary setup of configured backend storage services")
-
-	// this needs to be in init so that _ALL_ logs are in the correct format
-	if flagStorage.logFormat == jsonLogFormat {
-		logrus.SetFormatter(new(logrus.JSONFormatter))
-	}
-
-	flag.Usage = usage
-}
 
 func main() {
-	flagStorage := cmdFlags{}
-	setupFlags(&flagStorage)
-
-	flag.Parse()
-
-	if flagStorage.debug {
-		go debugServer(DebugAddress)
-	}
-
-	// when the server starts print the version for debugging and issue logs later
-	logrus.Infof("Version: %s, Git commit: %s", version.NotaryVersion, version.GitCommit)
-
-	ctx, serverConfig, err := parseServerConfig(flagStorage.configFile, health.RegisterPeriodicFunc, flagStorage.doBootstrap)
-	if err != nil {
-		logrus.Fatal(err.Error())
-	}
-
-	c := utils.SetupSignalTrap(utils.LogLevelSignalHandle)
-	if c != nil {
-		defer signal.Stop(c)
-	}
-
-	if flagStorage.doBootstrap {
-		err = bootstrap(ctx)
-	} else {
-		logrus.Info("Starting Server")
-		err = server.Run(ctx, serverConfig)
-	}
-
-	if err != nil {
-		logrus.Fatal(err.Error())
-	}
-	return
-}
-
-func usage() {
-	fmt.Println("usage:", os.Args[0])
-	flag.PrintDefaults()
-}
-
-// debugServer starts the debug server with pprof, expvar among other
-// endpoints. The addr should not be exposed externally. For most of these to
-// work, tls cannot be enabled on the endpoint, so it is generally separate.
-func debugServer(addr string) {
-	logrus.Infof("Debug server listening on %s", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil {
-		logrus.Fatalf("error listening on debug interface: %v", err)
-	}
+	serverSetup := runner.ReadServerConfig()
+	runner.RunServer(serverSetup)
 }

--- a/cmd/notary-server/runner/bootstrap.go
+++ b/cmd/notary-server/runner/bootstrap.go
@@ -1,4 +1,4 @@
-package main
+package runner
 
 import (
 	"fmt"

--- a/cmd/notary-server/runner/bootstrap_test.go
+++ b/cmd/notary-server/runner/bootstrap_test.go
@@ -1,4 +1,4 @@
-package main
+package runner
 
 import (
 	"testing"

--- a/cmd/notary-server/runner/server_test.go
+++ b/cmd/notary-server/runner/server_test.go
@@ -1,4 +1,4 @@
-package main
+package runner
 
 import (
 	"bytes"
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	Cert = "../../fixtures/notary-server.crt"
-	Key  = "../../fixtures/notary-server.key"
-	Root = "../../fixtures/root-ca.crt"
+	Cert = "../../../fixtures/notary-server.crt"
+	Key  = "../../../fixtures/notary-server.key"
+	Root = "../../../fixtures/root-ca.crt"
 )
 
 // initializes a viper object with test configuration
@@ -407,7 +407,7 @@ func TestGetGUNPRefixes(t *testing.T) {
 // For sanity, make sure we can always parse the sample config
 func TestSampleConfig(t *testing.T) {
 	var registerCalled = 0
-	_, _, err := parseServerConfig("../../fixtures/server-config.json", fakeRegisterer(&registerCalled), false)
+	_, _, err := parseServerConfig("../../../fixtures/server-config.json", fakeRegisterer(&registerCalled), false)
 	require.NoError(t, err)
 
 	// once for the DB, once for the trust service

--- a/cmd/notary-signer/main.go
+++ b/cmd/notary-signer/main.go
@@ -2,92 +2,13 @@ package main
 
 import (
 	_ "expvar"
-	"flag"
-	"log"
-	"net/http"
-	"os"
-	"os/signal"
 
-	"github.com/Sirupsen/logrus"
-	"github.com/docker/notary/utils"
-	"github.com/docker/notary/version"
+	"github.com/docker/notary/cmd/notary-signer/runner"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 )
 
-const (
-	jsonLogFormat = "json"
-	debugAddr     = "localhost:8080"
-)
-
-type cmdFlags struct {
-	debug       bool
-	logFormat   string
-	configFile  string
-	doBootstrap bool
-}
-
-func setupFlags(flagStorage *cmdFlags) {
-	// Setup flags
-	flag.StringVar(&flagStorage.configFile, "config", "", "Path to configuration file")
-	flag.BoolVar(&flagStorage.debug, "debug", false, "Show the version and exit")
-	flag.StringVar(&flagStorage.logFormat, "logf", "json", "Set the format of the logs. Only 'json' and 'logfmt' are supported at the moment.")
-	flag.BoolVar(&flagStorage.doBootstrap, "bootstrap", false, "Do any necessary setup of configured backend storage services")
-
-	// this needs to be in init so that _ALL_ logs are in the correct format
-	if flagStorage.logFormat == jsonLogFormat {
-		logrus.SetFormatter(new(logrus.JSONFormatter))
-	}
-
-	flag.Usage = usage
-}
-
 func main() {
-	flagStorage := cmdFlags{}
-	setupFlags(&flagStorage)
-
-	flag.Parse()
-
-	if flagStorage.debug {
-		go debugServer(debugAddr)
-	}
-
-	// when the signer starts print the version for debugging and issue logs later
-	logrus.Infof("Version: %s, Git commit: %s", version.NotaryVersion, version.GitCommit)
-
-	signerConfig, err := parseSignerConfig(flagStorage.configFile, flagStorage.doBootstrap)
-	if err != nil {
-		logrus.Fatal(err.Error())
-	}
-
-	grpcServer, lis, err := setupGRPCServer(signerConfig)
-	if err != nil {
-		logrus.Fatal(err.Error())
-	}
-
-	if flagStorage.debug {
-		log.Println("RPC server listening on", signerConfig.GRPCAddr)
-	}
-
-	c := utils.SetupSignalTrap(utils.LogLevelSignalHandle)
-	if c != nil {
-		defer signal.Stop(c)
-	}
-
-	grpcServer.Serve(lis)
-}
-
-func usage() {
-	log.Println("usage:", os.Args[0], "<config>")
-	flag.PrintDefaults()
-}
-
-// debugServer starts the debug server with pprof, expvar among other
-// endpoints. The addr should not be exposed externally. For most of these to
-// work, tls cannot be enabled on the endpoint, so it is generally separate.
-func debugServer(addr string) {
-	logrus.Infof("Debug server listening on %s", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil {
-		logrus.Fatalf("error listening on debug interface: %v", err)
-	}
+	setup := runner.ReadSignerConfig()
+	runner.RunSigner(setup)
 }

--- a/cmd/notary-signer/runner/signer_test.go
+++ b/cmd/notary-signer/runner/signer_test.go
@@ -1,4 +1,4 @@
-package main
+package runner
 
 import (
 	"bytes"
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	Cert = "../../fixtures/notary-signer.crt"
-	Key  = "../../fixtures/notary-signer.key"
+	Cert = "../../../fixtures/notary-signer.crt"
+	Key  = "../../../fixtures/notary-signer.key"
 )
 
 // initializes a viper object with test configuration
@@ -124,9 +124,9 @@ func TestSetupCryptoServicesRethinkDBStoreConnectionFails(t *testing.T) {
 			`{"storage": {
 				"backend": "%s",
 				"db_url": "host:port",
-				"tls_ca_file": "../../fixtures/rethinkdb/ca.pem",
-				"client_cert_file": "../../fixtures/rethinkdb/cert.pem",
-				"client_key_file": "../../fixtures/rethinkdb/key.pem",
+				"tls_ca_file": "../../../fixtures/rethinkdb/ca.pem",
+				"client_cert_file": "../../../fixtures/rethinkdb/cert.pem",
+				"client_key_file": "../../../fixtures/rethinkdb/key.pem",
 				"database": "rethinkdbtest",
 				"username": "signer",
 				"password": "password"
@@ -274,6 +274,6 @@ func TestSampleConfig(t *testing.T) {
 	// if using signer.Dockerfile.
 	os.Setenv("NOTARY_SIGNER_DEFAULT_ALIAS", "timestamp_1")
 	defer os.Unsetenv("NOTARY_SIGNER_DEFAULT_ALIAS")
-	_, err := parseSignerConfig("../../fixtures/signer-config-local.json", false)
+	_, err := parseSignerConfig("../../../fixtures/signer-config-local.json", false)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This is so that either can be imported and run outside the main package.

cc @endophage @vikstrous (I couldn't find an associated issue but I vaguely remember @vikstrous asking for this a while back as well)