### PR TITLE
`notary key generate` shouldn't be restricted to root keys

### DIFF
--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/docker/notary"
 	notaryclient "github.com/docker/notary/client"
@@ -14,10 +20,8 @@ import (
 	store "github.com/docker/notary/storage"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
+	tufutils "github.com/docker/notary/tuf/utils"
 	"github.com/docker/notary/utils"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var cmdKeyTemplate = usageTemplate{
@@ -38,10 +42,17 @@ var cmdRotateKeyTemplate = usageTemplate{
 	Long:  `Generates a new key for the given Globally Unique Name and role (one of "snapshot", "targets", "root", or "timestamp").  If rotating to a server-managed key, a new key is requested from the server rather than generated.  If the generation or key request is successful, the key rotation is immediately published.  No other changes, even if they are staged, will be published.`,
 }
 
-var cmdKeyGenerateRootKeyTemplate = usageTemplate{
+var cmdKeyGenerateKeyTemplate = usageTemplate{
 	Use:   "generate [ algorithm ]",
-	Short: "Generates a new root key with a given algorithm.",
-	Long:  "Generates a new root key with a given algorithm. If hardware key storage (e.g. a Yubikey) is available, the key will be stored both on hardware and on disk (so that it can be backed up).  Please make sure to back up and then remove this on-key disk immediately afterwards.",
+	Short: "Generates a new key with a given algorithm.",
+	Long: "Generates a new key with a given algorithm. If hardware key " +
+		"storage (e.g. a Yubikey) is available, the key will be stored both " +
+		"on hardware and on disk (so that it can be backed up).  Please make " +
+		"sure to back up and then remove this on-key disk immediately" +
+		"afterwards. If a `--output` file name is provided, two files will " +
+		"be written, <output>.pub and <output>.priv, containing the public" +
+		"and private keys respectively (the key will not be stored in Notary's " +
+		"key storage). If no `--role` is provided, \"root\" will be assumed.",
 }
 
 var cmdKeyRemoveTemplate = usageTemplate{
@@ -80,17 +91,29 @@ type keyCommander struct {
 	legacyVersions         int
 	input                  io.Reader
 
-	keysImportRole string
-	keysImportGUN  string
-	exportGUNs     []string
-	exportKeyIDs   []string
-	outFile        string
+	importRole    string
+	generateRole  string
+	keysImportGUN string
+	exportGUNs    []string
+	exportKeyIDs  []string
+	outFile       string
 }
 
 func (k *keyCommander) GetCommand() *cobra.Command {
 	cmd := cmdKeyTemplate.ToCommand(nil)
 	cmd.AddCommand(cmdKeyListTemplate.ToCommand(k.keysList))
-	cmd.AddCommand(cmdKeyGenerateRootKeyTemplate.ToCommand(k.keysGenerateRootKey))
+	cmdGenerate := cmdKeyGenerateKeyTemplate.ToCommand(k.keysGenerate)
+	cmdGenerate.Flags().StringVarP(
+		&k.outFile,
+		"output",
+		"o",
+		"",
+		"Filepath to write export output to",
+	)
+	cmdGenerate.Flags().StringVarP(
+		&k.generateRole, "role", "r", "root", "Role to generate key with, defaulting to \"root\".",
+	)
+	cmd.AddCommand(cmdGenerate)
 	cmd.AddCommand(cmdKeyRemoveTemplate.ToCommand(k.keyRemove))
 	cmd.AddCommand(cmdKeyPasswdTemplate.ToCommand(k.keyPassphraseChange))
 	cmdRotateKey := cmdRotateKeyTemplate.ToCommand(k.keysRotate)
@@ -110,7 +133,7 @@ func (k *keyCommander) GetCommand() *cobra.Command {
 
 	cmdKeysImport := cmdKeyImportTemplate.ToCommand(k.importKeys)
 	cmdKeysImport.Flags().StringVarP(
-		&k.keysImportRole, "role", "r", "", "Role to import key with, if a role is not already given in a PEM header")
+		&k.importRole, "role", "r", "", "Role to import key with, if a role is not already given in a PEM header")
 	cmdKeysImport.Flags().StringVarP(
 		&k.keysImportGUN, "gun", "g", "", "Gun to import key with, if a gun is not already given in a PEM header")
 	cmd.AddCommand(cmdKeysImport)
@@ -159,7 +182,7 @@ func (k *keyCommander) keysList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (k *keyCommander) keysGenerateRootKey(cmd *cobra.Command, args []string) error {
+func (k *keyCommander) keysGenerate(cmd *cobra.Command, args []string) error {
 	// We require one or no arguments (since we have a default value), but if the
 	// user passes in more than one argument, we error out.
 	if len(args) > 1 {
@@ -189,19 +212,77 @@ func (k *keyCommander) keysGenerateRootKey(cmd *cobra.Command, args []string) er
 	if err != nil {
 		return err
 	}
-	ks, err := k.getKeyStores(config, true, true)
+
+	// if no outFile is provided, use the known key stores
+	if k.outFile == "" {
+		ks, err := k.getKeyStores(config, true, true)
+		if err != nil {
+			return err
+		}
+		cs := cryptoservice.NewCryptoService(ks...)
+
+		pubKey, err := cs.Create(data.RoleName(k.generateRole), "", algorithm)
+		if err != nil {
+			return fmt.Errorf("Failed to create a new root key: %v", err)
+		}
+
+		cmd.Printf("Generated new %s %s key with keyID: %s\n", algorithm, k.generateRole, pubKey.ID())
+		return nil
+	}
+
+	// if we had an outfile set, we'll write 2 files with the given name, appending .pub and .priv for the
+	// public and private keys respectively
+	return generateKeyToFile(k.generateRole, algorithm, k.getRetriever(), k.outFile)
+}
+
+func generateKeyToFile(role, algorithm string, retriever notary.PassRetriever, outFile string) error {
+	privKey, err := tufutils.GenerateKey(algorithm)
 	if err != nil {
 		return err
 	}
-	cs := cryptoservice.NewCryptoService(ks...)
+	pubKey := data.PublicKeyFromPrivate(privKey)
 
-	pubKey, err := cs.Create(data.CanonicalRootRole, "", algorithm)
-	if err != nil {
-		return fmt.Errorf("Failed to create a new root key: %v", err)
+	var (
+		chosenPassphrase string
+		giveup           bool
+		pemPrivKey       []byte
+	)
+	keyID := privKey.ID()
+	for attempts := 0; ; attempts++ {
+		chosenPassphrase, giveup, err = retriever(keyID, "", true, attempts)
+		if err == nil {
+			break
+		}
+		if giveup || attempts > 10 {
+			return trustmanager.ErrAttemptsExceeded{}
+		}
 	}
 
-	cmd.Printf("Generated new %s root key with keyID: %s\n", algorithm, pubKey.ID())
-	return nil
+	if chosenPassphrase != "" {
+		pemPrivKey, err = tufutils.EncryptPrivateKey(privKey, data.RoleName(role), "", chosenPassphrase)
+		if err != nil {
+			return err
+		}
+	} else {
+		return errors.New("no password provided")
+	}
+
+	privFile := strings.Join([]string{outFile, "priv"}, ".")
+	pubFile := strings.Join([]string{outFile, "pub"}, ".")
+
+	err = ioutil.WriteFile(privFile, pemPrivKey, notary.PrivNoExecPerms)
+	if err != nil {
+		return err
+	}
+
+	pubPEM := pem.Block{
+		Type: "PUBLIC KEY",
+		Headers: map[string]string{
+			"role": role,
+		},
+		Bytes: pubKey.Public(),
+	}
+	return ioutil.WriteFile(pubFile, pem.EncodeToMemory(&pubPEM), notary.PrivNoExecPerms)
 }
 
 func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
@@ -442,7 +523,7 @@ func (k *keyCommander) importKeys(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		defer from.Close()
-		if err = utils.ImportKeys(from, importers, k.keysImportRole, k.keysImportGUN, k.getRetriever()); err != nil {
+		if err = utils.ImportKeys(from, importers, k.importRole, k.keysImportGUN, k.getRetriever()); err != nil {
 			return err
 		}
 	}

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/docker/notary/trustpinning"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/utils"
-	"path/filepath"
 )
 
 var ret = passphrase.ConstantRetriever("pass")
@@ -821,17 +821,20 @@ func TestKeyGeneration(t *testing.T) {
 	assertNumKeys(t, tempDir, 0, 1, false) // key shouldn't be written to store and won't show up in keylist
 
 	// test that we can read the keys we created
-	pub, err := ioutil.ReadFile(filepath.Join(tempDir, "testkeys.pub"))
+	pub, err := ioutil.ReadFile(filepath.Join(tempDir, "testkeys.pem"))
 	require.NoError(t, err)
 	pubK, err := utils.ParsePEMPublicKey(pub)
 	require.NoError(t, err)
 
-	priv, err := ioutil.ReadFile(filepath.Join(tempDir, "testkeys.priv"))
+	priv, err := ioutil.ReadFile(filepath.Join(tempDir, "testkeys-key.pem"))
 	require.NoError(t, err)
 	privK, err := utils.ParsePEMPrivateKey(priv, testPassphrase)
 	require.NoError(t, err)
 
 	// the ID is only generated from the public part of the key so they should be identical
 	require.Equal(t, pubK.ID(), privK.ID())
+
+	_, err = runCommand(t, tempDir, "key", "import", filepath.Join(tempDir, "testkeys-key.pem"))
+	require.NoError(t, err)
 
 }

--- a/cryptoservice/crypto_service.go
+++ b/cryptoservice/crypto_service.go
@@ -1,14 +1,12 @@
 package cryptoservice
 
 import (
-	"crypto/rand"
 	"fmt"
 
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/notary"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/utils"
@@ -37,42 +35,14 @@ func NewCryptoService(keyStores ...trustmanager.KeyStore) *CryptoService {
 
 // Create is used to generate keys for targets, snapshots and timestamps
 func (cs *CryptoService) Create(role data.RoleName, gun data.GUN, algorithm string) (data.PublicKey, error) {
-	var privKey data.PrivateKey
-	var err error
-
-	switch algorithm {
-	case data.RSAKey:
-		privKey, err = utils.GenerateRSAKey(rand.Reader, notary.MinRSABitSize)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate RSA key: %v", err)
-		}
-	case data.ECDSAKey:
-		privKey, err = utils.GenerateECDSAKey(rand.Reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate EC key: %v", err)
-		}
-	case data.ED25519Key:
-		privKey, err = utils.GenerateED25519Key(rand.Reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate ED25519 key: %v", err)
-		}
-	default:
-		return nil, fmt.Errorf("private key type not supported for key generation: %s", algorithm)
+	privKey, err := utils.GenerateKey(algorithm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate %s key: %v", algorithm, err)
 	}
 	logrus.Debugf("generated new %s key for role: %s and keyID: %s", algorithm, role.String(), privKey.ID())
+	pubKey := data.PublicKeyFromPrivate(privKey)
 
-	// Store the private key into our keystore
-	for _, ks := range cs.keyStores {
-		err = ks.AddKey(trustmanager.KeyInfo{Role: role, Gun: gun}, privKey)
-		if err == nil {
-			return data.PublicKeyFromPrivate(privKey), nil
-		}
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to add key to filestore: %v", err)
-	}
-
-	return nil, fmt.Errorf("keystores would not accept new private keys for unknown reasons")
+	return pubKey, cs.AddKey(role, gun, privKey)
 }
 
 // GetPrivateKey returns a private key and role if present by ID.

--- a/tuf/utils/x509.go
+++ b/tuf/utils/x509.go
@@ -313,6 +313,20 @@ func ValidateCertificate(c *x509.Certificate, checkExpiry bool) error {
 	return nil
 }
 
+// GenerateKey returns a new private key using the provided algorithm or an
+// error detailing why the key could not be generated
+func GenerateKey(algorithm string) (data.PrivateKey, error) {
+	switch algorithm {
+	case data.RSAKey:
+		return GenerateRSAKey(rand.Reader, notary.MinRSABitSize)
+	case data.ECDSAKey:
+		return GenerateECDSAKey(rand.Reader)
+	case data.ED25519Key:
+		return GenerateED25519Key(rand.Reader)
+	}
+	return nil, fmt.Errorf("private key type not supported for key generation: %s", algorithm)
+}
+
 // GenerateRSAKey generates an RSA private key and returns a TUF PrivateKey
 func GenerateRSAKey(random io.Reader, bits int) (data.PrivateKey, error) {
 	rsaPrivKey, err := rsa.GenerateKey(random, bits)


### PR DESCRIPTION
It also gains the `-o`/`--output` flag, which if provided will cause the public and private key to be output to the filepath specified in the flag with the .pub and .priv file extensions respectively.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)