### PR TITLE
client: improve constructor checks and docs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -96,7 +96,8 @@ func NewFileCachedNotaryRepository(baseDir string, gun data.GUN, baseURL string,
 // It takes the base directory under where all the trust files will be stored
 // (This is normally defaults to "~/.notary" or "~/.docker/trust" when enabling
 // docker content trust).
-// It expects an initialized remote store and cache.
+// It expects an initialized cache. In case of a nil remote store, a default
+// offline store is used.
 func NewNotaryRepository(baseDir string, gun data.GUN, baseURL string, remoteStore store.RemoteStore, cache store.MetadataStore,
 	trustPinning trustpinning.TrustPinConfig, cryptoService signed.CryptoService, cl changelist.Changelist) (
 	*NotaryRepository, error) {
@@ -104,6 +105,10 @@ func NewNotaryRepository(baseDir string, gun data.GUN, baseURL string, remoteSto
 	// Repo's remote store is either a valid remote store or an OfflineStore
 	if remoteStore == nil {
 		remoteStore = store.OfflineStore{}
+	}
+
+	if cache == nil {
+		return nil, fmt.Errorf("got an invalid cache (nil metadata store)")
 	}
 
 	nRepo := &NotaryRepository{

--- a/client/client.go
+++ b/client/client.go
@@ -57,6 +57,8 @@ type NotaryRepository struct {
 // a file cache from the provided repository, local config information and a crypto service.
 // It also retrieves the remote store associated to the base directory under where all the
 // trust files will be stored and the specified GUN.
+//
+// In case of a nil RoundTripper, a default offline store is used instead.
 func NewFileCachedNotaryRepository(baseDir string, gun data.GUN, baseURL string, rt http.RoundTripper,
 	retriever notary.PassRetriever, trustPinning trustpinning.TrustPinConfig) (
 	*NotaryRepository, error) {

--- a/storage/httpstore.go
+++ b/storage/httpstore.go
@@ -104,7 +104,9 @@ type HTTPStore struct {
 	roundTrip     http.RoundTripper
 }
 
-// NewHTTPStore initializes a new store against a URL and a number of configuration options
+// NewHTTPStore initializes a new store against a URL and a number of configuration options.
+//
+// In case of a nil `roundTrip`, a default offline store is used instead.
 func NewHTTPStore(baseURL, metaPrefix, metaExtension, keyExtension string, roundTrip http.RoundTripper) (RemoteStore, error) {
 	base, err := url.Parse(baseURL)
 	if err != nil {


### PR DESCRIPTION
This introduce and explicit nil-check on the metadata store in
`NewNotaryRepository()`, to match the docstring and to avoid further
panics at runtime.
It also clarify the default behavior in case of a nil remote store and of
a nil roundtripper.

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>