### PR TITLE
Make testutils metadata generation consistent with how metadata is produced by the client

### DIFF
--- a/tuf/testutils/repo.go
+++ b/tuf/testutils/repo.go
@@ -162,7 +162,7 @@ func SignAndSerialize(tufRepo *tuf.Repo) (map[data.RoleName][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		metaBytes, err := json.MarshalCanonical(signedThing)
+		metaBytes, err := json.Marshal(signedThing)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In the test repo generation code, when we serialized delegation metadata, we [serialized using canonical JSON serialization](https://github.com/docker/notary/blob/master/tuf/testutils/repo.go#L165), which does not match what actually gets [done in the client](https://github.com/docker/notary/blob/master/client/helpers.go#L270), or the rest of the testutil non-delegation serialization, or for [calculating the checksum in the snapshot](https://github.com/docker/notary/blob/master/tuf/tuf.go#L867).

Fix this to make it consistent with actual behavior.

(We want to migrate to doing canonical JSON everywhere at some point - see https://github.com/docker/notary/issues/481 - but until that happens we should keep the test generation and actual generation consistent).

Note that this should allow us to bump our canonical JSON vendor once https://github.com/docker/go/pull/6 gets merged.