### PR TITLE
Allow scripting the terminal in TUF commands

### DIFF
--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/ssh/terminal"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -814,7 +812,7 @@ type passwordStore struct {
 
 func (ps passwordStore) Basic(u *url.URL) (string, string) {
 	// if it's not a terminal, don't wait on input
-	if ps.anonymous || !terminal.IsTerminal(int(os.Stdin.Fd())) {
+	if ps.anonymous {
 		return "", ""
 	}
 


### PR DESCRIPTION
This change came in here: https://github.com/docker/notary/commit/25cd29c8b0df3e8ae3cc0d8427c213f760b5e76f

But I can't really tell why. It breaks scripting tuf commands (if you're not running in a terminal, all requests are anonymous to the server).

I think #861 is the proper solution, but for now it's nice to be able to script it via stdin.