### PR TITLE
Bump up default log level, key import/export logs

### DIFF
--- a/cmd/notary/integration_test.go
+++ b/cmd/notary/integration_test.go
@@ -1725,12 +1725,12 @@ func TestLogLevelFlags(t *testing.T) {
 	// Test default to fatal
 	n := notaryCommander{}
 	n.setVerbosityLevel()
-	require.Equal(t, "fatal", logrus.GetLevel().String())
+	require.Equal(t, "warning", logrus.GetLevel().String())
 
 	// Test that verbose (-v) sets to error
 	n.verbose = true
 	n.setVerbosityLevel()
-	require.Equal(t, "error", logrus.GetLevel().String())
+	require.Equal(t, "info", logrus.GetLevel().String())
 
 	// Test that debug (-D) sets to debug
 	n.debug = true

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -243,14 +243,14 @@ func getPassphraseRetriever() notary.PassRetriever {
 	}
 }
 
-// Set the logging level to fatal on default, or the most specific level the user specified (debug or error)
+// Set the logging level to warn on default, or the most verbose level the user specified (debug, info)
 func (n *notaryCommander) setVerbosityLevel() {
 	if n.debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	} else if n.verbose {
-		logrus.SetLevel(logrus.ErrorLevel)
+		logrus.SetLevel(logrus.InfoLevel)
 	} else {
-		logrus.SetLevel(logrus.FatalLevel)
+		logrus.SetLevel(logrus.WarnLevel)
 	}
 	logrus.SetOutput(os.Stderr)
 }

--- a/utils/keys.go
+++ b/utils/keys.go
@@ -33,7 +33,7 @@ func ExportKeysByGUN(to io.Writer, s Exporter, gun string) error {
 	for _, loc := range keys {
 		keyFile, err := s.Get(loc)
 		if err != nil {
-			logrus.Info("Could not parse key file at ", loc)
+			logrus.Warn("Could not parse key file at ", loc)
 			continue
 		}
 		block, _ := pem.Decode(keyFile)
@@ -203,7 +203,7 @@ func checkValidity(block *pem.Block) (string, error) {
 	case tufdata.CanonicalSnapshotRole.String(), tufdata.CanonicalTargetsRole.String(), tufdata.CanonicalTimestampRole.String():
 		// check if the key is missing a gun header or has an empty gun and error out since we don't know what gun it belongs to
 		if block.Headers["gun"] == "" {
-			logrus.Infof("failed to import key (%s) to store: Cannot have canonical role key without a gun, don't know what gun it belongs to", block.Headers["path"])
+			logrus.Warnf("failed to import key (%s) to store: Cannot have canonical role key without a gun, don't know what gun it belongs to", block.Headers["path"])
 			return "", errors.New("invalid key pem block")
 		}
 	default:
@@ -219,7 +219,7 @@ func checkValidity(block *pem.Block) (string, error) {
 
 		decodedKey, err := utils.ParsePEMPrivateKey(pem.EncodeToMemory(block), "")
 		if err != nil {
-			logrus.Info("failed to import key to store: Invalid key generated, key may be encrypted and does not contain path header")
+			logrus.Warn("failed to import key to store: Invalid key generated, key may be encrypted and does not contain path header")
 			return "", errors.New("invalid key pem block")
 		}
 		loc = decodedKey.ID()


### PR DESCRIPTION
- makes `warn` the default log level on notary CLI
- increases the `-v` log level from `error` to `info`
- bumps up key import/export failure logs from `info` to `warn`

cc @cyc115 @ecordell 

Closes #1162, #1178

Ex: here's what an offline `notary list` looks like now if there's a cache with a valid timestamp:
```
🐳 $ ./notary -s https://notary.docker.io list docker.io/library/alpine
ERRO[0000] could not reach https://notary.docker.io: Get https://notary.docker.io/v2/: dial tcp: lookup notary.docker.io on [::1]:53: read udp [::1]:56941->[::1]:53: read: connection refused
WARN[0000] Error while downloading remote metadata, using cached timestamp - this might not be the latest version available remotely
NAME               DIGEST                                                              SIZE (BYTES)    ROLE
----               ------                                                              ------------    ----
2.6                9ace551613070689a12857d62c30ef0daa9a376107ec0fff0e34786cedb3399b    528             targets
2.7                9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a    1374            targets
<..snip..>
```

<img src="https://s-media-cache-ak0.pinimg.com/originals/c8/9a/ff/c89aff3ea93601b856430706dd8918f4.jpg" width="400"></img>
