### PR TITLE
Not for merging: PoC of bug I can't work out

### DIFF
--- a/client/client_update_test.go
+++ b/client/client_update_test.go
@@ -164,7 +164,8 @@ func TestUpdateSucceedsEvenIfCannotWriteExistingRepo(t *testing.T) {
 
 			require.NoError(t, err)
 
-			for r, expected := range serverMeta {
+			for r, _ := range serverMeta {
+				expected, err := serverSwizzler.MetadataCache.GetSized(r, store.NoSizeLimit)
 				if r != data.CanonicalRootRole && strings.Contains(r, "root") {
 					// don't fetch versioned root roles here
 					continue


### PR DESCRIPTION
cc @riyazdf @n4ss @cyli 

~~I've managed to create this super minimal PoC. I must be doing something really dumb but I can't for the life of me work out why this causes `client.TestUpdateSucceedsEvenIfCannotWriteExistingRepo` to fail.~~

The test relied on the serverMeta map being shared between the mock server's
    MemoryStore and the test. This isn't particularly robust and caused the test to error
    when I updated the MemoryStore to make a copy of the map. This commit uses the MemoryStore
    directly to retrieve the expected values.

p.s. STILL DO NOT MERGE. I have a fixed version of this test incoming in the type update PR, no point in merging this one. I'll close this in a day or two once anyone interested has had a chance to look at it.