### PR TITLE
Change RSA key size to at least 1024 bits

### DIFF
--- a/tuf/signed/sign_test.go
+++ b/tuf/signed/sign_test.go
@@ -208,7 +208,7 @@ func TestSignReturnsNoSigs(t *testing.T) {
 }
 
 func TestSignWithX509(t *testing.T) {
-	// generate a key becase we need a cert
+	// generate a key because we need a cert
 	privKey, err := utils.GenerateRSAKey(rand.Reader, 1024)
 	require.NoError(t, err)
 

--- a/tuf/signed/verifiers_test.go
+++ b/tuf/signed/verifiers_test.go
@@ -97,7 +97,7 @@ func TestRSAPSSVerifierWithInvalidKeyType(t *testing.T) {
 }
 
 func TestRSAPSSVerifierWithInvalidKeyLength(t *testing.T) {
-	key, err := rsa.GenerateKey(rand.Reader, 512)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 
 	err = verifyPSS(key.Public(), nil, nil)

--- a/tuf/utils/x509_test.go
+++ b/tuf/utils/x509_test.go
@@ -83,7 +83,7 @@ func TestKeyOperations(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate our RSA private key
-	rsaKey, err := GenerateRSAKey(rand.Reader, 512)
+	rsaKey, err := GenerateRSAKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	// Encode our ED private key


### PR DESCRIPTION
OpenSSL-FIPS does not allow RSA keys to be generated if the key size is less than 1024. So the RSA key sizes in tests have been updated to prevent them from failing if Notary is made FIPS compliant.

Signed-off-by: Ali Yousuf <aly.yousuf7@gmail.com>