### PR TITLE
Notary repository lazy initialization

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -623,10 +623,12 @@ func (r *NotaryRepository) publish(cl changelist.Changelist) error {
 		if _, ok := err.(ErrRepositoryNotExist); ok {
 			err := r.bootstrapRepo()
 			if _, ok := err.(store.ErrMetaNotFound); ok {
+				logrus.Debugf("No metadata found on disk, initializing repository %s from scratch", r.gun.String())
 				err = r.Initialize(nil)
 			}
 
 			if err != nil {
+				logrus.Debugf("Unable to initialize repository at publish-time: %s", err.Error())
 				return err
 			}
 

--- a/client/client.go
+++ b/client/client.go
@@ -834,6 +834,8 @@ func (r *NotaryRepository) bootstrapRepo() error {
 	return nil
 }
 
+// initializeFromCache looks for cached metadata to bootstrap from
+// and will initialize the repository from scratch otherwise.
 func (r *NotaryRepository) initializeFromCache() error {
 	metaCached, err := isMetaCached(r.cache)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -633,23 +633,6 @@ func (r *NotaryRepository) Publish() error {
 	return nil
 }
 
-func (r *NotaryRepository) isMetaCached() (bool, error) {
-	for _, role := range data.BaseRoles {
-		_, err := r.cache.GetSized(role.String(), store.NoSizeLimit)
-		if err != nil {
-			if _, ok := err.(store.ErrMetaNotFound); ok {
-				continue
-			}
-
-			return false, err
-		}
-
-		return true, nil
-	}
-
-	return false, nil
-}
-
 // publish pushes the changes in the given changelist to the remote notary-server
 // Conceptually it performs an operation similar to a `git rebase`
 func (r *NotaryRepository) publish(cl changelist.Changelist) error {
@@ -659,20 +642,8 @@ func (r *NotaryRepository) publish(cl changelist.Changelist) error {
 		// If the remote is not aware of the repo, then this is being published
 		// for the first time.  Try to initialize the repository before publishing.
 		if _, ok := err.(ErrRepositoryNotExist); ok {
-			metaCached, err := r.isMetaCached()
+			err := r.initializeFromCache()
 			if err != nil {
-				logrus.Debugf("Unable to verify on-disk cache: %s", err.Error())
-				return err
-			}
-
-			if metaCached {
-				err = r.bootstrapRepo()
-			} else {
-				err = r.Initialize(nil)
-			}
-			if err != nil {
-				logrus.Debugf("Unable to initialize repository at publish-time: %s",
-					err.Error())
 				return err
 			}
 
@@ -882,6 +853,25 @@ func (r *NotaryRepository) bootstrapRepo() error {
 		r.tufRepo = tufRepo
 	}
 	return nil
+}
+
+func (r *NotaryRepository) initializeFromCache() error {
+	metaCached, err := isMetaCached(r.cache)
+	if err != nil {
+		logrus.Debugf("Unable to verify on-disk cache: %s", err.Error())
+		return err
+	}
+
+	if metaCached {
+		err = r.bootstrapRepo()
+	} else {
+		err = r.Initialize(nil)
+	}
+	if err != nil {
+		logrus.Debugf("Unable to initialize repository at publish-time: %s",
+			err.Error())
+		return err
+	}
 }
 
 // saveMetadata saves contents of r.tufRepo onto the local disk, creating

--- a/client/client.go
+++ b/client/client.go
@@ -187,6 +187,24 @@ func (r *NotaryRepository) Initialize(rootKeyIDs []string, serverManagedRoles ..
 		}
 		privKeys = append(privKeys, privKey)
 	}
+	if len(privKeys) == 0 {
+		var rootKeyID string
+		rootKeyList := r.CryptoService.ListKeys(data.CanonicalRootRole)
+		if len(rootKeyList) == 0 {
+			rootPublicKey, err := r.CryptoService.Create(data.CanonicalRootRole, "", data.ECDSAKey)
+			if err != nil {
+				return err
+			}
+			rootKeyID = rootPublicKey.ID()
+		} else {
+			rootKeyID = rootKeyList[0]
+		}
+		privKey, _, err := r.CryptoService.GetPrivateKey(rootKeyID)
+		if err != nil {
+			return err
+		}
+		privKeys = append(privKeys, privKey)
+	}
 
 	// currently we only support server managing timestamps and snapshots, and
 	// nothing else - timestamps are always managed by the server, and implicit
@@ -259,7 +277,6 @@ func (r *NotaryRepository) Initialize(rootKeyIDs []string, serverManagedRoles ..
 
 func (r *NotaryRepository) initializeRoles(rootKeys []data.PublicKey, localRoles, remoteRoles []data.RoleName) (
 	root, targets, snapshot, timestamp data.BaseRole, err error) {
-
 	root = data.NewBaseRole(
 		data.CanonicalRootRole,
 		notary.MinThreshold,
@@ -603,8 +620,8 @@ func (r *NotaryRepository) ListRoles() ([]RoleWithSignatures, error) {
 
 // Publish pushes the local changes in signed material to the remote notary-server
 // Conceptually it performs an operation similar to a `git rebase`
-func (r *NotaryRepository) Publish(rootKeyIDs []string) error {
-	if err := r.publish(r.changelist, rootKeyIDs); err != nil {
+func (r *NotaryRepository) Publish() error {
+	if err := r.publish(r.changelist); err != nil {
 		return err
 	}
 	if err := r.changelist.Clear(""); err != nil {
@@ -618,14 +635,14 @@ func (r *NotaryRepository) Publish(rootKeyIDs []string) error {
 
 // publish pushes the changes in the given changelist to the remote notary-server
 // Conceptually it performs an operation similar to a `git rebase`
-func (r *NotaryRepository) publish(cl changelist.Changelist, rootKeyIDs []string) error {
+func (r *NotaryRepository) publish(cl changelist.Changelist) error {
 	var initialPublish bool
 	// update first before publishing
 	if err := r.Update(true); err != nil {
 		// If the remote is not aware of the repo, then this is being published
 		// for the first time.  Try to initialize the repository before publishing.
 		if _, ok := err.(ErrRepositoryNotExist); ok {
-			err := r.Initialize(rootKeyIDs)
+			err := r.Initialize(nil)
 			if err != nil {
 				logrus.Debugf("Unable to initialize repository at publish-time: %s",
 					err.Error())
@@ -1032,7 +1049,7 @@ func (r *NotaryRepository) RotateKey(role data.RoleName, serverManagesKey bool, 
 	if err := r.rootFileKeyChange(cl, role, changelist.ActionCreate, pubKeyList); err != nil {
 		return err
 	}
-	return r.publish(cl, []string{r.GetGUN()})
+	return r.publish(cl)
 }
 
 // Given a set of new keys to rotate to and a set of keys to drop, returns the list of current keys to use

--- a/client/client.go
+++ b/client/client.go
@@ -603,8 +603,8 @@ func (r *NotaryRepository) ListRoles() ([]RoleWithSignatures, error) {
 
 // Publish pushes the local changes in signed material to the remote notary-server
 // Conceptually it performs an operation similar to a `git rebase`
-func (r *NotaryRepository) Publish() error {
-	if err := r.publish(r.changelist); err != nil {
+func (r *NotaryRepository) Publish(rootKeyIDs []string) error {
+	if err := r.publish(r.changelist, rootKeyIDs); err != nil {
 		return err
 	}
 	if err := r.changelist.Clear(""); err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -623,12 +623,12 @@ func (r *NotaryRepository) publish(cl changelist.Changelist) error {
 		if _, ok := err.(ErrRepositoryNotExist); ok {
 			err := r.bootstrapRepo()
 			if _, ok := err.(store.ErrMetaNotFound); ok {
-				logrus.Debugf("No metadata found on disk, initializing repository %s from scratch", r.gun.String())
+				logrus.Infof("No TUF data found locally or remotely - initializing repository %s for the first time", r.gun.String())
 				err = r.Initialize(nil)
 			}
 
 			if err != nil {
-				logrus.Debugf("Unable to initialize repository at publish-time: %s", err.Error())
+				logrus.WithError(err).Debugf("Unable to load or initialize repository during first publish: %s", err.Error())
 				return err
 			}
 

--- a/client/client.go
+++ b/client/client.go
@@ -121,7 +121,7 @@ func NewNotaryRepository(baseDir string, gun data.GUN, baseURL string, remoteSto
 }
 
 // GetGUN is a getter for the GUN object from a NotaryRepository
-func (r *NotaryRepository) GetGUN() string {
+func (r *NotaryRepository) GetGUN() data.GUN {
 	return r.gun
 }
 
@@ -635,7 +635,7 @@ func (r *NotaryRepository) Publish() error {
 
 func (r *NotaryRepository) isMetaCached() (bool, error) {
 	for _, role := range data.BaseRoles {
-		_, err := r.cache.GetSized(role, store.NoSizeLimit)
+		_, err := r.cache.GetSized(role.String(), store.NoSizeLimit)
 		if err != nil {
 			if _, ok := err.(store.ErrMetaNotFound); ok {
 				continue

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1986,26 +1986,6 @@ func testPublishBadMetadata(t *testing.T, roleName string, repo *NotaryRepositor
 	}
 }
 
-// If the repo is not initialized, calling repo.Publish() should return ErrRepoNotInitialized
-func TestNotInitializedOnPublish(t *testing.T) {
-	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	defer os.RemoveAll(tempBaseDir)
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
-
-	gun := "docker.com/notary"
-	ts := fullTestServer(t)
-	defer ts.Close()
-
-	repo, _, _ := createRepoAndKey(t, data.ECDSAKey, tempBaseDir, gun, ts.URL)
-
-	addTarget(t, repo, "v1", "../fixtures/intermediate-ca.crt")
-
-	err = repo.Publish()
-	require.Error(t, err)
-	require.IsType(t, ErrRepoNotInitialized{}, err)
-}
-
 type cannotCreateKeys struct {
 	signed.CryptoService
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1684,6 +1684,7 @@ func TestPublishUninitializedRepo(t *testing.T) {
 	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, true)
 	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
 
+	// check we can just call publish again
 	require.NoError(t, repo.Publish())
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1673,37 +1673,6 @@ func TestPublishUninitializedRepo(t *testing.T) {
 	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
 }
 
-// Initializing a repo and republishing after should succeed
-func TestPublishInitializedRepo(t *testing.T) {
-	var gun data.GUN = "docker.com/notary"
-	ts := fullTestServer(t)
-	defer ts.Close()
-
-	// uninitialized repo should not fail to publish
-	tempBaseDir, err := ioutil.TempDir("", "notary-tests")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempBaseDir)
-
-	// initialized repo should not fail to publish either
-	repo, err := NewFileCachedNotaryRepository(tempBaseDir, gun, ts.URL,
-		http.DefaultTransport, passphraseRetriever, trustpinning.TrustPinConfig{})
-	require.NoError(t, err, "error creating repository: %s", err)
-
-	// now, initialize and publish
-	rootPubKey, err := repo.CryptoService.Create(data.CanonicalRootRole, repo.gun, data.ECDSAKey)
-	require.NoError(t, err, "error generating root key: %s", err)
-
-	require.NoError(t, repo.Initialize([]string{rootPubKey.ID()}))
-
-	// now metadata is created
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalRootRole, true)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalSnapshotRole, true)
-	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
-
-	// check we can just call publish again
-	require.NoError(t, repo.Publish())
-}
-
 // Create a repo, instantiate a notary server, and publish the repo with
 // some targets to the server, signing all the non-timestamp metadata.
 // We test this with both an RSA and ECDSA root key

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1673,7 +1673,7 @@ func TestPublishUninitializedRepo(t *testing.T) {
 	requireRepoHasExpectedMetadata(t, repo, data.CanonicalTargetsRole, true)
 }
 
-// Tnitializing a repo and republishing after should succeed
+// Initializing a repo and republishing after should succeed
 func TestPublishInitializedRepo(t *testing.T) {
 	var gun data.GUN = "docker.com/notary"
 	ts := fullTestServer(t)
@@ -2647,19 +2647,17 @@ func TestRemoteRotationNoRootKey(t *testing.T) {
 	require.IsType(t, signed.ErrInsufficientSignatures{}, err)
 }
 
-// The repo is initialized at publish time after
-// rotating the key. We should be denied the access
-// to metadata by the server when trying to retrieve it.
+// The repo should initialize successfully at publish time after
+// rotating the key.
 func TestRemoteRotationNoInit(t *testing.T) {
-	ts, _, _ := simpleTestServer(t)
+	ts := fullTestServer(t)
 	defer ts.Close()
 
 	repo := newBlankRepo(t, ts.URL)
 	defer os.RemoveAll(repo.baseDir)
 
 	err := repo.RotateKey(data.CanonicalTimestampRole, true, nil)
-	require.Error(t, err)
-	require.IsType(t, store.ErrMetaNotFound{}, err)
+	require.NoError(t, err)
 }
 
 // Rotates the keys.  After the rotation, downloading the latest metadata

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2631,8 +2631,10 @@ func TestRemoteRotationNoRootKey(t *testing.T) {
 	require.IsType(t, signed.ErrInsufficientSignatures{}, err)
 }
 
-// The repo hasn't been initialized, so we can't rotate
-func TestRemoteRotationNonexistentRepo(t *testing.T) {
+// The repo is initialized at publish time after
+// rotating the key. We should be denied the access
+// to metadata by the server when trying to retrieve it.
+func TestRemoteRotationNoInit(t *testing.T) {
 	ts, _, _ := simpleTestServer(t)
 	defer ts.Close()
 
@@ -2641,7 +2643,7 @@ func TestRemoteRotationNonexistentRepo(t *testing.T) {
 
 	err := repo.RotateKey(data.CanonicalTimestampRole, true, nil)
 	require.Error(t, err)
-	require.IsType(t, ErrRepoNotInitialized{}, err)
+	require.IsType(t, store.ErrMetaNotFound{}, err)
 }
 
 // Rotates the keys.  After the rotation, downloading the latest metadata

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/registry/storage/cache"
 	"github.com/docker/notary/client/changelist"
 	store "github.com/docker/notary/storage"
 	"github.com/docker/notary/tuf"
@@ -267,4 +268,25 @@ func serializeCanonicalRole(tufRepo *tuf.Repo, role data.RoleName, extraSigningK
 	}
 
 	return json.Marshal(s)
+}
+
+func isMetaCached(cache store.MetadataStore) (bool, error) {
+	if cache == nil {
+		return false, nil
+	}
+
+	for _, role := range data.BaseRoles {
+		_, err := cache.GetSized(role.String(), store.NoSizeLimit)
+		if err != nil {
+			if _, ok := err.(store.ErrMetaNotFound); ok {
+				continue
+			}
+
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -270,6 +270,8 @@ func serializeCanonicalRole(tufRepo *tuf.Repo, role data.RoleName, extraSigningK
 	return json.Marshal(s)
 }
 
+// isMetaCached looks for metadata in the cache. For each role, get the associated
+// metadata if any. Stop searching if we get an error other than metadata not found.
 func isMetaCached(cache store.MetadataStore) (bool, error) {
 	if cache == nil {
 		return false, nil
@@ -278,10 +280,13 @@ func isMetaCached(cache store.MetadataStore) (bool, error) {
 	for _, role := range data.BaseRoles {
 		_, err := cache.GetSized(role.String(), store.NoSizeLimit)
 		if err != nil {
+			// no metadata found check
 			if _, ok := err.(store.ErrMetaNotFound); ok {
+				// try with next role
 				continue
 			}
 
+			// error while searching
 			return false, err
 		}
 

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -270,32 +270,6 @@ func serializeCanonicalRole(tufRepo *tuf.Repo, role data.RoleName, extraSigningK
 	return json.Marshal(s)
 }
 
-// isMetaCached looks for metadata in the cache. For each role, get the associated
-// metadata if any. Stop searching if we get an error other than metadata not found.
-func isMetaCached(cache store.MetadataStore) (bool, error) {
-	if cache == nil {
-		return false, nil
-	}
-
-	for _, role := range data.BaseRoles {
-		_, err := cache.GetSized(role.String(), store.NoSizeLimit)
-		if err != nil {
-			// no metadata found check
-			if _, ok := err.(store.ErrMetaNotFound); ok {
-				// try with next role
-				continue
-			}
-
-			// error while searching
-			return false, err
-		}
-
-		return true, nil
-	}
-
-	return false, nil
-}
-
 func getAllPrivKeys(rootKeyIDs []string, cryptoService signed.CryptoService) ([]data.PrivateKey, error) {
 	if cryptoService == nil {
 		return nil, fmt.Errorf("no crypto service available to get private keys from")

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -407,14 +407,7 @@ func importRootKey(cmd *cobra.Command, rootKey string, nRepo *notaryclient.Notar
 	}
 
 	var rootKeyID string
-	if len(rootKeyList) < 1 {
-		cmd.Println("No root keys found. Generating a new root key...")
-		rootPublicKey, err := nRepo.CryptoService.Create(data.CanonicalRootRole, "", data.ECDSAKey)
-		if err != nil {
-			return nil, err
-		}
-		rootKeyID = rootPublicKey.ID()
-	} else {
+	if len(rootKeyList) > 0 {
 		// Chooses the first root key available, which is initialization specific
 		// but should return the HW one first.
 		rootKeyID = rootKeyList[0]
@@ -699,18 +692,7 @@ func (t *tufCommander) tufPublish(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var rootKeyIDs []string
-
-	if err := nRepo.Update(true); err != nil {
-		if _, ok := err.(notaryclient.ErrRepositoryNotExist); ok {
-			rootKeyIDs, err = importRootKey(cmd, t.rootKey, nRepo, t.retriever)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return publishAndPrintToCLI(cmd, nRepo, rootKeyIDs)
+	return publishAndPrintToCLI(cmd, nRepo)
 }
 
 func (t *tufCommander) tufRemove(cmd *cobra.Command, args []string) error {
@@ -1056,7 +1038,7 @@ func maybeAutoPublish(cmd *cobra.Command, doPublish bool, gun data.GUN, config *
 	}
 
 	cmd.Println("Auto-publishing changes to", nRepo.GetGUN())
-	return publishAndPrintToCLI(cmd, nRepo, nil)
+	return publishAndPrintToCLI(cmd, nRepo)
 }
 
 func publishAndPrintToCLI(cmd *cobra.Command, nRepo *notaryclient.NotaryRepository, gun data.GUN) error {

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -142,8 +142,7 @@ func (t *tufCommander) AddToCommand(cmd *cobra.Command) {
 	cmdReset.Flags().BoolVar(&t.resetAll, "all", false, "Reset all changes shown in the status list")
 	cmd.AddCommand(cmdReset)
 
-	cmdTUFPublish := cmdTUFPublishTemplate.ToCommand(t.tufPublish)
-	cmd.AddCommand(cmdTUFPublish)
+	cmd.AddCommand(cmdTUFPublishTemplate.ToCommand(t.tufPublish))
 
 	cmd.AddCommand(cmdTUFLookupTemplate.ToCommand(t.tufLookup))
 

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -388,7 +388,7 @@ func (t *tufCommander) tufDeleteGUN(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func importRootKey(cmd *cobra.Command,rootKey string, nRepo *notaryclient.NotaryRepository, retriever notary.PassRetriever) ([]string, error) {
+func importRootKey(cmd *cobra.Command, rootKey string, nRepo *notaryclient.NotaryRepository, retriever notary.PassRetriever) ([]string, error) {
 	var rootKeyList []string
 	var err error
 

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -390,7 +390,6 @@ func (t *tufCommander) tufDeleteGUN(cmd *cobra.Command, args []string) error {
 
 func importRootKey(cmd *cobra.Command, rootKey string, nRepo *notaryclient.NotaryRepository, retriever notary.PassRetriever) ([]string, error) {
 	var rootKeyList []string
-	var err error
 
 	if rootKey != "" {
 		privKey, err := readKey(data.CanonicalRootRole, rootKey, retriever)
@@ -406,15 +405,16 @@ func importRootKey(cmd *cobra.Command, rootKey string, nRepo *notaryclient.Notar
 		rootKeyList = nRepo.CryptoService.ListKeys(data.CanonicalRootRole)
 	}
 
-	var rootKeyID string
 	if len(rootKeyList) > 0 {
 		// Chooses the first root key available, which is initialization specific
 		// but should return the HW one first.
-		rootKeyID = rootKeyList[0]
+		rootKeyID := rootKeyList[0]
 		cmd.Printf("Root key found, using: %s\n", rootKeyID)
+
+		return []string{rootKeyID}, nil
 	}
 
-	return []string{rootKeyID}, err
+	return []string{}, nil
 }
 
 func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -143,7 +143,6 @@ func (t *tufCommander) AddToCommand(cmd *cobra.Command) {
 	cmd.AddCommand(cmdReset)
 
 	cmdTUFPublish := cmdTUFPublishTemplate.ToCommand(t.tufPublish)
-	cmdTUFPublish.Flags().StringVar(&t.rootKey, "rootkey", "", "Root key to initialize the repository with")
 	cmd.AddCommand(cmdTUFPublish)
 
 	cmd.AddCommand(cmdTUFLookupTemplate.ToCommand(t.tufLookup))

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -1041,7 +1041,7 @@ func maybeAutoPublish(cmd *cobra.Command, doPublish bool, gun data.GUN, config *
 	return publishAndPrintToCLI(cmd, nRepo)
 }
 
-func publishAndPrintToCLI(cmd *cobra.Command, nRepo *notaryclient.NotaryRepository, gun data.GUN) error {
+func publishAndPrintToCLI(cmd *cobra.Command, nRepo *notaryclient.NotaryRepository) error {
 	if err := nRepo.Publish(); err != nil {
 		return err
 	}


### PR DESCRIPTION
This work depends on the work done in https://github.com/docker/notary/pull/1094, allowing us to inject a `remote store` and a `cache` in a `NotaryRepository` object.
Since this PR is stacked on top of https://github.com/docker/notary/pull/1094 which just got merged, make sure you pull the latests changes. 

We are now initializing the repository when publishing, if needed. We do this for three reasons:

1. reduce the amount of operations necessary for notary users to setup their repo
2. avoid metadata corruption when calling init several times on the same repo - https://github.com/docker/notary/issues/1071
3. give more flexibility on how to initialize

 The lazy initialization is done either from scratch by `NotaryRepository.Initialize()` when starting from a blank state or by `NotaryRepository.bootstrapRepo()` if metadata is found on disk (example: when someone does a `notary key rotate` as a first operation).

Some updates have been added to the way change lists were handled, we can now inject one in a`NotaryRepository` object.
