### PR TITLE
Docs: notary signer user requires UPDATE priv.

### DIFF
--- a/docs/running_a_service.md
+++ b/docs/running_a_service.md
@@ -215,7 +215,7 @@ giving the following MySQL (or equivalent) permissions to the users restricted t
 only their own databases:
 
 - Notary server database user: `SELECT, INSERT, UPDATE, DELETE`
-- Notary signer database user: `SELECT, INSERT, DELETE`
+- Notary signer database user: `SELECT, INSERT, UPDATE, DELETE`
 
 ### High Availability
 


### PR DESCRIPTION
https://github.com/docker/notary/blob/master/docs/running_a_service.md says 
```
Notary signer database user: SELECT, INSERT, DELETE
```
and it is missing `UPDATE` priv. 

From signer log:
```
(Error 1142: UPDATE command denied to user 'signer'@'172.17.0.3' for table 'private_keys') 
```

Captured SQL queries:
```
2017-03-01T08:52:40.905616Z	   88 Prepare	UPDATE `private_keys` SET `last_used` = ?  WHERE (`private_keys`.deleted_at IS NULL OR `private_keys`.deleted_at <= '0001-01-02') AND ((key_id = ?))
2017-03-01T08:52:40.905677Z	   88 Execute	UPDATE `private_keys` SET `last_used` = '2017-03-01 08:52:40.90511'  WHERE (`private_keys`.deleted_at IS NULL OR `private_keys`.deleted_at <= '0001-01-02') AND ((key_id = 'f3b0734272c75bbee386d780a6a01ad2a0c78e3f6e4d98f0aaee32efa9f3b508'))
2017-03-01T08:52:40.922681Z	   88 Prepare	UPDATE `private_keys` SET `last_used` = ?  WHERE (`private_keys`.deleted_at IS NULL OR `private_keys`.deleted_at <= '0001-01-02') AND ((key_id = ?))
2017-03-01T08:52:40.922740Z	   88 Execute	UPDATE `private_keys` SET `last_used` = '2017-03-01 08:52:40.922248'  WHERE (`private_keys`.deleted_at IS NULL OR `private_keys`.deleted_at <= '0001-01-02') AND ((key_id = '6109700048e572b8c38d8198aad52f704cc0ff9d03d97039d76bbb007a2ae51c'))
```