### PR TITLE
fixes #1107

### DIFF
--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -883,7 +884,7 @@ func tokenAuth(trustServerURL string, baseTransport *http.Transport, gun data.GU
 	if endpoint.Scheme == "" {
 		return nil, fmt.Errorf("Trust server url has to be in the form of http(s)://URL:PORT. Got: %s", trustServerURL)
 	}
-	subPath, err := url.Parse("v2/")
+	subPath, err := url.Parse(path.Join(endpoint.Path, "/v2") + "/")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse v2 subpath. This error should not have been reached. Please report it as an issue at https://github.com/docker/notary/issues: %s", err.Error())
 	}


### PR DESCRIPTION
When doing auth, add the path of "tuf URL" before "/v2" for ping client 

For more details please refer to #1107 

Signed-off-by: Tan Jiang <jiangd@vmware.com>