### PR TITLE
Support for initializing repository with root certificate 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -169,14 +169,14 @@ func rootCertKey(gun data.GUN, privKey data.PrivateKey) (data.PublicKey, error) 
 
 	x509PublicKey := utils.CertToKey(cert)
 	if x509PublicKey == nil {
-		return nil, fmt.Errorf("cannot generate public key from private key with id: %v. %v is not a supported type", privKey.ID(), privKey.Algorithm())
+		return nil, fmt.Errorf("cannot generate public key from private key with id: %v and algorithm: %v", privKey.ID(), privKey.Algorithm())
 	}
 
 	return x509PublicKey, nil
 }
 
-// repoInitialize initializes the notary repository with a set of rootkeys, root certificates and roles.
-func (r *NotaryRepository) repoInitialize(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error {
+// initialize initializes the notary repository with a set of rootkeys, root certificates and roles.
+func (r *NotaryRepository) initialize(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error {
 
 	// currently we only support server managing timestamps and snapshots, and
 	// nothing else - timestamps are always managed by the server, and implicit
@@ -205,8 +205,14 @@ func (r *NotaryRepository) repoInitialize(rootKeyIDs []string, rootCerts []data.
 		}
 	}
 
-	// gets valid public keys corresponding to the rootKeyIDs from r.crypto
-	publicKeys, err := r.certsOfKeyIDs(rootKeyIDs, rootCerts)
+	// gets valid public keys corresponding to the rootKeyIDs or generate if necessary
+	var publicKeys []data.PublicKey
+	var err error
+	if len(rootCerts) == 0 {
+		publicKeys, err = r.createNewPublicKeyFromKeyIDs(rootKeyIDs)
+	} else {
+		publicKeys, err = r.publicKeysOfKeyIDs(rootKeyIDs, rootCerts)
+	}
 	if err != nil {
 		return err
 	}
@@ -245,63 +251,58 @@ func (r *NotaryRepository) repoInitialize(rootKeyIDs []string, rootCerts []data.
 	return r.saveMetadata(serverManagesSnapshot)
 }
 
-// certsOfKeyIDs either confirms that the certs and keys (represented by Key IDs) forms valid, strictly ordered key pairs
-// (eg. keyIDs[0] must match certs[0] and keyIDs[1] must match certs[1] and so on).
-// Or throw error when they mismatch.
-// Or generate certificates from the keys if no certificate is provided
-func (r *NotaryRepository) certsOfKeyIDs(keyIDs []string, certs []data.PublicKey) ([]data.PublicKey, error) {
+// createNewPublicKeyFromKeyIDs generates a set of public keys corresponding to the given list of
+// key IDs existing in the repository's CryptoService.
+// the public keys returned are ordered to correspond to the keyIDs
+func (r *NotaryRepository) createNewPublicKeyFromKeyIDs(keyIDs []string) ([]data.PublicKey, error) {
+	publicKeys := []data.PublicKey{}
 
-	publicKeys := make([]data.PublicKey, 0, len(keyIDs))
-	// generate certificates if none are provided
-	if certs == nil || len(certs) == 0 {
-		privKeys, err := getAllPrivKeys(keyIDs, r.CryptoService)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, privKey := range privKeys {
-			rootKey, err := rootCertKey(r.gun, privKey)
-			if err != nil {
-				return nil, err
-			}
-			publicKeys = append(publicKeys, rootKey)
-		}
-
-	} else if len(keyIDs) != len(certs) { //return error if length does not match
-		errMsg := fmt.Sprintf("require matching number of keys and certificates but got %d rootkeys and %d certificates", len(keyIDs), len(certs))
-		logrus.Debug(errMsg)
-		return nil, fmt.Errorf(errMsg)
-
-	} else { // match each cert with corresponding Key ID
-		match, err := matchKeyIdsWithCerts(r, keyIDs, certs)
-		if err != nil {
-			return nil, err
-		} else if match {
-			publicKeys = certs
-		}
+	privKeys, err := getAllPrivKeys(keyIDs, r.CryptoService)
+	if err != nil {
+		return nil, err
 	}
 
+	for _, privKey := range privKeys {
+		rootKey, err := rootCertKey(r.gun, privKey)
+		if err != nil {
+			return nil, err
+		}
+		publicKeys = append(publicKeys, rootKey)
+	}
 	return publicKeys, nil
 }
 
-// matchKeyIdsWithCerts validates that the private keys (represented by their IDs) and the x509 PublicKeys
+// publicKeysOfKeyIDs confirms that the public key and private keys (by Key IDs) forms valid, strictly ordered key pairs
+// (eg. keyIDs[0] must match pubKeys[0] and keyIDs[1] must match certs[1] and so on).
+// Or throw error when they mismatch.
+func (r *NotaryRepository) publicKeysOfKeyIDs(keyIDs []string, pubKeys []data.PublicKey) ([]data.PublicKey, error) {
+	if len(keyIDs) != len(pubKeys) {
+		err := fmt.Errorf("require matching number of keyIDs and public keys but got %d IDs and %d public keys", len(keyIDs), len(pubKeys))
+		return nil, err
+	}
+
+	if err := matchKeyIdsWithPubKeys(r, keyIDs, pubKeys); err != nil {
+		return nil, fmt.Errorf("could not obtain public key from IDs: %v", err)
+	}
+	return pubKeys, nil
+}
+
+// matchKeyIdsWithPubKeys validates that the private keys (represented by their IDs) and the public keys
 // forms matching key pairs
-func matchKeyIdsWithCerts(r *NotaryRepository, ids []string, certs []data.PublicKey) (bool, error) {
+func matchKeyIdsWithPubKeys(r *NotaryRepository, ids []string, pubKeys []data.PublicKey) error {
 	for i := 0; i < len(ids); i++ {
 		privKey, _, err := r.CryptoService.GetPrivateKey(ids[i])
 		if err != nil {
-			return false, err
+			return fmt.Errorf("could not get the private key matching id %v: %v", ids[i], err)
 		}
 
-		pubKey := certs[i]
-
+		pubKey := pubKeys[i]
 		err = signed.VerifyPublicKeyMatchesPrivateKey(privKey, pubKey)
 		if err != nil {
-			return false, err
+			return err
 		}
 	}
-
-	return true, nil
+	return nil
 }
 
 // Initialize creates a new repository by using rootKey as the root Key for the
@@ -310,7 +311,7 @@ func matchKeyIdsWithCerts(r *NotaryRepository, ids []string, certs []data.Public
 // result is only stored on local disk, not published to the server. To do that,
 // use r.Publish() eventually.
 func (r *NotaryRepository) Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error {
-	return r.repoInitialize(rootKeyIDs, nil, serverManagedRoles...)
+	return r.initialize(rootKeyIDs, nil, serverManagedRoles...)
 }
 
 type errKeyNotFound struct{}
@@ -319,31 +320,30 @@ func (errKeyNotFound) Error() string {
 	return fmt.Sprintf("cannot find matching private key id")
 }
 
-// keyExistsInList returns the id of the private key in idList that matches the public key
+// keyExistsInList returns the id of the private key in ids that matches the public key
 // otherwise return empty string
-func keyExistsInList(cert data.PublicKey, idList []string) error {
+func keyExistsInList(cert data.PublicKey, ids map[string]bool) error {
 	pubKeyID, err := utils.CanonicalKeyID(cert)
 	if err != nil {
 		return fmt.Errorf("failed to obtain the public key id from the given certificate: %v", err)
 	}
-
-	for _, id := range idList {
-		if id == pubKeyID {
-			return nil
-		}
+	if _, ok := ids[pubKeyID]; ok {
+		return nil
 	}
 	return errKeyNotFound{}
 }
 
-// InitializeWithCertificate initializes the repository with root key and their corresponding certificates
+// InitializeWithCertificate initializes the repository with root keys and their corresponding certificates
 func (r *NotaryRepository) InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey,
 	nRepo *NotaryRepository, serverManagedRoles ...data.RoleName) error {
 
 	// If we explicitly pass in certificate(s) but not key, then look keys up using certificate
-	if rootKeyIDs == nil || len(rootKeyIDs) == 0 && rootCerts != nil && len(rootCerts) != 0 {
-
+	if len(rootKeyIDs) == 0 && len(rootCerts) != 0 {
 		rootKeyIDs = []string{}
-		availableRootKeyIDs := nRepo.CryptoService.ListKeys(data.CanonicalRootRole)
+		availableRootKeyIDs := make(map[string]bool)
+		for _, k := range nRepo.CryptoService.ListKeys(data.CanonicalRootRole) {
+			availableRootKeyIDs[k] = true
+		}
 
 		for _, cert := range rootCerts {
 			if err := keyExistsInList(cert, availableRootKeyIDs); err != nil {
@@ -353,7 +353,7 @@ func (r *NotaryRepository) InitializeWithCertificate(rootKeyIDs []string, rootCe
 			rootKeyIDs = append(rootKeyIDs, keyID)
 		}
 	}
-	return r.repoInitialize(rootKeyIDs, rootCerts, serverManagedRoles...)
+	return r.initialize(rootKeyIDs, rootCerts, serverManagedRoles...)
 }
 
 func (r *NotaryRepository) initializeRoles(rootKeys []data.PublicKey, localRoles, remoteRoles []data.RoleName) (
@@ -456,7 +456,6 @@ func addChange(cl changelist.Changelist, c changelist.Change, roles ...data.Role
 // in the repository when the changelist gets applied at publish time.
 // If roles are unspecified, the default role is "targets"
 func (r *NotaryRepository) AddTarget(target *Target, roles ...data.RoleName) error {
-
 	if len(target.Hashes) == 0 {
 		return fmt.Errorf("no hashes specified for target \"%s\"", target.Name)
 	}

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -288,7 +288,7 @@ i85wnaTwOgWv8n6q3tavmnIA/v2QqsTpmI+bhwrPNKQ=
 		"init", gun+"3",
 		"--rootkey", privKeyFilename,
 		"--rootcert")
-	require.Error(t, err)
+	require.Error(t, err, "--rootcert requires one or more argument")
 
 	// === test non matching key pairs ===
 	_, err = runCommand(t, tempDir,
@@ -296,7 +296,7 @@ i85wnaTwOgWv8n6q3tavmnIA/v2QqsTpmI+bhwrPNKQ=
 		"init", gun+"4",
 		"--rootkey", nonMatchingKeyFilename,
 		"--rootcert", certFilename)
-	require.Error(t, err)
+	require.Error(t, err, "should not be able to init a repository with mismatched key and cert")
 
 	// === test non existing path ===
 	_, err = runCommand(t, tempDir,
@@ -304,7 +304,7 @@ i85wnaTwOgWv8n6q3tavmnIA/v2QqsTpmI+bhwrPNKQ=
 		"init", gun+"5",
 		"--rootkey", nonMatchingKeyFilename,
 		"--rootcert", "fake/path/to/cert")
-	require.Error(t, err)
+	require.Error(t, err, "should not be able to init a repository with non-existent certificate path")
 
 }
 

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -207,6 +207,9 @@ func TestInitWithRootCert(t *testing.T) {
 	err = ioutil.WriteFile(encryptedPEMKeyFilename, encrpytedPEMPrivKey, 0644)
 	require.NoError(t, err)
 
+	// crypService := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(passphrase.ConstantRetriever(testPassphrase)))
+	// pubKey, err := crypService.Create(data.CanonicalRootRole, motoGUN, data.ECDSAKey)
+
 	//filepathes of certificates used in this test
 	// TODO: move the file to notary/fixture or appropriate places
 	nonMatchingCertFilename := filepath.Join("~/test", "non_matching_cert.pem")
@@ -220,6 +223,10 @@ func TestInitWithRootCert(t *testing.T) {
 	res, err = runCommand(t, tempDir, "-s", server.URL, "init", "motorolasolutions.com/hello", "--rootcert", matchingCertFilename)
 	require.Error(t, err)
 
+	//init repo with matching rootcert
+	res, err = runCommand(t, tempDir, "-s", server.URL, "init", "motorolasolutions.com/hello", "--rootkey", encryptedPEMKeyFilename, "--rootcert", matchingCertFilename)
+	require.NoError(t, err)
+
 	//test init repo with nonexisting path to rootcert
 	res, err = runCommand(t, tempDir, "-s", server.URL, "init", "motorolasolutions.com/hello", "--rootkey", encryptedPEMKeyFilename, "--rootcert", nonExistingCertFilename)
 	require.Error(t, err)
@@ -228,11 +235,26 @@ func TestInitWithRootCert(t *testing.T) {
 	res, err = runCommand(t, tempDir, "-s", server.URL, "init", "motorolasolutions.com/hello", "--rootkey", encryptedPEMKeyFilename, "--rootcert", nonMatchingCertFilename)
 	require.Error(t, err)
 
-	//init repo with matching rootcert
-	res, err = runCommand(t, tempDir, "-s", server.URL, "init", "motorolasolutions.com/hello", "--rootkey", encryptedPEMKeyFilename, "--rootcert", matchingCertFilename)
-	require.NoError(t, err)
-
 	err = ioutil.WriteFile(filepath.Join(tempDir, "log.txt"), []byte(res), 0644)
+	require.NoError(t, err)
+}
+
+func TestInitOneTest(t *testing.T) {
+	setUp(t)
+
+	// tempDir := tempDirWithConfig(t, "{}")
+	// defer os.RemoveAll(tempDir)
+
+	server := setupServer()
+	defer server.Close()
+
+	//test init repo without --rootkey but with --rootcert
+	_, err := runCommand(t, "/Users/xjqw46/test/wildcard/private", "init",
+		"motorolasolutions.com/hello2",
+		"--rootkey",
+		"/Users/xjqw46/test/wildcard/private/13012c56c9916e348df2731837a1f8dba7839903699f645702ecbedce1960cd7.key",
+		"--rootcert",
+		"/Users/xjqw46/test/wildcard/private/pub.pem")
 	require.NoError(t, err)
 }
 

--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -225,7 +225,7 @@ i85wnaTwOgWv8n6q3tavmnIA/v2QqsTpmI+bhwrPNKQ=
 	//set up temp dir
 	tempDir := tempDirWithConfig(t, `{
 		"trust_pinning" : {
-			"disable_tufu" : false
+			"disable_tofu" : false
 		}
 	}`)
 	defer os.RemoveAll(tempDir)

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -465,7 +465,7 @@ func importRootCert(certFilePath string) ([]data.PublicKey, error) {
 		return publicKeys, nil
 	}
 
-	// read from file
+	// read certificate from file
 	certFile, err := os.Open(certFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("Opening file to import as root cert: %v", err)
@@ -525,7 +525,7 @@ func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// if err = nRepo.Initialize(rootKeyIDs, rootCerts); err != nil {
-	if err = nRepo.Initialize(rootKeyIDs, rootCerts); err != nil {
+	if err = nRepo.InitializeWithCertificate(rootKeyIDs, rootCerts); err != nil {
 		return err
 	}
 

--- a/cmd/notary/tuf_test.go
+++ b/cmd/notary/tuf_test.go
@@ -60,7 +60,7 @@ adLwkjqoeEKMaAXf
 	fakeFile := filepath.Join(dir, "fake.crt")
 	_, err = importRootCert(fakeFile)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "error when opening")
+	require.Contains(t, err.Error(), "error reading")
 
 	//5. test import non-certificate file
 	nonCert := filepath.Join(dir, "noncert.crt")

--- a/cmd/notary/tuf_test.go
+++ b/cmd/notary/tuf_test.go
@@ -9,12 +9,35 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/notary/tuf/data"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/notary/tuf/data"
 )
+
+func TestImportRootCert(t *testing.T) {
+	certFile := "/Users/xjqw46/test/wildcard/tuf/motorolasolutions.com/wildcard/metadata/public.pem"
+
+	pKeys, err := importRootCert(certFile)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(pKeys), "length of the public key slice should be 1")
+
+	pkey := pKeys[0]
+	expectedCert := `-----BEGIN CERTIFICATE-----
+MIIBeTCCAR6gAwIBAgIRANBbisNFPzTP0AGYpt/9A+gwCgYIKoZIzj0EAwIwIjEg
+MB4GA1UEAxMXbW90b3JvbGFzb2x1dGlvbnMuY29tLyowHhcNMTcwNDIxMjAwODMz
+WhcNMjcwNDE5MjAwODMzWjAiMSAwHgYDVQQDExdtb3Rvcm9sYXNvbHV0aW9ucy5j
+b20vKjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABABNAJcPmmq1u7momB86nDsm
+zjSaqNp/81qRbhy66OwGCdW4xB4rjEPkGwLuGf/Z2Iv2bpW88mYEHS63XvKsPgOj
+NTAzMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMB
+Af8EAjAAMAoGCCqGSM49BAMCA0kAMEYCIQCfBCLOwZbMteiN+fbaufRQ+dZsuzM8
+BhGUrl2GLIHPqgIhAIQMb+IjIhY/eJ0cRccWlQz11eIL1rtyrkcKr0e6rKO3
+-----END CERTIFICATE-----`
+
+	require.Equal(t, "184225703b57d45e2bffc12a7633f787b62cb32b7fb3f1febf1f838418260164", pkey.ID())
+	require.Equal(t, "ecdsa-x509", pkey.Algorithm())
+	require.Equal(t, expectedCert, pkey.Public())
+}
 
 func TestTokenAuth(t *testing.T) {
 	var (

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -112,12 +112,8 @@ func VerifySignature(msg []byte, sig *data.Signature, pk data.PublicKey) error {
 // VerifyPublicKeyMatchesPrivateKey checks if the private key and the public keys forms valid key pairs.
 // This should work with both ecdsa-x509 certificate PublicKey as well as ecdsa PublicKey
 func VerifyPublicKeyMatchesPrivateKey(privKey data.PrivateKey, pubKey data.PublicKey) error {
-	if pubKey.Algorithm() != privKey.Algorithm() {
-		return fmt.Errorf("public key and private key has different algorithms")
-	}
-
-	privKeyID := privKey.ID()
 	pubKeyID, err := utils.CanonicalKeyID(pubKey)
+	privKeyID := privKey.ID()
 
 	if err != nil {
 		return fmt.Errorf("could not verify key pair: %v", err)

--- a/tuf/signed/verify.go
+++ b/tuf/signed/verify.go
@@ -110,16 +110,14 @@ func VerifySignature(msg []byte, sig *data.Signature, pk data.PublicKey) error {
 }
 
 // VerifyPublicKeyMatchesPrivateKey checks if the private key and the public keys forms valid key pairs.
-// This should work with both ecdsa-x509 certificate PublicKey as well as ecdsa PublicKey
+// Supports both x509 certificate PublicKeys and non-certificate PublicKeys
 func VerifyPublicKeyMatchesPrivateKey(privKey data.PrivateKey, pubKey data.PublicKey) error {
 	pubKeyID, err := utils.CanonicalKeyID(pubKey)
-	privKeyID := privKey.ID()
-
 	if err != nil {
 		return fmt.Errorf("could not verify key pair: %v", err)
 	}
-	if pubKeyID != privKeyID {
-		return fmt.Errorf("private key did not match public key")
+	if privKey == nil || pubKeyID != privKey.ID() {
+		return fmt.Errorf("private key is nil or does not match public key")
 	}
 	return nil
 }

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -227,9 +227,16 @@ func TestVerifyPublicKeyMatchesPrivateKeyHappyCase(t *testing.T) {
 
 func TestVerifyPublicKeyMatchesPrivateKeyFails(t *testing.T) {
 	goodPrivKey, err := utils.GenerateECDSAKey(rand.Reader)
+	require.NoError(t, err)
 	badPrivKey, err := utils.GenerateECDSAKey(rand.Reader)
 	require.NoError(t, err)
 	badPubKey := data.PublicKeyFromPrivate(badPrivKey)
 	err = VerifyPublicKeyMatchesPrivateKey(goodPrivKey, badPubKey)
+	require.Error(t, err)
+
+	//witness fail signing
+	badPrivKey2, err := utils.GenerateED25519Key(rand.Reader)
+	require.NoError(t, err)
+	err = VerifyPublicKeyMatchesPrivateKey(badPrivKey2, data.PublicKeyFromPrivate(badPrivKey))
 	require.Error(t, err)
 }

--- a/tuf/signed/verify_test.go
+++ b/tuf/signed/verify_test.go
@@ -239,4 +239,11 @@ func TestVerifyPublicKeyMatchesPrivateKeyFails(t *testing.T) {
 	require.NoError(t, err)
 	err = VerifyPublicKeyMatchesPrivateKey(badPrivKey2, data.PublicKeyFromPrivate(badPrivKey))
 	require.Error(t, err)
+
+	err = VerifyPublicKeyMatchesPrivateKey(nil, data.PublicKeyFromPrivate(goodPrivKey))
+	require.Error(t, err, "should throw error if pubKey is nil")
+
+	err = VerifyPublicKeyMatchesPrivateKey(goodPrivKey, nil)
+	require.Error(t, err, "should throw error if privKey is nil")
+
 }

--- a/tuf/utils/x509.go
+++ b/tuf/utils/x509.go
@@ -26,6 +26,9 @@ import (
 // On regular RSA/ECDSA TUF keys, this is just the key ID.  On X509 RSA/ECDSA
 // TUF keys, this is the key ID of the public key part of the key in the leaf cert
 func CanonicalKeyID(k data.PublicKey) (string, error) {
+	if k == nil {
+		return "", errors.New("public key is nil")
+	}
 	switch k.Algorithm() {
 	case data.ECDSAx509Key, data.RSAx509Key:
 		return X509PublicKeyID(k)


### PR DESCRIPTION
Supports initializing a notary repository by passing in a root certificate alone with the corresponding root key. This would make wildcard certificate trust pinning usable as an existing trusted certificate can now be included in `root.json` metadata.

usage : `notary init [ GUN ] --rootkey path/to/key.key --rootcert path/to/cert.crt` 

`--rootcert` can only be used when `--rootkey` is specified. 

related works include #821 and #883.

