### PR TITLE
update setuptools required by codecov

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash notary \
+	&& pip install setuptools --upgrade \
 	&& pip install codecov \
 	&& go get github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign github.com/HewlettPackard/gas
 


### PR DESCRIPTION
`docker build -t notary_client` complains that  "platform_system" is required, when installing codecov. It looks like codecov's dependency `setuptools` needs upgrading.  

```
Step 4/9 : RUN pip install codecov
 ---> Running in 4c5abc930d19
Downloading/unpacking codecov
  Downloading codecov-2.0.9-py2.py3-none-any.whl
Downloading/unpacking requests>=2.7.9 (from codecov)
Cleaning up...
Exception:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/usr/lib/python2.7/dist-packages/pip/commands/install.py", line 290, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/usr/lib/python2.7/dist-packages/pip/req.py", line 1266, in prepare_files
    req_to_install.extras):
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2401, in requires
    dm = self._dep_map
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2597, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2630, in _compute_dependencies
    common = frozenset(reqs_for_extra(None))
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2627, in reqs_for_extra
    if req.marker_fn(override={'extra':extra}):
  File "/usr/lib/python2.7/dist-packages/_markerlib/markers.py", line 113, in marker_fn
    return eval(compiled_marker, environment)
  File "<environment marker>", line 1, in <module>
NameError: name 'platform_system' is not defined
```