### PR TITLE
Protecting passphrase used to wrap private keys

### DIFF
--- a/cmd/notary-signer/main_test.go
+++ b/cmd/notary-signer/main_test.go
@@ -254,16 +254,10 @@ func TestBootstrap(t *testing.T) {
 	require.True(t, tb.Booted)
 }
 
-func TestGetEnv(t *testing.T) {
-	os.Setenv("NOTARY_SIGNER_TIMESTAMP", "password")
-	defer os.Unsetenv("NOTARY_SIGNER_TIMESTAMP")
-
-	require.Equal(t, "password", getEnv("timestamp"))
-}
-
 func TestPassphraseRetrieverInvalid(t *testing.T) {
 	_, _, err := passphraseRetriever("fakeKey", "fakeAlias", false, 1)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "error retrieving passphrase from passphrase store")
 }
 
 // For sanity, make sure we can always parse the sample config

--- a/cmd/notary-signer/passphrase/default_protect.go
+++ b/cmd/notary-signer/passphrase/default_protect.go
@@ -1,0 +1,21 @@
+package passphrase
+
+// NewDefaultPassphraseProtector instantiates a default passphrase protector.
+func NewDefaultPassphraseProtector() Protector {
+	return DefaultPassphraseProtector{}
+}
+
+// DefaultPassphraseProtector implements a place holder passphrase protector. This is because, by default the
+// passphrase is maintained in clear.
+type DefaultPassphraseProtector struct {
+}
+
+// Encrypt is a dummy function in the default implementation as the passphrase is maintained in clear.
+func (dp DefaultPassphraseProtector) Encrypt(clearText string) (string, error) {
+	return clearText, nil
+}
+
+// Decrypt is a dummy function in the default implementation as the passphrase is maintained in clear.
+func (dp DefaultPassphraseProtector) Decrypt(cipherText string) (string, error) {
+	return cipherText, nil
+}

--- a/cmd/notary-signer/passphrase/default_storage.go
+++ b/cmd/notary-signer/passphrase/default_storage.go
@@ -1,0 +1,35 @@
+package passphrase
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	envPrefix = "NOTARY_SIGNER_"
+)
+
+// NewDefaultPassphraseStore instantiates a default passphrase store
+func NewDefaultPassphraseStore() Storage {
+	return DefaultPassphraseStore{}
+}
+
+// DefaultPassphraseStore implements a basic passphrase store which just stores and
+// retrieves passphrase from an environment variable.
+type DefaultPassphraseStore struct {
+}
+
+// SetPassphrase stores the clear passphrase in the ENV variable as is in clear text.
+func (pw DefaultPassphraseStore) SetPassphrase(alias string, newPassphrase string) error {
+	envVariable := strings.ToUpper(envPrefix + alias)
+	error := os.Setenv(envVariable, newPassphrase)
+
+	return error
+}
+
+// GetPassphrase retrieves the clear passphrase from the ENV variable.
+func (pw DefaultPassphraseStore) GetPassphrase(alias string) (string, error) {
+	envVariable := strings.ToUpper(envPrefix + alias)
+	pass := os.Getenv(envVariable)
+	return pass, nil
+}

--- a/cmd/notary-signer/passphrase/interface.go
+++ b/cmd/notary-signer/passphrase/interface.go
@@ -1,0 +1,19 @@
+package passphrase
+
+// Storage is the interface to store/retrieve passphrase from any specific implementation type.
+type Storage interface {
+	// Get passphrase from storage.
+	GetPassphrase(alias string) (string, error)
+
+	// Set passphrase in storage.
+	SetPassphrase(alias string, newPassphrase string) error
+}
+
+// Protector is the interface to wrap/unwrap passphrase using any specific implementation type.
+type Protector interface {
+	// Wrap the passphrase passed in as clear text.
+	Encrypt(clearText string) (string, error)
+
+	// Unwrap the passphrase passed in as cipher text.
+	Decrypt(cipherText string) (string, error)
+}

--- a/cmd/notary-signer/passphrase/passphrase_test.go
+++ b/cmd/notary-signer/passphrase/passphrase_test.go
@@ -1,0 +1,38 @@
+package passphrase
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestDefaultStorageGetPassword(t *testing.T) {
+	os.Setenv("NOTARY_SIGNER_TIMESTAMP", "password")
+	defer os.Unsetenv("NOTARY_SIGNER_TIMESTAMP")
+
+	passphraseStore := NewDefaultPassphraseStore()
+	passphrase, _ := passphraseStore.GetPassphrase("timestamp")
+	require.Equal(t, "password", passphrase)
+}
+
+func TestDefaultStorageSetPassword(t *testing.T) {
+	passphraseStore := NewDefaultPassphraseStore()
+	passphraseStore.SetPassphrase("timestamp", "password")
+	defer os.Unsetenv("NOTARY_SIGNER_TIMESTAMP")
+
+	require.Equal(t, "password", os.Getenv("NOTARY_SIGNER_TIMESTAMP"))
+}
+
+func TestDefaultProtectorEncrypt(t *testing.T) {
+	passphraseProtector := NewDefaultPassphraseProtector()
+	cipherText, _ := passphraseProtector.Encrypt("password")
+
+	require.Equal(t, "password", cipherText)
+}
+
+func TestDefaultProtectorDecrypt(t *testing.T) {
+	passphraseProtector := NewDefaultPassphraseProtector()
+	clearText, _ := passphraseProtector.Decrypt("password")
+
+	require.Equal(t, "password", clearText)
+}


### PR DESCRIPTION
Pull request that addresses the issue: #1091

 - Currently only the default storage and protection mechanisms are implemented.
 - Have not included configuration changes as they can be brought in when mechanism to protect at run time is implemented.
 - Once there is more clarity on using plugins details of configuration can be implemented.
