### PR TITLE
Fix trustpinning tests because certs have expired

### DIFF
--- a/trustpinning/certs_test.go
+++ b/trustpinning/certs_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -15,10 +14,16 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/initca"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+	"github.com/docker/go/canonical/json"
 	"github.com/docker/notary"
 	"github.com/docker/notary/cryptoservice"
 	"github.com/docker/notary/trustmanager"
@@ -36,84 +41,154 @@ type SignedRSARootTemplate struct {
 
 var passphraseRetriever = func(string, string, bool, int) (string, bool, error) { return "passphrase", false, nil }
 
-const validPEMEncodedRSARoot = `LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZLekNDQXhXZ0F3SUJBZ0lRUnlwOVFxY0pmZDNheXFkaml6OHhJREFMQmdrcWhraUc5dzBCQVFzd09ERWEKTUJnR0ExVUVDaE1SWkc5amEyVnlMbU52YlM5dWIzUmhjbmt4R2pBWUJnTlZCQU1URVdSdlkydGxjaTVqYjIwdgpibTkwWVhKNU1CNFhEVEUxTURjeE56QTJNelF5TTFvWERURTNNRGN4TmpBMk16UXlNMW93T0RFYU1CZ0dBMVVFCkNoTVJaRzlqYTJWeUxtTnZiUzl1YjNSaGNua3hHakFZQmdOVkJBTVRFV1J2WTJ0bGNpNWpiMjB2Ym05MFlYSjUKTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFvUWZmcnpzWW5zSDh2R2Y0Smg1NQpDajV3cmpVR3pEL3NIa2FGSHB0ako2VG9KR0p2NXlNQVB4enlJbnU1c0lvR0xKYXBuWVZCb0FVMFlnSTlxbEFjCllBNlN4YVN3Z202cnB2bW5sOFFuMHFjNmdlcjNpbnBHYVVKeWxXSHVQd1drdmNpbVFBcUhaeDJkUXRMN2c2a3AKcm1LZVRXcFdvV0x3M0pvQVVaVVZoWk1kNmEyMlpML0R2QXcrSHJvZ2J6NFhleWFoRmI5SUg0MDJ6UHhONnZnYQpKRUZURjBKaTFqdE5nME1vNHBiOVNIc01zaXcrTFpLN1NmZkhWS1B4dmQyMW0vYmlObXdzZ0V4QTNVOE9PRzhwCnV5Z2ZhY3lzNWM4K1pyWCtaRkcvY3Z3S3owazYvUWZKVTQwczZNaFh3NUMyV3R0ZFZtc0c5LzdyR0ZZakhvSUoKd2VEeXhnV2s3dnhLelJKSS91bjdjYWdESWFRc0tySlFjQ0hJR0ZSbHBJUjVUd1g3dmwzUjdjUm5jckRSTVZ2YwpWU0VHMmVzeGJ3N2p0eklwL3lwblZSeGNPbnk3SXlweWpLcVZlcVo2SGd4WnRUQlZyRjFPL2FIbzJrdmx3eVJTCkF1czRrdmg2ejMranpUbTlFemZYaVBRelk5QkVrNWdPTHhoVzlyYzZVaGxTK3BlNWxrYU4vSHlxeS9sUHVxODkKZk1yMnJyN2xmNVdGZEZuemU2V05ZTUFhVzdkTkE0TkUwZHlENTM0MjhaTFh4TlZQTDRXVTY2R2FjNmx5blE4bApyNXRQc1lJRlh6aDZGVmFSS0dRVXRXMWh6OWVjTzZZMjdSaDJKc3lpSXhnVXFrMm9veEU2OXVONDJ0K2R0cUtDCjFzOEcvN1Z0WThHREFMRkxZVG56THZzQ0F3RUFBYU0xTURNd0RnWURWUjBQQVFIL0JBUURBZ0NnTUJNR0ExVWQKSlFRTU1Bb0dDQ3NHQVFVRkJ3TURNQXdHQTFVZEV3RUIvd1FDTUFBd0N3WUpLb1pJaHZjTkFRRUxBNElDQVFCTQpPbGwzRy9YQno4aWRpTmROSkRXVWgrNXczb2ptd2FuclRCZENkcUVrMVdlbmFSNkR0Y2ZsSng2WjNmL213VjRvCmIxc2tPQVgxeVg1UkNhaEpIVU14TWljei9RMzhwT1ZlbEdQclduYzNUSkIrVktqR3lIWGxRRFZrWkZiKzQrZWYKd3RqN0huZ1hoSEZGRFNnam0zRWRNbmR2Z0RRN1NRYjRza09uQ05TOWl5WDdlWHhoRkJDWm1aTCtIQUxLQmoyQgp5aFY0SWNCRHFtcDUwNHQxNHJ4OS9KdnR5MGRHN2ZZN0k1MWdFUXBtNFMwMkpNTDV4dlRtMXhmYm9XSWhaT0RJCnN3RUFPK2VrQm9GSGJTMVE5S01QaklBdzNUckNISDh4OFhacTV6c1l0QUMxeVpIZENLYTI2YVdkeTU2QTllSGoKTzFWeHp3bWJOeVhSZW5WdUJZUCswd3IzSFZLRkc0Sko0WlpwTlp6UVcvcHFFUGdoQ1RKSXZJdWVLNjUyQnlVYwovL3N2K25YZDVmMTlMZUVTOXBmMGwyNTNORGFGWlBiNmFlZ0tmcXVXaDhxbFFCbVVRMkd6YVRMYnRtTmQyOE02Clc3aUw3dGtLWmUxWm5CejlSS2d0UHJEampXR1pJbmpqY09VOEV0VDRTTHE3a0NWRG1QczVNRDh2YUFtOTZKc0UKam1MQzNVdS80azdIaURZWDBpMG1PV2tGalpRTWRWYXRjSUY1RlBTcHB3c1NiVzhRaWRuWHQ1NFV0d3RGREVQegpscGpzN3liZVFFNzFKWGNNWm5WSUs0YmpSWHNFRlBJOThScElsRWRlZGJTVWRZQW5jTE5KUlQ3SFpCTVBHU3daCjBQTkp1Z2xubHIzc3JWemRXMWR6MnhRamR2THd4eTZtTlVGNnJiUUJXQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K`
+type rootData struct {
+	rootMeta                      *data.Signed
+	rootPubKeyID, targetsPubkeyID string
+}
 
-const validCAPEMEncodeRSARoot = `LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlHTXpDQ0JCdWdBd0lCQWdJQkFUQU5CZ2txaGtpRzl3MEJBUXNGQURCZk1Rc3dDUVlEVlFRR0V3SlZVekVMDQpNQWtHQTFVRUNBd0NRMEV4RmpBVUJnTlZCQWNNRFZOaGJpQkdjbUZ1WTJselkyOHhEekFOQmdOVkJBb01Ca1J2DQpZMnRsY2pFYU1CZ0dBMVVFQXd3UlRtOTBZWEo1SUZSbGMzUnBibWNnUTBFd0hoY05NVFV3TnpFMk1EUXlOVEF6DQpXaGNOTWpVd056RXpNRFF5TlRBeldqQmZNUm93R0FZRFZRUUREQkZPYjNSaGNua2dWR1Z6ZEdsdVp5QkRRVEVMDQpNQWtHQTFVRUJoTUNWVk14RmpBVUJnTlZCQWNNRFZOaGJpQkdjbUZ1WTJselkyOHhEekFOQmdOVkJBb01Ca1J2DQpZMnRsY2pFTE1Ba0dBMVVFQ0F3Q1EwRXdnZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElDRHdBd2dnSUtBb0lDDQpBUUN3VlZENHBLN3o3cFhQcEpiYVoxSGc1ZVJYSWNhWXRiRlBDbk4waXF5OUhzVkVHbkVuNUJQTlNFc3VQK20wDQo1TjBxVlY3REdiMVNqaWxvTFhEMXFERHZoWFdrK2dpUzlwcHFQSFBMVlBCNGJ2enNxd0RZcnRwYnFrWXZPMFlLDQowU0wza3hQWFVGZGxrRmZndTB4amxjem0yUGhXRzNKZDhhQXRzcEwvTCtWZlBBMTNKVWFXeFNMcHVpMUluOHJoDQpnQXlRVEs2UTRPZjZHYkpZVG5BSGI1OVVvTFhTekI1QWZxaVVxNkw3bkVZWUtvUGZsUGJSQUlXTC9VQm0wYytIDQpvY21zNzA2UFlwbVBTMlJRdjNpT0dtbm45aEVWcDNQNmpxN1dBZXZiQTRhWUd4NUVzYlZ0WUFCcUpCYkZXQXV3DQp3VEdSWW16bjBNajBlVE1nZTl6dFlCMi8yc3hkVGU2dWhtRmdwVVhuZ0RxSkk1TzlOM3pQZnZsRUltQ2t5M0hNDQpqSm9MN2c1c21xWDlvMVArRVNMaDBWWnpoaDdJRFB6UVRYcGNQSVMvNnowbDIyUUdrSy8xTjFQYUFEYVVIZExMDQp2U2F2M3kyQmFFbVB2ZjJma1pqOHlQNWVZZ2k3Q3c1T05oSExEWUhGY2w5Wm0veXdtZHhISkVUejluZmdYbnNXDQpITnhEcXJrQ1ZPNDZyL3U2clNyVXQ2aHIzb2RkSkc4czhKbzA2ZWFydzZYVTNNek0rM2dpd2tLMFNTTTN1UlBxDQo0QXNjUjFUditFMzFBdU9BbWpxWVFvVDI5Yk1JeG9TemVsamovWW5lZHdqVzQ1cFd5YzNKb0hhaWJEd3ZXOVVvDQpHU1pCVnk0aHJNL0ZhN1hDV3YxV2ZITlcxZ0R3YUxZd0RubDVqRm1SQnZjZnVRSURBUUFCbzRINU1JSDJNSUdSDQpCZ05WSFNNRWdZa3dnWWFBRkhVTTFVM0U0V3lMMW52RmQrZFBZOGY0TzJoWm9XT2tZVEJmTVFzd0NRWURWUVFHDQpFd0pWVXpFTE1Ba0dBMVVFQ0F3Q1EwRXhGakFVQmdOVkJBY01EVk5oYmlCR2NtRnVZMmx6WTI4eER6QU5CZ05WDQpCQW9NQmtSdlkydGxjakVhTUJnR0ExVUVBd3dSVG05MFlYSjVJRlJsYzNScGJtY2dRMEdDQ1FEQ2VETGJlbUlUDQpTekFTQmdOVkhSTUJBZjhFQ0RBR0FRSC9BZ0VBTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQ0JnZ3JCZ0VGDQpCUWNEQVRBT0JnTlZIUThCQWY4RUJBTUNBVVl3SFFZRFZSME9CQllFRkhlNDhoY0JjQXAwYlVWbFR4WGVSQTRvDQpFMTZwTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElDQVFBV1V0QVBkVUZwd1JxK04xU3pHVWVqU2lrZU1HeVBac2NaDQpKQlVDbWhab0Z1ZmdYR2JMTzVPcGNSTGFWM1hkYTB0LzVQdGRHTVNFemN6ZW9aSFdrbkR0dys3OU9CaXR0UFBqDQpTaDFvRkR1UG8zNVI3ZVA2MjRsVUNjaC9JblpDcGhUYUx4OW9ETEdjYUszYWlsUTl3akJkS2RsQmw4S05LSVpwDQphMTNhUDVyblNtMkp2YSt0WHkveWkzQlNkczNkR0Q4SVRLWnlJLzZBRkh4R3ZPYnJESUJwbzRGRi96Y1dYVkRqDQpwYU9teHBsUnRNNEhpdG0rc1hHdmZxSmU0eDVEdU9YT25QclQzZEh2UlQ2dlNaVW9Lb2J4TXFtUlRPY3JPSVBhDQpFZU1wT29ic2hPUnVSbnRNRFl2dmdPM0Q2cDZpY2lEVzJWcDlONnJkTWRmT1dFUU44SlZXdkI3SXhSSGs5cUtKDQp2WU9XVmJjekF0MHFwTXZYRjNQWExqWmJVTTBrbk9kVUtJRWJxUDRZVWJnZHp4NlJ0Z2lpWTkzMEFqNnRBdGNlDQowZnBnTmx2ak1ScFNCdVdUbEFmTk5qRy9ZaG5kTXo5dUk2OFRNZkZwUjNQY2dWSXYzMGtydy85VnpvTGkyRHBlDQpvdzZEckdPNm9pK0RoTjc4UDRqWS9POVVjelpLMnJvWkwxT2k1UDBSSXhmMjNVWkM3eDFEbGNOM25CcjRzWVN2DQpyQng0Y0ZUTU5wd1UrbnpzSWk0ZGpjRkRLbUpkRU95ak1ua1AydjBMd2U3eXZLMDhwWmRFdSswemJycTE3a3VlDQpYcFhMYzdLNjhRQjE1eXh6R3lsVTVyUnd6bUMvWXNBVnlFNGVvR3U4UHhXeHJFUnZIYnk0QjhZUDB2QWZPcmFMDQpsS21YbEs0ZFRnPT0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NCg==`
+type certChain struct {
+	rootCert, intermediateCert, leafCert []byte
+	rootKey, intermediateKey, leafKey    data.PrivateKey
+}
 
-const validIntermediateAndCertRSA = `LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlHTXpDQ0JCdWdBd0lCQWdJQkFUQU5CZ2txaGtpRzl3MEJBUXNGQURCZk1Rc3dDUVlEVlFRR0V3SlZVekVMDQpNQWtHQTFVRUNBd0NRMEV4RmpBVUJnTlZCQWNNRFZOaGJpQkdjbUZ1WTJselkyOHhEekFOQmdOVkJBb01Ca1J2DQpZMnRsY2pFYU1CZ0dBMVVFQXd3UlRtOTBZWEo1SUZSbGMzUnBibWNnUTBFd0hoY05NVFV3TnpFMk1EUXlOVEF6DQpXaGNOTWpVd056RXpNRFF5TlRBeldqQmZNUm93R0FZRFZRUUREQkZPYjNSaGNua2dWR1Z6ZEdsdVp5QkRRVEVMDQpNQWtHQTFVRUJoTUNWVk14RmpBVUJnTlZCQWNNRFZOaGJpQkdjbUZ1WTJselkyOHhEekFOQmdOVkJBb01Ca1J2DQpZMnRsY2pFTE1Ba0dBMVVFQ0F3Q1EwRXdnZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElDRHdBd2dnSUtBb0lDDQpBUUN3VlZENHBLN3o3cFhQcEpiYVoxSGc1ZVJYSWNhWXRiRlBDbk4waXF5OUhzVkVHbkVuNUJQTlNFc3VQK20wDQo1TjBxVlY3REdiMVNqaWxvTFhEMXFERHZoWFdrK2dpUzlwcHFQSFBMVlBCNGJ2enNxd0RZcnRwYnFrWXZPMFlLDQowU0wza3hQWFVGZGxrRmZndTB4amxjem0yUGhXRzNKZDhhQXRzcEwvTCtWZlBBMTNKVWFXeFNMcHVpMUluOHJoDQpnQXlRVEs2UTRPZjZHYkpZVG5BSGI1OVVvTFhTekI1QWZxaVVxNkw3bkVZWUtvUGZsUGJSQUlXTC9VQm0wYytIDQpvY21zNzA2UFlwbVBTMlJRdjNpT0dtbm45aEVWcDNQNmpxN1dBZXZiQTRhWUd4NUVzYlZ0WUFCcUpCYkZXQXV3DQp3VEdSWW16bjBNajBlVE1nZTl6dFlCMi8yc3hkVGU2dWhtRmdwVVhuZ0RxSkk1TzlOM3pQZnZsRUltQ2t5M0hNDQpqSm9MN2c1c21xWDlvMVArRVNMaDBWWnpoaDdJRFB6UVRYcGNQSVMvNnowbDIyUUdrSy8xTjFQYUFEYVVIZExMDQp2U2F2M3kyQmFFbVB2ZjJma1pqOHlQNWVZZ2k3Q3c1T05oSExEWUhGY2w5Wm0veXdtZHhISkVUejluZmdYbnNXDQpITnhEcXJrQ1ZPNDZyL3U2clNyVXQ2aHIzb2RkSkc4czhKbzA2ZWFydzZYVTNNek0rM2dpd2tLMFNTTTN1UlBxDQo0QXNjUjFUditFMzFBdU9BbWpxWVFvVDI5Yk1JeG9TemVsamovWW5lZHdqVzQ1cFd5YzNKb0hhaWJEd3ZXOVVvDQpHU1pCVnk0aHJNL0ZhN1hDV3YxV2ZITlcxZ0R3YUxZd0RubDVqRm1SQnZjZnVRSURBUUFCbzRINU1JSDJNSUdSDQpCZ05WSFNNRWdZa3dnWWFBRkhVTTFVM0U0V3lMMW52RmQrZFBZOGY0TzJoWm9XT2tZVEJmTVFzd0NRWURWUVFHDQpFd0pWVXpFTE1Ba0dBMVVFQ0F3Q1EwRXhGakFVQmdOVkJBY01EVk5oYmlCR2NtRnVZMmx6WTI4eER6QU5CZ05WDQpCQW9NQmtSdlkydGxjakVhTUJnR0ExVUVBd3dSVG05MFlYSjVJRlJsYzNScGJtY2dRMEdDQ1FEQ2VETGJlbUlUDQpTekFTQmdOVkhSTUJBZjhFQ0RBR0FRSC9BZ0VBTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQ0JnZ3JCZ0VGDQpCUWNEQVRBT0JnTlZIUThCQWY4RUJBTUNBVVl3SFFZRFZSME9CQllFRkhlNDhoY0JjQXAwYlVWbFR4WGVSQTRvDQpFMTZwTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElDQVFBV1V0QVBkVUZwd1JxK04xU3pHVWVqU2lrZU1HeVBac2NaDQpKQlVDbWhab0Z1ZmdYR2JMTzVPcGNSTGFWM1hkYTB0LzVQdGRHTVNFemN6ZW9aSFdrbkR0dys3OU9CaXR0UFBqDQpTaDFvRkR1UG8zNVI3ZVA2MjRsVUNjaC9JblpDcGhUYUx4OW9ETEdjYUszYWlsUTl3akJkS2RsQmw4S05LSVpwDQphMTNhUDVyblNtMkp2YSt0WHkveWkzQlNkczNkR0Q4SVRLWnlJLzZBRkh4R3ZPYnJESUJwbzRGRi96Y1dYVkRqDQpwYU9teHBsUnRNNEhpdG0rc1hHdmZxSmU0eDVEdU9YT25QclQzZEh2UlQ2dlNaVW9Lb2J4TXFtUlRPY3JPSVBhDQpFZU1wT29ic2hPUnVSbnRNRFl2dmdPM0Q2cDZpY2lEVzJWcDlONnJkTWRmT1dFUU44SlZXdkI3SXhSSGs5cUtKDQp2WU9XVmJjekF0MHFwTXZYRjNQWExqWmJVTTBrbk9kVUtJRWJxUDRZVWJnZHp4NlJ0Z2lpWTkzMEFqNnRBdGNlDQowZnBnTmx2ak1ScFNCdVdUbEFmTk5qRy9ZaG5kTXo5dUk2OFRNZkZwUjNQY2dWSXYzMGtydy85VnpvTGkyRHBlDQpvdzZEckdPNm9pK0RoTjc4UDRqWS9POVVjelpLMnJvWkwxT2k1UDBSSXhmMjNVWkM3eDFEbGNOM25CcjRzWVN2DQpyQng0Y0ZUTU5wd1UrbnpzSWk0ZGpjRkRLbUpkRU95ak1ua1AydjBMd2U3eXZLMDhwWmRFdSswemJycTE3a3VlDQpYcFhMYzdLNjhRQjE1eXh6R3lsVTVyUnd6bUMvWXNBVnlFNGVvR3U4UHhXeHJFUnZIYnk0QjhZUDB2QWZPcmFMDQpsS21YbEs0ZFRnPT0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQ0KTUlJRlZ6Q0NBeitnQXdJQkFnSUJBekFOQmdrcWhraUc5dzBCQVFzRkFEQmZNUm93R0FZRFZRUUREQkZPYjNSaA0KY25rZ1ZHVnpkR2x1WnlCRFFURUxNQWtHQTFVRUJoTUNWVk14RmpBVUJnTlZCQWNNRFZOaGJpQkdjbUZ1WTJseg0KWTI4eER6QU5CZ05WQkFvTUJrUnZZMnRsY2pFTE1Ba0dBMVVFQ0F3Q1EwRXdIaGNOTVRVd056RTJNRFF5TlRVdw0KV2hjTk1UWXdOekUxTURReU5UVXdXakJnTVJzd0dRWURWUVFEREJKelpXTjFjbVV1WlhoaGJYQnNaUzVqYjIweA0KQ3pBSkJnTlZCQVlUQWxWVE1SWXdGQVlEVlFRSERBMVRZVzRnUm5KaGJtTnBjMk52TVE4d0RRWURWUVFLREFaRQ0KYjJOclpYSXhDekFKQmdOVkJBZ01Ba05CTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQw0KQVFFQW1MWWlZQ1RBV0pCV0F1eFpMcVZtVjRGaVVkR2dFcW9RdkNiTjczekYvbVFmaHEwQ0lUbzZ4U3hzMVFpRw0KRE96VXRrcHpYenppU2o0SjUrZXQ0SmtGbGVlRUthTWNIYWRlSXNTbEhHdlZ0WER2OTNvUjN5ZG1mWk8rVUxSVQ0KOHhIbG9xY0xyMUtyT1AxZGFMZmRNUmJhY3RkNzVVUWd2dzlYVHNkZU1WWDVBbGljU0VOVktWK0FRWHZWcHY4UA0KVDEwTVN2bEJGYW00cmVYdVkvU2tlTWJJYVc1cEZ1NkFRdjNabWZ0dDJ0YTBDQjlrYjFtWWQrT0tydThIbm5xNQ0KYUp3NlIzR2hQMFRCZDI1UDFQa2lTeE0yS0dZWlprMFcvTlpxTEs5L0xURktUTkN2N1ZqQ2J5c1ZvN0h4Q1kwYg0KUWUvYkRQODJ2N1NuTHRiM2Fab2dmdmE0SFFJREFRQUJvNElCR3pDQ0FSY3dnWWdHQTFVZEl3U0JnREIrZ0JSMw0KdVBJWEFYQUtkRzFGWlU4VjNrUU9LQk5lcWFGanBHRXdYekVMTUFrR0ExVUVCaE1DVlZNeEN6QUpCZ05WQkFnTQ0KQWtOQk1SWXdGQVlEVlFRSERBMVRZVzRnUm5KaGJtTnBjMk52TVE4d0RRWURWUVFLREFaRWIyTnJaWEl4R2pBWQ0KQmdOVkJBTU1FVTV2ZEdGeWVTQlVaWE4wYVc1bklFTkJnZ0VCTUF3R0ExVWRFd0VCL3dRQ01BQXdIUVlEVlIwbA0KQkJZd0ZBWUlLd1lCQlFVSEF3SUdDQ3NHQVFVRkJ3TUJNQTRHQTFVZER3RUIvd1FFQXdJRm9EQXVCZ05WSFJFRQ0KSnpBbGdoSnpaV04xY21VdVpYaGhiWEJzWlM1amIyMkNDV3h2WTJGc2FHOXpkSWNFZndBQUFUQWRCZ05WSFE0RQ0KRmdRVURQRDRDYVhSYnU1UUJiNWU4eThvZHZUcVc0SXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnSUJBSk95bG1jNA0KbjdKNjRHS3NQL3hoVWRLS1Y5L0tEK3VmenBLYnJMSW9qV243clR5ZTcwdlkwT2pRRnVPWGM1NHlqTVNJTCsvNQ0KbWxOUTdZL2ZKUzh4ZEg3OUVSKzRuV011RDJlY2lMbnNMZ2JZVWs0aGl5Ynk4LzVWKy9ZcVBlQ3BQQ242VEpSSw0KYTBFNmxWL1VqWEpkcmlnSnZKb05PUjhaZ3RFWi9RUGdqSkVWVXNnNDdkdHF6c0RwZ2VTOGRjanVNV3BaeFAwMg0KcWF2RkxEalNGelZIKzJENk90eTFEUXBsbS8vM1hhUlhoMjNkT0NQOHdqL2J4dm5WVG9GV3Mrek80dVQxTEYvUw0KS1hDTlFvZWlHeFdIeXpyWEZWVnRWbkM5RlNOejBHZzIvRW0xdGZSZ3ZoVW40S0xKY3ZaVzlvMVI3VlZDWDBMMQ0KMHgwZnlLM1ZXZVdjODZhNWE2ODFhbUtaU0ViakFtSVZaRjl6T1gwUE9EQzhveSt6cU9QV2EwV0NsNEs2ekRDNg0KMklJRkJCTnk1MFpTMmlPTjZSWTZtRTdObUE3OGdja2Y0MTVjcUlWcmxvWUpiYlREZXBmaFRWMjE4U0xlcHBoNA0KdUdiMi9zeGtsZkhPWUUrcnBIY2lpYld3WHJ3bE9ESmFYdXpYRmhwbFVkL292ZHVqQk5BSUhrQmZ6eStZNnoycw0KYndaY2ZxRDROSWIvQUdoSXlXMnZidnU0enNsRHAxTUVzTG9hTytTemlyTXpreU1CbEtSdDEyMHR3czRFa1VsbQ0KL1FoalNVb1pwQ0FzeTVDL3BWNCtieDBTeXNOZC9TK2tLYVJaYy9VNlkzWllCRmhzekxoN0phTFhLbWs3d0huRQ0KcmdnbTZvejRML0d5UFdjL0ZqZm5zZWZXS00yeUMzUURoanZqDQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQo=`
+var (
+	_sampleRootData  *rootData
+	_sampleCertChain *certChain
+)
 
-const signedRSARootTemplate = `{"signed":{"_type":"Root","consistent_snapshot":false,"expires":"2016-07-16T23:34:13.389129622-07:00","keys":{"1fc4fdc38f66558658c5c59b67f1716bdc6a74ef138b023ae5931db69f51d670":{"keytype":"ecdsa","keyval":{"private":null,"public":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nIgzLigo5D47dWQe1IUjzHXxvyx0j/OL16VQymuloWsgVDxxT6+mH3CeviMAs+/McnEPE9exnm6SQGR5x3XMw=="}},"23c29cc372109c819e081bc953b7657d05e3f968f03c21d0d75ea457590f3d14":{"keytype":"ecdsa","keyval":{"private":null,"public":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEClUFVWkc85OQScfTQRS02VaLIEaeCmxdwYS/hcTLVoTxlFfRfs7HyalTwXGAGO79XZZS+koE6s8D0xGcCJQkLQ=="}},"49cf5c6404a35fa41d5a5aa2ce539dfee0d7a2176d0da488914a38603b1f4292":{"keytype":"rsa-x509","keyval":{"private":null,"public":"{{.RootPem}}"}},"e3a5a4fdaf11ea1ec58f5efed6f3639b39cd4cfa1418c8b55c9a8c2447ace5d9":{"keytype":"ecdsa","keyval":{"private":null,"public":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgl3rzMPMEKhS1k/AX16MM4PdidpjJr+z4pj0Td+30QnpbOIARgpyR1PiFztU8BZlqG3cUazvFclr2q/xHvfrqw=="}}},"roles":{"root":{"keyids":["49cf5c6404a35fa41d5a5aa2ce539dfee0d7a2176d0da488914a38603b1f4292"],"threshold":1},"snapshot":{"keyids":["23c29cc372109c819e081bc953b7657d05e3f968f03c21d0d75ea457590f3d14"],"threshold":1},"targets":{"keyids":["1fc4fdc38f66558658c5c59b67f1716bdc6a74ef138b023ae5931db69f51d670"],"threshold":1},"timestamp":{"keyids":["e3a5a4fdaf11ea1ec58f5efed6f3639b39cd4cfa1418c8b55c9a8c2447ace5d9"],"threshold":1}},"version":2},"signatures":[{"keyid":"49cf5c6404a35fa41d5a5aa2ce539dfee0d7a2176d0da488914a38603b1f4292","method":"rsapss","sig":"YlZwtCj028Xc23+KHfj6govFEY6hMbBXO5HT20F0I5ZeIPb1l7OmkjEiwp9ZHusClY+QeqiP1CFh\n/AfCbv4tLanqMkXPtm8UJJ1hMZVq86coieB32PQDj9k6x1hErHzvPUbOzTRW2BQkFFMZFkLDAd06\npH8lmxyPLOhdkVE8qIT7sBCy/4bQIGfvEX6yCDz84MZdcLNX5B9mzGi9A7gDloh9IEZxA8UgoI18\nSYpv/fYeSZSqM/ws2G+kiELGgTWhcZ+gOlF7ArM/DOlcC/NYqcvY1ugE6Gn7G8opre6NOofdRp3w\n603A2rMMvYTwqKLY6oX/d+07A2+WGHXPUy5otCAybWOw2hIZ35Jjmh12g6Dc6Qk4K2zXwAgvWwBU\nWlT8MlP1Tf7f80jnGjh0aARlHI4LCxlYU5L/pCaYuHgynujvLuzoOuiiPfJv7sYvKoQ8UieE1w//\nHc8E6tWtV5G2FguKLurMoKZ9FBWcanDO0fg5AWuG3qcgUJdvh9acQ33EKer1fqBxs6LSAUWo8rDt\nQkg+b55AW0YBukAW9IAfMySQGAS2e3mHZ8nK/ijaygCRu7/P+NgKY9/zpmfL2xgcNslLcANcSOOt\nhiJS6yqYM9i9G0af0yw/TxAT4ntwjVm8u52UyR/hXIiUc/mjZcYRbSmJOHws902+i+Z/qv72knk="}]}`
+func sampleRootData(t *testing.T) *rootData {
+	if _sampleRootData == nil {
+		var err error
+		_sampleRootData = new(rootData)
+		// generate a single test repo we can use for testing
+		tufRepo, _, err := testutils.EmptyRepo("docker.com/notary")
+		require.NoError(t, err)
+		_sampleRootData.rootPubKeyID = tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs[0]
+		_sampleRootData.targetsPubkeyID = tufRepo.Root.Signed.Roles[data.CanonicalTargetsRole].KeyIDs[0]
+		tufRepo.Root.Signed.Version++
+		_sampleRootData.rootMeta, err = tufRepo.SignRoot(data.DefaultExpires(data.CanonicalRootRole), nil)
+		require.NoError(t, err)
+	}
+	return _sampleRootData
+}
 
-const rootPubKeyID = "49cf5c6404a35fa41d5a5aa2ce539dfee0d7a2176d0da488914a38603b1f4292"
+func sampleCertChain(t *testing.T) *certChain {
+	if _sampleCertChain == nil {
+		// generate a CA, an intermedate, and a leaf certificate using CFSSL
+		// Create a simple CSR for the CA using the default CA validator and policy
+		req := &csr.CertificateRequest{
+			CN:         "NotaryRoot",
+			KeyRequest: csr.NewBasicKeyRequest(),
+			CA:         &csr.CAConfig{},
+		}
 
-const targetsPubKeyID = "1fc4fdc38f66558658c5c59b67f1716bdc6a74ef138b023ae5931db69f51d670"
+		// Generate the CA and get the certificate and private key
+		rootCert, _, rootKey, _ := initca.New(req)
+		priv, _ := helpers.ParsePrivateKeyPEM(rootKey)
+		cert, _ := helpers.ParseCertificatePEM(rootCert)
+		s, _ := local.NewSigner(priv, cert, signer.DefaultSigAlgo(priv), initca.CAPolicy())
+
+		req.CN = "NotaryIntermediate"
+		intCSR, intKey, _ := csr.ParseRequest(req)
+		intCert, _ := s.Sign(signer.SignRequest{
+			Request: string(intCSR),
+			Subject: &signer.Subject{CN: req.CN},
+		})
+
+		priv, _ = helpers.ParsePrivateKeyPEM(intKey)
+		cert, _ = helpers.ParseCertificatePEM(intCert)
+		s, _ = local.NewSigner(priv, cert, signer.DefaultSigAlgo(priv), &config.Signing{
+			Default: config.DefaultConfig(),
+		})
+		req.CA = nil
+		req.CN = "NotaryLeaf"
+		leafCSR, leafKey, _ := csr.ParseRequest(req)
+		leafCert, _ := s.Sign(signer.SignRequest{
+			Request: string(leafCSR),
+			Subject: &signer.Subject{CN: req.CN},
+		})
+
+		parsedRootKey, _ := utils.ParsePEMPrivateKey(rootKey, "")
+		parsedIntKey, _ := utils.ParsePEMPrivateKey(intKey, "")
+		parsedLeafKey, _ := utils.ParsePEMPrivateKey(leafKey, "")
+
+		_sampleCertChain = &certChain{
+			rootCert:         rootCert,
+			intermediateCert: intCert,
+			leafCert:         leafCert,
+
+			rootKey:         parsedRootKey,
+			intermediateKey: parsedIntKey,
+			leafKey:         parsedLeafKey,
+		}
+	}
+	return _sampleCertChain
+}
 
 func TestValidateRoot(t *testing.T) {
-	var testSignedRoot data.Signed
-	var signedRootBytes bytes.Buffer
-
-	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	defer os.RemoveAll(tempBaseDir)
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
-
-	// Execute our template
-	templ, _ := template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: validPEMEncodedRSARoot})
-
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
-
 	// This call to trustpinning.ValidateRoot will succeed since we are using a valid PEM
 	// encoded certificate, and have no other certificates for this CN
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{})
+	_, err := trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary", trustpinning.TrustPinConfig{})
 	require.NoError(t, err)
 
 	// This call to trustpinning.ValidateRoot will fail since we are passing in a dnsName that
 	// doesn't match the CN of the certificate.
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "diogomonica.com/notary", trustpinning.TrustPinConfig{})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "diogomonica.com/notary", trustpinning.TrustPinConfig{})
 	require.Error(t, err, "An error was expected")
 	require.Equal(t, err, &trustpinning.ErrValidationFail{Reason: "unable to retrieve valid leaf certificates"})
+
+	// --- now we mess around with changing the keys, so we need to create a custom TUF repo that we can re-sign
+	tufRepo, cs, err := testutils.EmptyRepo("docker.com/notary")
+	require.NoError(t, err)
+	tufRepo.Root.Signed.Version++
+	rootKeyID := tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs[0]
+	pubKey := tufRepo.Root.Signed.Keys[rootKeyID]
+
+	rootMeta, err := tufRepo.SignRoot(data.DefaultExpires(data.CanonicalRootRole), nil)
+	require.NoError(t, err)
 
 	//
 	// This call to trustpinning.ValidateRoot will fail since we are passing an unparsable RootSigned
 	//
-	// Execute our template deleting the old buffer first
-	signedRootBytes.Reset()
-	templ, _ = template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: "------ ABSOLUTELY NOT A PEM -------"})
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
+	keyBytes, err := json.MarshalCanonical(&pubKey)
+	require.NoError(t, err)
 
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{})
+	rawJSONBytes, err := json.Marshal(rootMeta.Signed)
+	require.NoError(t, err)
+	rawJSONBytes = bytes.Replace(rawJSONBytes, keyBytes, []byte(`"------ ABSOLUTELY NOT A BASE64 PEM -------"`), -1)
+	require.NoError(t, json.Unmarshal(rawJSONBytes, rootMeta.Signed))
+	require.NoError(t, signed.Sign(cs, rootMeta, []data.PublicKey{pubKey}, 1, nil))
+
+	_, err = trustpinning.ValidateRoot(nil, rootMeta, "docker.com/notary", trustpinning.TrustPinConfig{})
 	require.Error(t, err, "illegal base64 data at input byte")
 
 	//
 	// This call to trustpinning.ValidateRoot will fail since we are passing an invalid PEM cert
 	//
-	// Execute our template deleting the old buffer first
-	signedRootBytes.Reset()
-	templ, _ = template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: "LS0tLS1CRUdJTiBDRVJU"})
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
+	tufRepo.Root.Signed.Keys[rootKeyID] = data.NewECDSAx509PublicKey([]byte("-----BEGIN CERTIFICATE-----\ninvalid PEM\n-----END CERTIFICATE-----\n"))
+	rootMeta, err = tufRepo.Root.ToSigned()
+	require.NoError(t, signed.Sign(cs, rootMeta, []data.PublicKey{pubKey}, 1, nil))
 
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{})
+	_, err = trustpinning.ValidateRoot(nil, rootMeta, "docker.com/notary", trustpinning.TrustPinConfig{})
 	require.Error(t, err, "An error was expected")
 	require.Equal(t, err, &trustpinning.ErrValidationFail{Reason: "unable to retrieve valid leaf certificates"})
+
+	tufRepo.Root.Signed.Keys[rootKeyID] = pubKey // put things back the way they were
 
 	//
 	// This call to trustpinning.ValidateRoot will fail since we are passing only CA certificate
 	// This will fail due to the lack of a leaf certificate
 	//
-	// Execute our template deleting the old buffer first
-	signedRootBytes.Reset()
-	templ, _ = template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: validCAPEMEncodeRSARoot})
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
+	pubKey = data.NewECDSAx509PublicKey(sampleCertChain(t).rootCert)
+	tufRepo.Root.Signed.Keys[pubKey.ID()] = pubKey
+	tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs = []string{pubKey.ID()}
+	require.NoError(t, cs.AddKey(data.CanonicalRootRole, "NotaryRoot", sampleCertChain(t).rootKey))
 
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{})
+	rootMeta, err = tufRepo.Root.ToSigned()
+	require.NoError(t, err)
+	require.NoError(t, signed.Sign(cs, rootMeta, []data.PublicKey{pubKey}, 1, nil))
+
+	_, err = trustpinning.ValidateRoot(nil, rootMeta, "secure.example.com", trustpinning.TrustPinConfig{})
 	require.Error(t, err, "An error was expected")
 	require.Equal(t, err, &trustpinning.ErrValidationFail{Reason: "unable to retrieve valid leaf certificates"})
 
@@ -124,66 +199,57 @@ func TestValidateRoot(t *testing.T) {
 	// It will, however, fail to validate, because the leaf cert does not precede the
 	// intermediate in the certificate bundle
 	//
-	// Execute our template deleting the old buffer first
-	signedRootBytes.Reset()
-	templ, _ = template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: validIntermediateAndCertRSA})
+	pubKey = data.NewECDSAx509PublicKey(
+		append(append(sampleCertChain(t).intermediateCert, sampleCertChain(t).leafCert...), sampleCertChain(t).rootCert...))
+	tufRepo.Root.Signed.Keys[pubKey.ID()] = pubKey
+	tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs = []string{pubKey.ID()}
+	require.NoError(t, cs.AddKey(data.CanonicalRootRole, "NotaryIntermediate", sampleCertChain(t).intermediateKey))
+	require.NoError(t, cs.AddKey(data.CanonicalRootRole, "NotaryLeaf", sampleCertChain(t).leafKey))
 
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
+	rootMeta, err = tufRepo.Root.ToSigned()
+	require.NoError(t, err)
+	require.NoError(t, signed.Sign(cs, rootMeta, []data.PublicKey{pubKey}, 1, nil))
 
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "secure.example.com", trustpinning.TrustPinConfig{})
+	_, err = trustpinning.ValidateRoot(nil, rootMeta, "NotaryIntermediate", trustpinning.TrustPinConfig{})
 	require.Error(t, err, "An error was expected")
 	require.Equal(t, err, &trustpinning.ErrValidationFail{Reason: "unable to retrieve valid leaf certificates"})
+
+	//
+	// This call to trustpinning.ValidateRoot will succeed in getting to the TUF validation, since
+	// we are using a valid PEM encoded certificate chain of leaf cert + intermediate cert + root cert
+	pubKey = data.NewECDSAx509PublicKey(
+		append(append(sampleCertChain(t).leafCert, sampleCertChain(t).intermediateCert...), sampleCertChain(t).rootCert...))
+	tufRepo.Root.Signed.Keys[pubKey.ID()] = pubKey
+	tufRepo.Root.Signed.Roles[data.CanonicalRootRole].KeyIDs = []string{pubKey.ID()}
+
+	rootMeta, err = tufRepo.Root.ToSigned()
+	require.NoError(t, err)
+	require.NoError(t, signed.Sign(cs, rootMeta, []data.PublicKey{pubKey}, 1, nil))
+
+	_, err = trustpinning.ValidateRoot(nil, rootMeta, "NotaryLeaf", trustpinning.TrustPinConfig{})
+	require.NoError(t, err)
 }
 
 func TestValidateRootWithoutTOFUS(t *testing.T) {
-	var testSignedRoot data.Signed
-	var signedRootBytes bytes.Buffer
-
-	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	defer os.RemoveAll(tempBaseDir)
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
-
-	// Execute our template
-	templ, _ := template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: validPEMEncodedRSARoot})
-
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
-
 	// This call to trustpinning.ValidateRoot will fail since we are explicitly disabling TOFU and have no local certs
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{DisableTOFU: true})
+	_, err := trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary", trustpinning.TrustPinConfig{DisableTOFU: true})
 	require.Error(t, err)
 }
 
 func TestValidateRootWithPinnedCert(t *testing.T) {
-	var testSignedRoot data.Signed
-	var signedRootBytes bytes.Buffer
-
-	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	defer os.RemoveAll(tempBaseDir)
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
-
-	// Execute our template
-	templ, _ := template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: validPEMEncodedRSARoot})
-
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
-	typedSignedRoot, err := data.RootFromSigned(&testSignedRoot)
+	typedSignedRoot, err := data.RootFromSigned(sampleRootData(t).rootMeta)
 	require.NoError(t, err)
 
 	// This call to trustpinning.ValidateRoot should succeed with the correct Cert ID (same as root public key ID)
-	validatedSignedRoot, err := trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {rootPubKeyID}}, DisableTOFU: true})
+	validatedSignedRoot, err := trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {sampleRootData(t).rootPubKeyID}}, DisableTOFU: true})
 	require.NoError(t, err)
 	typedSignedRoot.Signatures[0].IsValid = true
 	require.Equal(t, validatedSignedRoot, typedSignedRoot)
 
 	// This call to trustpinning.ValidateRoot should also succeed with the correct Cert ID (same as root public key ID), even though we passed an extra bad one
-	validatedSignedRoot, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {rootPubKeyID, "invalidID"}}, DisableTOFU: true})
+	validatedSignedRoot, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {sampleRootData(t).rootPubKeyID, "invalidID"}}, DisableTOFU: true})
 	require.NoError(t, err)
 	// This extra assignment is necessary because ValidateRoot calls through to a successful VerifySignature which marks IsValid
 	typedSignedRoot.Signatures[0].IsValid = true
@@ -436,72 +502,59 @@ func TestValidateRootWithPinnedCertAndIntermediates(t *testing.T) {
 }
 
 func TestValidateRootFailuresWithPinnedCert(t *testing.T) {
-	var testSignedRoot data.Signed
-	var signedRootBytes bytes.Buffer
-
-	// Temporary directory where test files will be created
-	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	defer os.RemoveAll(tempBaseDir)
-	require.NoError(t, err, "failed to create a temporary directory: %s", err)
-
-	// Execute our template
-	templ, _ := template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: validPEMEncodedRSARoot})
-
-	// Unmarshal our signedroot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
-	typedSignedRoot, err := data.RootFromSigned(&testSignedRoot)
+	typedSignedRoot, err := data.RootFromSigned(sampleRootData(t).rootMeta)
 	require.NoError(t, err)
 
 	// This call to trustpinning.ValidateRoot should fail due to an incorrect cert ID
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {"ABSOLUTELY NOT A CERT ID"}}, DisableTOFU: true})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {"ABSOLUTELY NOT A CERT ID"}}, DisableTOFU: true})
 	require.Error(t, err)
 
 	// This call to trustpinning.ValidateRoot should fail due to an empty cert ID
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {""}}, DisableTOFU: true})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {""}}, DisableTOFU: true})
 	require.Error(t, err)
 
 	// This call to trustpinning.ValidateRoot should fail due to an invalid GUN (even though the cert ID is correct), and TOFUS is set to false
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"not_a_gun": {rootPubKeyID}}, DisableTOFU: true})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{Certs: map[string][]string{"not_a_gun": {sampleRootData(t).rootPubKeyID}}, DisableTOFU: true})
 	require.Error(t, err)
 
 	// This call to trustpinning.ValidateRoot should fail due to an invalid cert ID, even though it's a valid key ID for targets
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {targetsPubKeyID}}, DisableTOFU: true})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {sampleRootData(t).targetsPubkeyID}}, DisableTOFU: true})
 	require.Error(t, err)
 
 	// This call to trustpinning.ValidateRoot should succeed because we fall through to TOFUS because we have no matching GUNs under Certs
-	validatedRoot, err := trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"not_a_gun": {rootPubKeyID}}, DisableTOFU: false})
+	validatedRoot, err := trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{Certs: map[string][]string{"not_a_gun": {sampleRootData(t).rootPubKeyID}}, DisableTOFU: false})
 	require.NoError(t, err)
 	typedSignedRoot.Signatures[0].IsValid = true
 	require.Equal(t, typedSignedRoot, validatedRoot)
 }
 
 func TestValidateRootWithPinnedCA(t *testing.T) {
-	var testSignedRoot data.Signed
-	var signedRootBytes bytes.Buffer
-
 	// Temporary directory where test files will be created
 	tempBaseDir, err := ioutil.TempDir("", "notary-test-")
-	defer os.RemoveAll(tempBaseDir)
 	require.NoError(t, err, "failed to create a temporary directory: %s", err)
+	defer os.RemoveAll(tempBaseDir)
 
-	templ, _ := template.New("SignedRSARootTemplate").Parse(signedRSARootTemplate)
-	templ.Execute(&signedRootBytes, SignedRSARootTemplate{RootPem: validPEMEncodedRSARoot})
-	// Unmarshal our signedRoot
-	json.Unmarshal(signedRootBytes.Bytes(), &testSignedRoot)
-	typedSignedRoot, err := data.RootFromSigned(&testSignedRoot)
+	typedSignedRoot, err := data.RootFromSigned(sampleRootData(t).rootMeta)
 	require.NoError(t, err)
 
 	// This call to trustpinning.ValidateRoot will fail because we have an invalid path for the CA
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{CA: map[string]string{"docker.com/notary": filepath.Join(tempBaseDir, "nonexistent")}})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{CA: map[string]string{"docker.com/notary": filepath.Join(tempBaseDir, "nonexistent")}})
 	require.Error(t, err)
 
 	// This call to trustpinning.ValidateRoot will fail because we have no valid GUNs to use, and TOFUS is disabled
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{CA: map[string]string{"othergun": filepath.Join(tempBaseDir, "nonexistent")}, DisableTOFU: true})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{CA: map[string]string{"othergun": filepath.Join(tempBaseDir, "nonexistent")}, DisableTOFU: true})
 	require.Error(t, err)
 
 	// This call to trustpinning.ValidateRoot will succeed because we have no valid GUNs to use and we fall back to enabled TOFUS
-	validatedRoot, err := trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{CA: map[string]string{"othergun": filepath.Join(tempBaseDir, "nonexistent")}, DisableTOFU: false})
+	validatedRoot, err := trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{CA: map[string]string{"othergun": filepath.Join(tempBaseDir, "nonexistent")}, DisableTOFU: false})
 	require.NoError(t, err)
 	typedSignedRoot.Signatures[0].IsValid = true
 	require.Equal(t, typedSignedRoot, validatedRoot)
@@ -511,13 +564,18 @@ func TestValidateRootWithPinnedCA(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(invalidCAFilepath, []byte("ABSOLUTELY NOT A PEM"), 0644))
 
 	// Using this invalid CA cert should fail on trustpinning.ValidateRoot
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{CA: map[string]string{"docker.com/notary": invalidCAFilepath}, DisableTOFU: true})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{CA: map[string]string{"docker.com/notary": invalidCAFilepath}, DisableTOFU: true})
 	require.Error(t, err)
 
 	validCAFilepath := "../fixtures/root-ca.crt"
 
 	// If we pass an invalid Certs entry in addition to this valid CA entry, since Certs has priority for pinning we will fail
-	_, err = trustpinning.ValidateRoot(nil, &testSignedRoot, "docker.com/notary", trustpinning.TrustPinConfig{Certs: map[string][]string{"docker.com/notary": {"invalidID"}}, CA: map[string]string{"docker.com/notary": validCAFilepath}, DisableTOFU: true})
+	_, err = trustpinning.ValidateRoot(nil, sampleRootData(t).rootMeta, "docker.com/notary",
+		trustpinning.TrustPinConfig{
+			Certs:       map[string][]string{"docker.com/notary": {"invalidID"}},
+			CA:          map[string]string{"docker.com/notary": validCAFilepath},
+			DisableTOFU: true})
 	require.Error(t, err)
 
 	// Now construct a new root with a valid cert chain, such that signatures are correct over the 'notary-signer' GUN.  Pin the root-ca and validate

--- a/vendor.conf
+++ b/vendor.conf
@@ -19,7 +19,6 @@ github.com/prometheus/client_golang 449ccefff16c8e2b7229f6be1921ba22f62461fe
 github.com/golang/protobuf          c3cefd437628a0b7d31b34fe44b3a7a540e98527
 github.com/spf13/cobra              f368244301305f414206f889b1735a54cfc8bde8
 github.com/spf13/viper              be5ff3e4840cf692388bde7a057595a474ef379e
-github.com/stretchr/testify         089c7181b8c728499929ff09b62d3fdd8df8adff
 golang.org/x/crypto                 5bcd134fee4dd1475da17714aac19c0aa0142e2f
 golang.org/x/net                    6a513affb38dc9788b449d59ffed099b8de18fa0
 google.golang.org/grpc              v1.0.5
@@ -29,3 +28,8 @@ gopkg.in/dancannon/gorethink.v3     v3.0.0
 # dependencies of gorethink.v3
 gopkg.in/gorethink/gorethink.v2     v2.2.2
 github.com/cenk/backoff             v1.0.0
+
+# Testing requirements
+github.com/stretchr/testify                     089c7181b8c728499929ff09b62d3fdd8df8adff
+github.com/cloudflare/cfssl                     7fb22c8cba7ecaf98e4082d22d65800cf45e042a
+github.com/google/certificate-transparency      0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341

--- a/vendor/github.com/cloudflare/cfssl/LICENSE
+++ b/vendor/github.com/cloudflare/cfssl/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2014 CloudFlare Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/cloudflare/cfssl/README.md
+++ b/vendor/github.com/cloudflare/cfssl/README.md
@@ -1,0 +1,438 @@
+# CFSSL
+
+[![Build Status](https://travis-ci.org/cloudflare/cfssl.svg?branch=master)](https://travis-ci.org/cloudflare/cfssl)
+[![Coverage Status](http://codecov.io/github/cloudflare/cfssl/coverage.svg?branch=master)](http://codecov.io/github/cloudflare/cfssl?branch=master)
+[![GoDoc](https://godoc.org/github.com/cloudflare/cfssl?status.svg)](https://godoc.org/github.com/cloudflare/cfssl)
+
+## CloudFlare's PKI/TLS toolkit
+
+CFSSL is CloudFlare's PKI/TLS swiss army knife. It is both a command line
+tool and an HTTP API server for signing, verifying, and bundling TLS
+certificates. It requires Go 1.5+ to build.
+
+Note that certain linux distributions have certain algorithms removed
+(RHEL-based distributions in particular), so the golang from the
+official repositories will not work. Users of these distributions should
+[install go manually](//golang.org/dl) to install CFSSL.
+
+CFSSL consists of:
+
+* a set of packages useful for building custom TLS PKI tools
+* the `cfssl` program, which is the canonical command line utility
+  using the CFSSL packages.
+* the `multirootca` program, which is a certificate authority server
+  that can use multiple signing keys.
+* the `mkbundle` program is used to build certificate pool bundles.
+* the `cfssljson` program, which takes the JSON output from the
+  `cfssl` and `multirootca` programs and writes certificates, keys,
+  CSRs, and bundles to disk.
+
+### Building
+
+See [BUILDING](BUILDING.md)
+
+### Installation
+
+Installation requires a
+[working Go 1.5+ installation](http://golang.org/doc/install) and a
+properly set `GOPATH`.
+
+```
+$ go get -u github.com/cloudflare/cfssl/cmd/cfssl
+```
+
+will download and build the CFSSL tool, installing it in
+`$GOPATH/bin/cfssl`. To install the other utility programs that are in
+this repo:
+
+```
+$ go get -u github.com/cloudflare/cfssl/cmd/...
+```
+
+This will download, build, and install `cfssl`, `cfssljson`, and
+`mkbundle` into `$GOPATH/bin/`.
+
+Note that CFSSL makes use of vendored packages; in Go 1.5, the
+`GO15VENDOREXPERIMENT` environment variable will need to be set, e.g.
+
+```
+export GO15VENDOREXPERIMENT=1
+```
+
+In Go 1.6, this works out of the box.
+
+#### Installing pre-Go 1.5
+With a Go 1.4 or earlier installation, you won't be able to install the latest version of CFSSL. However, you can checkout the `1.1.0` release and build that.
+
+```
+git clone -b 1.1.0 https://github.com/cloudflare/cfssl.git $GOPATH/src/github.com/cloudflare/cfssl
+go get github.com/cloudflare/cfssl/cmd/cfssl
+```
+
+### Using the Command Line Tool
+
+The `cfssl` command line tool takes a command to specify what
+operation it should carry out:
+
+       sign             signs a certificate
+       bundle           build a certificate bundle
+       genkey           generate a private key and a certificate request
+       gencert          generate a private key and a certificate
+       serve            start the API server
+       version          prints out the current version
+       selfsign         generates a self-signed certificate
+       print-defaults	print default configurations
+
+Use "cfssl [command] -help" to find out more about a command.
+The version command takes no arguments.
+
+#### Signing
+
+```
+cfssl sign [-ca cert] [-ca-key key] [-hostname comma,separated,hostnames] csr [subject]
+```
+
+The csr is the client's certificate request. The `-ca` and `-ca-key`
+flags are the CA's certificate and private key, respectively. By
+default, they are "ca.pem" and "ca_key.pem". The `-hostname` is
+a comma separated hostname list that overrides the DNS names and
+IP address in the certificate SAN extension.
+For example, assuming the CA's private key is in
+`/etc/ssl/private/cfssl_key.pem` and the CA's certificate is in
+`/etc/ssl/certs/cfssl.pem`, to sign the `cloudflare.pem` certificate
+for cloudflare.com:
+
+```
+cfssl sign -ca /etc/ssl/certs/cfssl.pem \
+           -ca-key /etc/ssl/private/cfssl_key.pem \
+           -hostname cloudflare.com ./cloudflare.pem
+```
+
+It is also possible to specify csr through '-csr' flag. By doing so,
+flag values take precedence and will overwrite the argument.
+
+The subject is an optional file that contains subject information that
+should be used in place of the information from the CSR. It should be
+a JSON file with the type:
+
+```json
+{
+    "CN": "example.com",
+    "names": [
+        {
+            "C": "US",
+            "L": "San Francisco",
+            "O": "Internet Widgets, Inc.",
+            "OU": "WWW",
+            "ST": "California"
+        }
+    ]
+}
+```
+
+#### Bundling
+
+```
+cfssl bundle [-ca-bundle bundle] [-int-bundle bundle] \
+             [-metadata metadata_file] [-flavor bundle_flavor] \
+             -cert certificate_file [-key key_file]
+```
+
+The bundles are used for the root and intermediate certificate
+pools. In addition, platform metadata is specified through '-metadata'
+The bundle files, metadata file (and auxiliary files) can be
+found at [cfssl_trust](https://github.com/cloudflare/cfssl_trust)
+
+
+Specify PEM-encoded client certificate and key through '-cert' and
+'-key' respectively. If key is specified, the bundle will be built
+and verified with the key. Otherwise the bundle will be built
+without a private key. Instead of file path, use '-' for reading
+certificate PEM from stdin. It is also acceptable the certificate
+file contains a (partial) certificate bundle.
+
+Specify bundling flavor through '-flavor'. There are three flavors:
+'optimal' to generate a bundle of shortest chain and most advanced
+cryptographic algorithms, 'ubiquitous' to generate a bundle of most
+widely acceptance across different browsers and OS platforms, and
+'force' to find an acceptable bundle which is identical to the
+content of the input certificate file.
+
+Alternatively, the client certificate can be pulled directly from
+a domain. It is also possible to connect to the remote address
+through '-ip'.
+
+```
+cfssl bundle [-ca-bundle bundle] [-int-bundle bundle] \
+             [-metadata metadata_file] [-flavor bundle_flavor] \
+             -domain domain_name [-ip ip_address]
+```
+
+The bundle output form should follow the example
+
+```json
+{
+    "bundle": "CERT_BUNDLE_IN_PEM",
+    "crt": "LEAF_CERT_IN_PEM",
+    "crl_support": true,
+    "expires": "2015-12-31T23:59:59Z",
+    "hostnames": ["example.com"],
+    "issuer": "ISSUER CERT SUBJECT",
+    "key": "KEY_IN_PEM",
+    "key_size": 2048,
+    "key_type": "2048-bit RSA",
+    "ocsp": ["http://ocsp.example-ca.com"],
+    "ocsp_support": true,
+    "root": "ROOT_CA_CERT_IN_PEM",
+    "signature": "SHA1WithRSA",
+    "subject": "LEAF CERT SUBJECT",
+    "status": {
+        "rebundled": false,
+        "expiring_SKIs": [],
+        "untrusted_root_stores": [],
+        "messages": [],
+        "code": 0
+    }
+}
+```
+
+
+#### Generating certificate signing request and private key
+
+```
+cfssl genkey csr.json
+```
+
+To generate a private key and corresponding certificate request, specify
+the key request as a JSON file. This file should follow the form
+
+```json
+{
+    "hosts": [
+        "example.com",
+        "www.example.com"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "US",
+            "L": "San Francisco",
+            "O": "Internet Widgets, Inc.",
+            "OU": "WWW",
+            "ST": "California"
+        }
+    ]
+}
+```
+
+#### Generating self-signed root CA certificate and private key
+
+```
+cfssl genkey -initca csr.json | cfssljson -bare ca
+```
+
+To generate a self-signed root CA certificate, specify the key request as
+the JSON file in the same format as in 'genkey'. Three PEM-encoded entities
+will appear in the output: the private key, the csr, and the self-signed
+certificate.
+
+#### Generating a remote-issued certificate and private key.
+
+```
+cfssl gencert -remote=remote_server [-hostname=comma,separated,hostnames] csr.json
+```
+
+This is calls genkey, but has a remote CFSSL server sign and issue
+a certificate. You may use `-hostname` to override certificate SANs.
+
+#### Generating a local-issued certificate and private key.
+
+```
+cfssl gencert -ca cert -ca-key key [-hostname=comma,separated,hostnames] csr.json
+```
+
+This is generates and issues a certificate and private key from a local CA
+via a JSON request. You may use `-hostname` to override certificate SANs.
+
+
+#### Updating a OCSP responses file with a newly issued certificate
+
+```
+cfssl ocspsign -ca cert -responder key -responder-key key -cert cert \
+ | cfssljson -bare -stdout >> responses
+```
+
+This will generate a OCSP response for the `cert` and add it to the
+`responses` file. You can then pass `responses` to `ocspserve` to start a
+OCSP server.
+
+### Starting the API Server
+
+CFSSL comes with an HTTP-based API server; the endpoints are
+documented in `doc/api.txt`. The server is started with the "serve"
+command:
+
+```
+cfssl serve [-address address] [-ca cert] [-ca-bundle bundle] \
+            [-ca-key key] [-int-bundle bundle] [-int-dir dir] [-port port] \
+            [-metadata file] [-remote remote_host] [-config config] \
+            [-responder cert] [-responder-key key] [-db-config db-config]
+```
+
+Address and port default to "127.0.0.1:8888". The `-ca` and `-ca-key`
+arguments should be the PEM-encoded certificate and private key to use
+for signing; by default, they are "ca.pem" and "ca_key.pem". The
+`-ca-bundle` and `-int-bundle` should be the certificate bundles used
+for the root and intermediate certificate pools, respectively. These
+default to "ca-bundle.crt" and "int-bundle." If the "remote" option is
+provided, all signature operations will be forwarded to the remote CFSSL.
+
+'-int-dir' specifies intermediates directory. '-metadata' is a file for
+root certificate presence. The content of the file is a json dictionary 
+(k,v): each key k is SHA-1 digest of a root certificate while value v 
+is a list of key store filenames. '-config' specifies path to configuration
+file. '-responder' and  '-responder-key' are Certificate for OCSP responder
+and private key for OCSP responder certificate, respectively.
+
+The amount of logging can be controlled with the `-loglevel` option. This
+comes *after* the serve command:
+
+```
+cfssl serve -loglevel 2
+```
+
+The levels are:
+
+* 0. DEBUG
+* 1. INFO (this is the default level)
+* 2. WARNING
+* 3. ERROR
+* 4. CRITICAL
+
+### The multirootca
+
+The `cfssl` program can act as an online certificate authority, but it
+only uses a single key. If multiple signing keys are needed, the
+`multirootca` program can be used. It only provides the sign,
+authsign, and info endpoints. The documentation contains instructions
+for configuring and running the CA.
+
+### The mkbundle Utility
+
+`mkbundle` is used to build the root and intermediate bundles used in
+verifying certificates. It can be installed with
+
+```
+go get -u github.com/cloudflare/cfssl/cmd/mkbundle
+```
+
+It takes a collection of certificates, checks for CRL revocation (OCSP
+support is planned for the next release) and expired certificates, and
+bundles them into one file. It takes directories of certificates and
+certificate files (which may contain multiple certificates). For example,
+if the directory `intermediates` contains a number of intermediate
+certificates,
+
+```
+mkbundle -f int-bundle.crt intermediates
+```
+
+will check those certificates and combine valid ones into a single
+`int-bundle.crt` file.
+
+The `-f` flag specifies an output name; `-loglevel` specifies the verbosity
+of the logging (using the same loglevels above), and `-nw` controls the
+number of revocation-checking workers.
+
+### The cfssljson Utility
+
+Most of the output from `cfssl` is in JSON. The `cfssljson` will take
+this output and split it out into separate key, certificate, CSR, and
+bundle files as appropriate. The tool takes a single flag, `-f`, that
+specifies the input file, and an argument that specifies the base name for
+the files produced. If the input filename is "-" (which is the default),
+`cfssljson` reads from standard input. It maps keys in the JSON file to
+filenames in the following way:
+
+* if there is a "cert" (or if not, if there's a "certificate") field, the
+  file "basename.pem" will be produced.
+* if there is a "key" (or if not, if there's a "private_key") field, the
+  file "basename-key.pem" will be produced.
+* if there is a "csr" (or if not, if there's a "certificate_request") field,
+  the file "basename.csr" will be produced.
+* if there is a "bundle" field, the file "basename-bundle.pem" will
+  be produced.
+* if there is a "ocspResponse" field, the file "basename-response.der" will
+  be produced.
+
+Instead of saving to a file, you can pass `-stdout` to output the encoded
+contents.
+
+### Static Builds
+
+By default, the web assets are accessed from disk, based on their
+relative locations.  If you’re wishing to distribute a single,
+statically-linked, cfssl binary, you’ll want to embed these resources
+before building.  This can by done with the
+[go.rice](https://github.com/GeertJohan/go.rice) tool.
+
+```
+pushd cli/serve && rice embed-go && popd
+```
+
+Then building with `go build` will use the embedded resources.
+
+### Using a PKCS#11 hardware token / HSM
+
+For better security, you may want to store your private key in an HSM or
+smartcard. The interface to both of these categories of device is described by
+the PKCS#11 spec. If you need to do approximately one signing operation per
+second or fewer, the Yubikey NEO and NEO-n are inexpensive smartcard options:
+https://www.yubico.com/products/yubikey-hardware/yubikey-neo/. In general you
+are looking for a product that supports PIV (personal identity verification). If
+your signing needs are in the hundreds of signatures per second, you will need
+to purchase an expensive HSM (in the thousands to many thousands of USD).
+
+If you want to try out the PKCS#11 signing modes without a hardware token, you
+can use the [SoftHSM](https://github.com/opendnssec/SoftHSMv1#softhsm)
+implementation. Please note that using SoftHSM simply stores your private key in
+a file on disk and does not increase security.
+
+To get started with your PKCS#11 token you will need to initialize it with a
+private key, PIN, and token label. The instructions to do this will be specific
+to each hardware device, and you should follow the instructions provided by your
+vendor. You will also need to find the path to your 'module', a shared object
+file (.so). Having initialized your device, you can query it to check your token
+label with:
+
+    pkcs11-tool --module <module path> --list-token-slots
+
+You'll also want to check the label of the private key you imported (or
+generated). Run the following command and look for a 'Private Key Object':
+
+    pkcs11-tool --module <module path> --pin <pin> \
+      --list-token-slots --login --list-objects
+
+You now have all the information you need to use your PKCS#11 token with CFSSL.
+CFSSL supports PKCS#11 for certificate signing and OCSP signing. To create a
+Signer (for certificate signing), import `signer/universal` and call NewSigner
+with a Root object containing the module, pin, token label and private label
+from above, plus a path to your certificate. The structure of the Root object is
+documented in universal.go.
+
+Alternately, you can construct a pkcs11key.Key or pkcs11key.Pool yourself, and
+pass it to ocsp.NewSigner (for OCSP) or local.NewSigner (for certificate
+signing). This will be necessary, for example, if you are using a single-session
+token like the Yubikey and need both OCSP signing and certificate signing at the
+same time.
+
+### Additional Documentation
+
+Additional documentation can be found in the "doc/" directory:
+
+* `api.txt`: documents the API endpoints
+* `bootstrap.txt`: a walkthrough from building the package to getting
+  up and running

--- a/vendor/github.com/cloudflare/cfssl/auth/auth.go
+++ b/vendor/github.com/cloudflare/cfssl/auth/auth.go
@@ -1,0 +1,94 @@
+// Package auth implements an interface for providing CFSSL
+// authentication. This is meant to authenticate a client CFSSL to a
+// remote CFSSL in order to prevent unauthorised use of the signature
+// capabilities. This package provides both the interface and a
+// standard HMAC-based implementation.
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// An AuthenticatedRequest contains a request and authentication
+// token. The Provider may determine whether to validate the timestamp
+// and remote address.
+type AuthenticatedRequest struct {
+	// An Authenticator decides whether to use this field.
+	Timestamp     int64  `json:"timestamp,omitempty"`
+	RemoteAddress []byte `json:"remote_address,omitempty"`
+	Token         []byte `json:"token"`
+	Request       []byte `json:"request"`
+}
+
+// A Provider can generate tokens from a request and verify a
+// request. The handling of additional authentication data (such as
+// the IP address) is handled by the concrete type, as is any
+// serialisation and state-keeping.
+type Provider interface {
+	Token(req []byte) (token []byte, err error)
+	Verify(aReq *AuthenticatedRequest) bool
+}
+
+// Standard implements an HMAC-SHA-256 authentication provider. It may
+// be supplied additional data at creation time that will be used as
+// request || additional-data with the HMAC.
+type Standard struct {
+	key []byte
+	ad  []byte
+}
+
+// New generates a new standard authentication provider from the key
+// and additional data. The additional data will be used when
+// generating a new token.
+func New(key string, ad []byte) (*Standard, error) {
+	if splitKey := strings.SplitN(key, ":", 2); len(splitKey) == 2 {
+		switch splitKey[0] {
+		case "env":
+			key = os.Getenv(splitKey[1])
+		case "file":
+			data, err := ioutil.ReadFile(splitKey[1])
+			if err != nil {
+				return nil, err
+			}
+			key = string(data)
+		default:
+			return nil, fmt.Errorf("unknown key prefix: %s", splitKey[0])
+		}
+	}
+
+	keyBytes, err := hex.DecodeString(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Standard{keyBytes, ad}, nil
+}
+
+// Token generates a new authentication token from the request.
+func (p Standard) Token(req []byte) (token []byte, err error) {
+	h := hmac.New(sha256.New, p.key)
+	h.Write(req)
+	h.Write(p.ad)
+	return h.Sum(nil), nil
+}
+
+// Verify determines whether an authenticated request is valid.
+func (p Standard) Verify(ad *AuthenticatedRequest) bool {
+	if ad == nil {
+		return false
+	}
+
+	// Standard token generation returns no error.
+	token, _ := p.Token(ad.Request)
+	if len(ad.Token) != len(token) {
+		return false
+	}
+
+	return hmac.Equal(token, ad.Token)
+}

--- a/vendor/github.com/cloudflare/cfssl/certdb/README.md
+++ b/vendor/github.com/cloudflare/cfssl/certdb/README.md
@@ -1,0 +1,75 @@
+# certdb usage
+
+Using a database enables additional functionality for existing commands when a
+db config is provided:
+
+ - `sign` and `gencert` add a certificate to the certdb after signing it
+ - `serve` enables database functionality for the sign and revoke endpoints
+
+A database is required for the following:
+
+ - `revoke` marks certificates revoked in the database with an optional reason
+ - `ocsprefresh` refreshes the table of cached OCSP responses
+ - `ocspdump` outputs cached OCSP responses in a concatenated base64-encoded format
+
+## Setup/Migration
+
+This directory stores [goose](https://bitbucket.org/liamstask/goose/) db migration scripts for various DB backends.
+Currently supported:
+ - MySQL in mysql
+ - PostgreSQL in pg
+ - SQLite in sqlite
+
+### Get goose
+
+    go get bitbucket.org/liamstask/goose/cmd/goose
+
+### Use goose to start and terminate a MySQL DB
+To start a MySQL using goose:
+
+    goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/mysql up
+
+To tear down a MySQL DB using goose
+
+    goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/mysql down
+
+Note: the administration of MySQL DB is not included. We assume
+the databases being connected to are already created and access control
+is properly handled.
+
+### Use goose to start and terminate a PostgreSQL DB
+To start a PostgreSQL using goose:
+
+    goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/pg up
+
+To tear down a PostgreSQL DB using goose
+
+    goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/pg down
+
+Note: the administration of PostgreSQL DB is not included. We assume
+the databases being connected to are already created and access control
+is properly handled.
+
+### Use goose to start and terminate a SQLite DB
+To start a SQLite DB using goose:
+
+    goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/sqlite up
+
+To tear down a SQLite DB using goose
+
+    goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/sqlite down
+
+## CFSSL Configuration
+
+Several cfssl commands take a -db-config flag. Create a file with a
+JSON dictionary:
+
+    {"driver":"sqlite3","data_source":"certs.db"}
+
+or
+
+    {"driver":"postgres","data_source":"postgres://user:password@host/db"}
+ 
+or
+
+    {"driver":"mysql","data_source":"user:password@tcp(hostname:3306)/db?parseTime=true"}

--- a/vendor/github.com/cloudflare/cfssl/certdb/certdb.go
+++ b/vendor/github.com/cloudflare/cfssl/certdb/certdb.go
@@ -1,0 +1,40 @@
+package certdb
+
+import (
+	"time"
+)
+
+// CertificateRecord encodes a certificate and its metadata
+// that will be recorded in a database.
+type CertificateRecord struct {
+	Serial    string    `db:"serial_number"`
+	AKI       string    `db:"authority_key_identifier"`
+	CALabel   string    `db:"ca_label"`
+	Status    string    `db:"status"`
+	Reason    int       `db:"reason"`
+	Expiry    time.Time `db:"expiry"`
+	RevokedAt time.Time `db:"revoked_at"`
+	PEM       string    `db:"pem"`
+}
+
+// OCSPRecord encodes a OCSP response body and its metadata
+// that will be recorded in a database.
+type OCSPRecord struct {
+	Serial string    `db:"serial_number"`
+	AKI    string    `db:"authority_key_identifier"`
+	Body   string    `db:"body"`
+	Expiry time.Time `db:"expiry"`
+}
+
+// Accessor abstracts the CRUD of certdb objects from a DB.
+type Accessor interface {
+	InsertCertificate(cr CertificateRecord) error
+	GetCertificate(serial, aki string) ([]CertificateRecord, error)
+	GetUnexpiredCertificates() ([]CertificateRecord, error)
+	RevokeCertificate(serial, aki string, reasonCode int) error
+	InsertOCSP(rr OCSPRecord) error
+	GetOCSP(serial, aki string) ([]OCSPRecord, error)
+	GetUnexpiredOCSPs() ([]OCSPRecord, error)
+	UpdateOCSP(serial, aki, body string, expiry time.Time) error
+	UpsertOCSP(serial, aki, body string, expiry time.Time) error
+}

--- a/vendor/github.com/cloudflare/cfssl/config/config.go
+++ b/vendor/github.com/cloudflare/cfssl/config/config.go
@@ -1,0 +1,659 @@
+// Package config contains the configuration logic for CFSSL.
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cloudflare/cfssl/auth"
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
+	ocspConfig "github.com/cloudflare/cfssl/ocsp/config"
+)
+
+// A CSRWhitelist stores booleans for fields in the CSR. If a CSRWhitelist is
+// not present in a SigningProfile, all of these fields may be copied from the
+// CSR into the signed certificate. If a CSRWhitelist *is* present in a
+// SigningProfile, only those fields with a `true` value in the CSRWhitelist may
+// be copied from the CSR to the signed certificate. Note that some of these
+// fields, like Subject, can be provided or partially provided through the API.
+// Since API clients are expected to be trusted, but CSRs are not, fields
+// provided through the API are not subject to whitelisting through this
+// mechanism.
+type CSRWhitelist struct {
+	Subject, PublicKeyAlgorithm, PublicKey, SignatureAlgorithm bool
+	DNSNames, IPAddresses, EmailAddresses                      bool
+}
+
+// OID is our own version of asn1's ObjectIdentifier, so we can define a custom
+// JSON marshal / unmarshal.
+type OID asn1.ObjectIdentifier
+
+// CertificatePolicy represents the ASN.1 PolicyInformation structure from
+// https://tools.ietf.org/html/rfc3280.html#page-106.
+// Valid values of Type are "id-qt-unotice" and "id-qt-cps"
+type CertificatePolicy struct {
+	ID         OID
+	Qualifiers []CertificatePolicyQualifier
+}
+
+// CertificatePolicyQualifier represents a single qualifier from an ASN.1
+// PolicyInformation structure.
+type CertificatePolicyQualifier struct {
+	Type  string
+	Value string
+}
+
+// AuthRemote is an authenticated remote signer.
+type AuthRemote struct {
+	RemoteName  string `json:"remote"`
+	AuthKeyName string `json:"auth_key"`
+}
+
+// CAConstraint specifies various CA constraints on the signed certificate.
+// CAConstraint would verify against (and override) the CA
+// extensions in the given CSR.
+type CAConstraint struct {
+	IsCA           bool `json:"is_ca"`
+	MaxPathLen     int  `json:"max_path_len"`
+	MaxPathLenZero bool `json:"max_path_len_zero"`
+}
+
+// A SigningProfile stores information that the CA needs to store
+// signature policy.
+type SigningProfile struct {
+	Usage               []string     `json:"usages"`
+	IssuerURL           []string     `json:"issuer_urls"`
+	OCSP                string       `json:"ocsp_url"`
+	CRL                 string       `json:"crl_url"`
+	CAConstraint        CAConstraint `json:"ca_constraint"`
+	OCSPNoCheck         bool         `json:"ocsp_no_check"`
+	ExpiryString        string       `json:"expiry"`
+	BackdateString      string       `json:"backdate"`
+	AuthKeyName         string       `json:"auth_key"`
+	RemoteName          string       `json:"remote"`
+	NotBefore           time.Time    `json:"not_before"`
+	NotAfter            time.Time    `json:"not_after"`
+	NameWhitelistString string       `json:"name_whitelist"`
+	AuthRemote          AuthRemote   `json:"auth_remote"`
+	CTLogServers        []string     `json:"ct_log_servers"`
+	AllowedExtensions   []OID        `json:"allowed_extensions"`
+	CertStore           string       `json:"cert_store"`
+
+	Policies                    []CertificatePolicy
+	Expiry                      time.Duration
+	Backdate                    time.Duration
+	Provider                    auth.Provider
+	RemoteProvider              auth.Provider
+	RemoteServer                string
+	RemoteCAs                   *x509.CertPool
+	ClientCert                  *tls.Certificate
+	CSRWhitelist                *CSRWhitelist
+	NameWhitelist               *regexp.Regexp
+	ExtensionWhitelist          map[string]bool
+	ClientProvidesSerialNumbers bool
+}
+
+// UnmarshalJSON unmarshals a JSON string into an OID.
+func (oid *OID) UnmarshalJSON(data []byte) (err error) {
+	if data[0] != '"' || data[len(data)-1] != '"' {
+		return errors.New("OID JSON string not wrapped in quotes." + string(data))
+	}
+	data = data[1 : len(data)-1]
+	parsedOid, err := parseObjectIdentifier(string(data))
+	if err != nil {
+		return err
+	}
+	*oid = OID(parsedOid)
+	return
+}
+
+// MarshalJSON marshals an oid into a JSON string.
+func (oid OID) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%v"`, asn1.ObjectIdentifier(oid))), nil
+}
+
+func parseObjectIdentifier(oidString string) (oid asn1.ObjectIdentifier, err error) {
+	validOID, err := regexp.MatchString("\\d(\\.\\d+)*", oidString)
+	if err != nil {
+		return
+	}
+	if !validOID {
+		err = errors.New("Invalid OID")
+		return
+	}
+
+	segments := strings.Split(oidString, ".")
+	oid = make(asn1.ObjectIdentifier, len(segments))
+	for i, intString := range segments {
+		oid[i], err = strconv.Atoi(intString)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+const timeFormat = "2006-01-02T15:04:05"
+
+// populate is used to fill in the fields that are not in JSON
+//
+// First, the ExpiryString parameter is needed to parse
+// expiration timestamps from JSON. The JSON decoder is not able to
+// decode a string time duration to a time.Duration, so this is called
+// when loading the configuration to properly parse and fill out the
+// Expiry parameter.
+// This function is also used to create references to the auth key
+// and default remote for the profile.
+// It returns true if ExpiryString is a valid representation of a
+// time.Duration, and the AuthKeyString and RemoteName point to
+// valid objects. It returns false otherwise.
+func (p *SigningProfile) populate(cfg *Config) error {
+	if p == nil {
+		return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("can't parse nil profile"))
+	}
+
+	var err error
+	if p.RemoteName == "" && p.AuthRemote.RemoteName == "" {
+		log.Debugf("parse expiry in profile")
+		if p.ExpiryString == "" {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("empty expiry string"))
+		}
+
+		dur, err := time.ParseDuration(p.ExpiryString)
+		if err != nil {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+		}
+
+		log.Debugf("expiry is valid")
+		p.Expiry = dur
+
+		if p.BackdateString != "" {
+			dur, err = time.ParseDuration(p.BackdateString)
+			if err != nil {
+				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+			}
+
+			p.Backdate = dur
+		}
+
+		if !p.NotBefore.IsZero() && !p.NotAfter.IsZero() && p.NotAfter.Before(p.NotBefore) {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+		}
+
+		if len(p.Policies) > 0 {
+			for _, policy := range p.Policies {
+				for _, qualifier := range policy.Qualifiers {
+					if qualifier.Type != "" && qualifier.Type != "id-qt-unotice" && qualifier.Type != "id-qt-cps" {
+						return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+							errors.New("invalid policy qualifier type"))
+					}
+				}
+			}
+		}
+	} else if p.RemoteName != "" {
+		log.Debug("match remote in profile to remotes section")
+		if p.AuthRemote.RemoteName != "" {
+			log.Error("profile has both a remote and an auth remote specified")
+			return cferr.New(cferr.PolicyError, cferr.InvalidPolicy)
+		}
+		if remote := cfg.Remotes[p.RemoteName]; remote != "" {
+			if err := p.updateRemote(remote); err != nil {
+				return err
+			}
+		} else {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+				errors.New("failed to find remote in remotes section"))
+		}
+	} else {
+		log.Debug("match auth remote in profile to remotes section")
+		if remote := cfg.Remotes[p.AuthRemote.RemoteName]; remote != "" {
+			if err := p.updateRemote(remote); err != nil {
+				return err
+			}
+		} else {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+				errors.New("failed to find remote in remotes section"))
+		}
+	}
+
+	if p.AuthKeyName != "" {
+		log.Debug("match auth key in profile to auth_keys section")
+		if key, ok := cfg.AuthKeys[p.AuthKeyName]; ok == true {
+			if key.Type == "standard" {
+				p.Provider, err = auth.New(key.Key, nil)
+				if err != nil {
+					log.Debugf("failed to create new standard auth provider: %v", err)
+					return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+						errors.New("failed to create new standard auth provider"))
+				}
+			} else {
+				log.Debugf("unknown authentication type %v", key.Type)
+				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+					errors.New("unknown authentication type"))
+			}
+		} else {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+				errors.New("failed to find auth_key in auth_keys section"))
+		}
+	}
+
+	if p.AuthRemote.AuthKeyName != "" {
+		log.Debug("match auth remote key in profile to auth_keys section")
+		if key, ok := cfg.AuthKeys[p.AuthRemote.AuthKeyName]; ok == true {
+			if key.Type == "standard" {
+				p.RemoteProvider, err = auth.New(key.Key, nil)
+				if err != nil {
+					log.Debugf("failed to create new standard auth provider: %v", err)
+					return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+						errors.New("failed to create new standard auth provider"))
+				}
+			} else {
+				log.Debugf("unknown authentication type %v", key.Type)
+				return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+					errors.New("unknown authentication type"))
+			}
+		} else {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+				errors.New("failed to find auth_remote's auth_key in auth_keys section"))
+		}
+	}
+
+	if p.NameWhitelistString != "" {
+		log.Debug("compiling whitelist regular expression")
+		rule, err := regexp.Compile(p.NameWhitelistString)
+		if err != nil {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+				errors.New("failed to compile name whitelist section"))
+		}
+		p.NameWhitelist = rule
+	}
+
+	p.ExtensionWhitelist = map[string]bool{}
+	for _, oid := range p.AllowedExtensions {
+		p.ExtensionWhitelist[asn1.ObjectIdentifier(oid).String()] = true
+	}
+
+	return nil
+}
+
+// updateRemote takes a signing profile and initializes the remote server object
+// to the hostname:port combination sent by remote.
+func (p *SigningProfile) updateRemote(remote string) error {
+	if remote != "" {
+		p.RemoteServer = remote
+	}
+	return nil
+}
+
+// OverrideRemotes takes a signing configuration and updates the remote server object
+// to the hostname:port combination sent by remote
+func (p *Signing) OverrideRemotes(remote string) error {
+	if remote != "" {
+		var err error
+		for _, profile := range p.Profiles {
+			err = profile.updateRemote(remote)
+			if err != nil {
+				return err
+			}
+		}
+		err = p.Default.updateRemote(remote)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetClientCertKeyPairFromFile updates the properties to set client certificates for mutual
+// authenticated TLS remote requests
+func (p *Signing) SetClientCertKeyPairFromFile(certFile string, keyFile string) error {
+	if certFile != "" && keyFile != "" {
+		cert, err := helpers.LoadClientCertificate(certFile, keyFile)
+		if err != nil {
+			return err
+		}
+		for _, profile := range p.Profiles {
+			profile.ClientCert = cert
+		}
+		p.Default.ClientCert = cert
+	}
+	return nil
+}
+
+// SetRemoteCAsFromFile reads root CAs from file and updates the properties to set remote CAs for TLS
+// remote requests
+func (p *Signing) SetRemoteCAsFromFile(caFile string) error {
+	if caFile != "" {
+		remoteCAs, err := helpers.LoadPEMCertPool(caFile)
+		if err != nil {
+			return err
+		}
+		p.SetRemoteCAs(remoteCAs)
+	}
+	return nil
+}
+
+// SetRemoteCAs updates the properties to set remote CAs for TLS
+// remote requests
+func (p *Signing) SetRemoteCAs(remoteCAs *x509.CertPool) {
+	for _, profile := range p.Profiles {
+		profile.RemoteCAs = remoteCAs
+	}
+	p.Default.RemoteCAs = remoteCAs
+}
+
+// NeedsRemoteSigner returns true if one of the profiles has a remote set
+func (p *Signing) NeedsRemoteSigner() bool {
+	for _, profile := range p.Profiles {
+		if profile.RemoteServer != "" {
+			return true
+		}
+	}
+
+	if p.Default.RemoteServer != "" {
+		return true
+	}
+
+	return false
+}
+
+// NeedsLocalSigner returns true if one of the profiles doe not have a remote set
+func (p *Signing) NeedsLocalSigner() bool {
+	for _, profile := range p.Profiles {
+		if profile.RemoteServer == "" {
+			return true
+		}
+	}
+
+	if p.Default.RemoteServer == "" {
+		return true
+	}
+
+	return false
+}
+
+// Usages parses the list of key uses in the profile, translating them
+// to a list of X.509 key usages and extended key usages.  The unknown
+// uses are collected into a slice that is also returned.
+func (p *SigningProfile) Usages() (ku x509.KeyUsage, eku []x509.ExtKeyUsage, unk []string) {
+	for _, keyUse := range p.Usage {
+		if kuse, ok := KeyUsage[keyUse]; ok {
+			ku |= kuse
+		} else if ekuse, ok := ExtKeyUsage[keyUse]; ok {
+			eku = append(eku, ekuse)
+		} else {
+			unk = append(unk, keyUse)
+		}
+	}
+	return
+}
+
+// A valid profile must be a valid local profile or a valid remote profile.
+// A valid local profile has defined at least key usages to be used, and a
+// valid local default profile has defined at least a default expiration.
+// A valid remote profile (default or not) has remote signer initialized.
+// In addition, a remote profile must has a valid auth provider if auth
+// key defined.
+func (p *SigningProfile) validProfile(isDefault bool) bool {
+	if p == nil {
+		return false
+	}
+
+	if p.AuthRemote.RemoteName == "" && p.AuthRemote.AuthKeyName != "" {
+		log.Debugf("invalid auth remote profile: no remote signer specified")
+		return false
+	}
+
+	if p.RemoteName != "" {
+		log.Debugf("validate remote profile")
+
+		if p.RemoteServer == "" {
+			log.Debugf("invalid remote profile: no remote signer specified")
+			return false
+		}
+
+		if p.AuthKeyName != "" && p.Provider == nil {
+			log.Debugf("invalid remote profile: auth key name is defined but no auth provider is set")
+			return false
+		}
+
+		if p.AuthRemote.RemoteName != "" {
+			log.Debugf("invalid remote profile: auth remote is also specified")
+			return false
+		}
+	} else if p.AuthRemote.RemoteName != "" {
+		log.Debugf("validate auth remote profile")
+		if p.RemoteServer == "" {
+			log.Debugf("invalid auth remote profile: no remote signer specified")
+			return false
+		}
+
+		if p.AuthRemote.AuthKeyName == "" || p.RemoteProvider == nil {
+			log.Debugf("invalid auth remote profile: no auth key is defined")
+			return false
+		}
+	} else {
+		log.Debugf("validate local profile")
+		if !isDefault {
+			if len(p.Usage) == 0 {
+				log.Debugf("invalid local profile: no usages specified")
+				return false
+			} else if _, _, unk := p.Usages(); len(unk) == len(p.Usage) {
+				log.Debugf("invalid local profile: no valid usages")
+				return false
+			}
+		} else {
+			if p.Expiry == 0 {
+				log.Debugf("invalid local profile: no expiry set")
+				return false
+			}
+		}
+	}
+
+	log.Debugf("profile is valid")
+	return true
+}
+
+// This checks if the SigningProfile object contains configurations that are only effective with a local signer
+// which has access to CA private key.
+func (p *SigningProfile) hasLocalConfig() bool {
+	if p.Usage != nil ||
+		p.IssuerURL != nil ||
+		p.OCSP != "" ||
+		p.ExpiryString != "" ||
+		p.BackdateString != "" ||
+		p.CAConstraint.IsCA != false ||
+		!p.NotBefore.IsZero() ||
+		!p.NotAfter.IsZero() ||
+		p.NameWhitelistString != "" ||
+		len(p.CTLogServers) != 0 {
+		return true
+	}
+	return false
+}
+
+// warnSkippedSettings prints a log warning message about skipped settings
+// in a SigningProfile, usually due to remote signer.
+func (p *Signing) warnSkippedSettings() {
+	const warningMessage = `The configuration value by "usages", "issuer_urls", "ocsp_url", "crl_url", "ca_constraint", "expiry", "backdate", "not_before", "not_after", "cert_store" and "ct_log_servers" are skipped`
+	if p == nil {
+		return
+	}
+
+	if (p.Default.RemoteName != "" || p.Default.AuthRemote.RemoteName != "") && p.Default.hasLocalConfig() {
+		log.Warning("default profile points to a remote signer: ", warningMessage)
+	}
+
+	for name, profile := range p.Profiles {
+		if (profile.RemoteName != "" || profile.AuthRemote.RemoteName != "") && profile.hasLocalConfig() {
+			log.Warningf("Profiles[%s] points to a remote signer: %s", name, warningMessage)
+		}
+	}
+}
+
+// Signing codifies the signature configuration policy for a CA.
+type Signing struct {
+	Profiles map[string]*SigningProfile `json:"profiles"`
+	Default  *SigningProfile            `json:"default"`
+}
+
+// Config stores configuration information for the CA.
+type Config struct {
+	Signing  *Signing           `json:"signing"`
+	OCSP     *ocspConfig.Config `json:"ocsp"`
+	AuthKeys map[string]AuthKey `json:"auth_keys,omitempty"`
+	Remotes  map[string]string  `json:"remotes,omitempty"`
+}
+
+// Valid ensures that Config is a valid configuration. It should be
+// called immediately after parsing a configuration file.
+func (c *Config) Valid() bool {
+	return c.Signing.Valid()
+}
+
+// Valid checks the signature policies, ensuring they are valid
+// policies. A policy is valid if it has defined at least key usages
+// to be used, and a valid default profile has defined at least a
+// default expiration.
+func (p *Signing) Valid() bool {
+	if p == nil {
+		return false
+	}
+
+	log.Debugf("validating configuration")
+	if !p.Default.validProfile(true) {
+		log.Debugf("default profile is invalid")
+		return false
+	}
+
+	for _, sp := range p.Profiles {
+		if !sp.validProfile(false) {
+			log.Debugf("invalid profile")
+			return false
+		}
+	}
+
+	p.warnSkippedSettings()
+
+	return true
+}
+
+// KeyUsage contains a mapping of string names to key usages.
+var KeyUsage = map[string]x509.KeyUsage{
+	"signing":             x509.KeyUsageDigitalSignature,
+	"digital signature":   x509.KeyUsageDigitalSignature,
+	"content committment": x509.KeyUsageContentCommitment,
+	"key encipherment":    x509.KeyUsageKeyEncipherment,
+	"key agreement":       x509.KeyUsageKeyAgreement,
+	"data encipherment":   x509.KeyUsageDataEncipherment,
+	"cert sign":           x509.KeyUsageCertSign,
+	"crl sign":            x509.KeyUsageCRLSign,
+	"encipher only":       x509.KeyUsageEncipherOnly,
+	"decipher only":       x509.KeyUsageDecipherOnly,
+}
+
+// ExtKeyUsage contains a mapping of string names to extended key
+// usages.
+var ExtKeyUsage = map[string]x509.ExtKeyUsage{
+	"any":              x509.ExtKeyUsageAny,
+	"server auth":      x509.ExtKeyUsageServerAuth,
+	"client auth":      x509.ExtKeyUsageClientAuth,
+	"code signing":     x509.ExtKeyUsageCodeSigning,
+	"email protection": x509.ExtKeyUsageEmailProtection,
+	"s/mime":           x509.ExtKeyUsageEmailProtection,
+	"ipsec end system": x509.ExtKeyUsageIPSECEndSystem,
+	"ipsec tunnel":     x509.ExtKeyUsageIPSECTunnel,
+	"ipsec user":       x509.ExtKeyUsageIPSECUser,
+	"timestamping":     x509.ExtKeyUsageTimeStamping,
+	"ocsp signing":     x509.ExtKeyUsageOCSPSigning,
+	"microsoft sgc":    x509.ExtKeyUsageMicrosoftServerGatedCrypto,
+	"netscape sgc":     x509.ExtKeyUsageNetscapeServerGatedCrypto,
+}
+
+// An AuthKey contains an entry for a key used for authentication.
+type AuthKey struct {
+	// Type contains information needed to select the appropriate
+	// constructor. For example, "standard" for HMAC-SHA-256,
+	// "standard-ip" for HMAC-SHA-256 incorporating the client's
+	// IP.
+	Type string `json:"type"`
+	// Key contains the key information, such as a hex-encoded
+	// HMAC key.
+	Key string `json:"key"`
+}
+
+// DefaultConfig returns a default configuration specifying basic key
+// usage and a 1 year expiration time. The key usages chosen are
+// signing, key encipherment, client auth and server auth.
+func DefaultConfig() *SigningProfile {
+	d := helpers.OneYear
+	return &SigningProfile{
+		Usage:        []string{"signing", "key encipherment", "server auth", "client auth"},
+		Expiry:       d,
+		ExpiryString: "8760h",
+	}
+}
+
+// LoadFile attempts to load the configuration file stored at the path
+// and returns the configuration. On error, it returns nil.
+func LoadFile(path string) (*Config, error) {
+	log.Debugf("loading configuration file from %s", path)
+	if path == "" {
+		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("invalid path"))
+	}
+
+	body, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("could not read configuration file"))
+	}
+
+	return LoadConfig(body)
+}
+
+// LoadConfig attempts to load the configuration from a byte slice.
+// On error, it returns nil.
+func LoadConfig(config []byte) (*Config, error) {
+	var cfg = &Config{}
+	err := json.Unmarshal(config, &cfg)
+	if err != nil {
+		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy,
+			errors.New("failed to unmarshal configuration: "+err.Error()))
+	}
+
+	if cfg.Signing == nil {
+		return nil, errors.New("No \"signing\" field present")
+	}
+
+	if cfg.Signing.Default == nil {
+		log.Debugf("no default given: using default config")
+		cfg.Signing.Default = DefaultConfig()
+	} else {
+		if err := cfg.Signing.Default.populate(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	for k := range cfg.Signing.Profiles {
+		if err := cfg.Signing.Profiles[k].populate(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if !cfg.Valid() {
+		return nil, cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, errors.New("invalid configuration"))
+	}
+
+	log.Debugf("configuration ok")
+	return cfg, nil
+}

--- a/vendor/github.com/cloudflare/cfssl/crypto/pkcs7/pkcs7.go
+++ b/vendor/github.com/cloudflare/cfssl/crypto/pkcs7/pkcs7.go
@@ -1,0 +1,188 @@
+// Package pkcs7 implements the subset of the CMS PKCS #7 datatype that is typically
+// used to package certificates and CRLs.  Using openssl, every certificate converted
+// to PKCS #7 format from another encoding such as PEM conforms to this implementation.
+// reference: https://www.openssl.org/docs/apps/crl2pkcs7.html
+//
+//			PKCS #7 Data type, reference: https://tools.ietf.org/html/rfc2315
+//
+// The full pkcs#7 cryptographic message syntax allows for cryptographic enhancements,
+// for example data can be encrypted and signed and then packaged through pkcs#7 to be
+// sent over a network and then verified and decrypted.  It is asn1, and the type of
+// PKCS #7 ContentInfo, which comprises the PKCS #7 structure, is:
+//
+//			ContentInfo ::= SEQUENCE {
+//				contentType ContentType,
+//				content [0] EXPLICIT ANY DEFINED BY contentType OPTIONAL
+//			}
+//
+// There are 6 possible ContentTypes, data, signedData, envelopedData,
+// signedAndEnvelopedData, digestedData, and encryptedData.  Here signedData, Data, and encrypted
+// Data are implemented, as the degenerate case of signedData without a signature is the typical
+// format for transferring certificates and CRLS, and Data and encryptedData are used in PKCS #12
+// formats.
+// The ContentType signedData has the form:
+//
+//
+//			signedData ::= SEQUENCE {
+//				version Version,
+//				digestAlgorithms DigestAlgorithmIdentifiers,
+//				contentInfo ContentInfo,
+//				certificates [0] IMPLICIT ExtendedCertificatesAndCertificates OPTIONAL
+//				crls [1] IMPLICIT CertificateRevocationLists OPTIONAL,
+//				signerInfos SignerInfos
+//			}
+//
+// As of yet signerInfos and digestAlgorithms are not parsed, as they are not relevant to
+// this system's use of PKCS #7 data.  Version is an integer type, note that PKCS #7 is
+// recursive, this second layer of ContentInfo is similar ignored for our degenerate
+// usage.  The ExtendedCertificatesAndCertificates type consists of a sequence of choices
+// between PKCS #6 extended certificates and x509 certificates.  Any sequence consisting
+// of any number of extended certificates is not yet supported in this implementation.
+//
+// The ContentType Data is simply a raw octet string and is parsed directly into a Go []byte slice.
+//
+// The ContentType encryptedData is the most complicated and its form can be gathered by
+// the go type below.  It essentially contains a raw octet string of encrypted data and an
+// algorithm identifier for use in decrypting this data.
+package pkcs7
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+
+	cferr "github.com/cloudflare/cfssl/errors"
+)
+
+// Types used for asn1 Unmarshaling.
+
+type signedData struct {
+	Version          int
+	DigestAlgorithms asn1.RawValue
+	ContentInfo      asn1.RawValue
+	Certificates     asn1.RawValue `asn1:"optional" asn1:"tag:0"`
+	Crls             asn1.RawValue `asn1:"optional"`
+	SignerInfos      asn1.RawValue
+}
+
+type initPKCS7 struct {
+	Raw         asn1.RawContent
+	ContentType asn1.ObjectIdentifier
+	Content     asn1.RawValue `asn1:"tag:0,explicit,optional"`
+}
+
+// Object identifier strings of the three implemented PKCS7 types.
+const (
+	ObjIDData          = "1.2.840.113549.1.7.1"
+	ObjIDSignedData    = "1.2.840.113549.1.7.2"
+	ObjIDEncryptedData = "1.2.840.113549.1.7.6"
+)
+
+// PKCS7 represents the ASN1 PKCS #7 Content type.  It contains one of three
+// possible types of Content objects, as denoted by the object identifier in
+// the ContentInfo field, the other two being nil.  SignedData
+// is the degenerate SignedData Content info without signature used
+// to hold certificates and crls.  Data is raw bytes, and EncryptedData
+// is as defined in PKCS #7 standard.
+type PKCS7 struct {
+	Raw         asn1.RawContent
+	ContentInfo string
+	Content     Content
+}
+
+// Content implements three of the six possible PKCS7 data types.  Only one is non-nil.
+type Content struct {
+	Data          []byte
+	SignedData    SignedData
+	EncryptedData EncryptedData
+}
+
+// SignedData defines the typical carrier of certificates and crls.
+type SignedData struct {
+	Raw          asn1.RawContent
+	Version      int
+	Certificates []*x509.Certificate
+	Crl          *pkix.CertificateList
+}
+
+// Data contains raw bytes.  Used as a subtype in PKCS12.
+type Data struct {
+	Bytes []byte
+}
+
+// EncryptedData contains encrypted data.  Used as a subtype in PKCS12.
+type EncryptedData struct {
+	Raw                  asn1.RawContent
+	Version              int
+	EncryptedContentInfo EncryptedContentInfo
+}
+
+// EncryptedContentInfo is a subtype of PKCS7EncryptedData.
+type EncryptedContentInfo struct {
+	Raw                        asn1.RawContent
+	ContentType                asn1.ObjectIdentifier
+	ContentEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedContent           []byte `asn1:"tag:0,optional"`
+}
+
+// ParsePKCS7 attempts to parse the DER encoded bytes of a
+// PKCS7 structure.
+func ParsePKCS7(raw []byte) (msg *PKCS7, err error) {
+
+	var pkcs7 initPKCS7
+	_, err = asn1.Unmarshal(raw, &pkcs7)
+	if err != nil {
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
+	}
+
+	msg = new(PKCS7)
+	msg.Raw = pkcs7.Raw
+	msg.ContentInfo = pkcs7.ContentType.String()
+	switch {
+	case msg.ContentInfo == ObjIDData:
+		msg.ContentInfo = "Data"
+		_, err = asn1.Unmarshal(pkcs7.Content.Bytes, &msg.Content.Data)
+		if err != nil {
+			return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
+		}
+	case msg.ContentInfo == ObjIDSignedData:
+		msg.ContentInfo = "SignedData"
+		var signedData signedData
+		_, err = asn1.Unmarshal(pkcs7.Content.Bytes, &signedData)
+		if err != nil {
+			return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
+		}
+		if len(signedData.Certificates.Bytes) != 0 {
+			msg.Content.SignedData.Certificates, err = x509.ParseCertificates(signedData.Certificates.Bytes)
+			if err != nil {
+				return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
+			}
+		}
+		if len(signedData.Crls.Bytes) != 0 {
+			msg.Content.SignedData.Crl, err = x509.ParseDERCRL(signedData.Crls.Bytes)
+			if err != nil {
+				return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
+			}
+		}
+		msg.Content.SignedData.Version = signedData.Version
+		msg.Content.SignedData.Raw = pkcs7.Content.Bytes
+	case msg.ContentInfo == ObjIDEncryptedData:
+		msg.ContentInfo = "EncryptedData"
+		var encryptedData EncryptedData
+		_, err = asn1.Unmarshal(pkcs7.Content.Bytes, &encryptedData)
+		if err != nil {
+			return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
+		}
+		if encryptedData.Version != 0 {
+			return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, errors.New("Only support for PKCS #7 encryptedData version 0"))
+		}
+		msg.Content.EncryptedData = encryptedData
+
+	default:
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, errors.New("Attempt to parse PKCS# 7 Content not of type data, signed data or encrypted data"))
+	}
+
+	return msg, nil
+
+}

--- a/vendor/github.com/cloudflare/cfssl/csr/csr.go
+++ b/vendor/github.com/cloudflare/cfssl/csr/csr.go
@@ -1,0 +1,431 @@
+// Package csr implements certificate requests for CFSSL.
+package csr
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"net"
+	"net/mail"
+	"strings"
+
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
+)
+
+const (
+	curveP256 = 256
+	curveP384 = 384
+	curveP521 = 521
+)
+
+// A Name contains the SubjectInfo fields.
+type Name struct {
+	C            string // Country
+	ST           string // State
+	L            string // Locality
+	O            string // OrganisationName
+	OU           string // OrganisationalUnitName
+	SerialNumber string
+}
+
+// A KeyRequest is a generic request for a new key.
+type KeyRequest interface {
+	Algo() string
+	Size() int
+	Generate() (crypto.PrivateKey, error)
+	SigAlgo() x509.SignatureAlgorithm
+}
+
+// A BasicKeyRequest contains the algorithm and key size for a new private key.
+type BasicKeyRequest struct {
+	A string `json:"algo"`
+	S int    `json:"size"`
+}
+
+// NewBasicKeyRequest returns a default BasicKeyRequest.
+func NewBasicKeyRequest() *BasicKeyRequest {
+	return &BasicKeyRequest{"ecdsa", curveP256}
+}
+
+// Algo returns the requested key algorithm represented as a string.
+func (kr *BasicKeyRequest) Algo() string {
+	return kr.A
+}
+
+// Size returns the requested key size.
+func (kr *BasicKeyRequest) Size() int {
+	return kr.S
+}
+
+// Generate generates a key as specified in the request. Currently,
+// only ECDSA and RSA are supported.
+func (kr *BasicKeyRequest) Generate() (crypto.PrivateKey, error) {
+	log.Debugf("generate key from request: algo=%s, size=%d", kr.Algo(), kr.Size())
+	switch kr.Algo() {
+	case "rsa":
+		if kr.Size() < 2048 {
+			return nil, errors.New("RSA key is too weak")
+		}
+		if kr.Size() > 8192 {
+			return nil, errors.New("RSA key size too large")
+		}
+		return rsa.GenerateKey(rand.Reader, kr.Size())
+	case "ecdsa":
+		var curve elliptic.Curve
+		switch kr.Size() {
+		case curveP256:
+			curve = elliptic.P256()
+		case curveP384:
+			curve = elliptic.P384()
+		case curveP521:
+			curve = elliptic.P521()
+		default:
+			return nil, errors.New("invalid curve")
+		}
+		return ecdsa.GenerateKey(curve, rand.Reader)
+	default:
+		return nil, errors.New("invalid algorithm")
+	}
+}
+
+// SigAlgo returns an appropriate X.509 signature algorithm given the
+// key request's type and size.
+func (kr *BasicKeyRequest) SigAlgo() x509.SignatureAlgorithm {
+	switch kr.Algo() {
+	case "rsa":
+		switch {
+		case kr.Size() >= 4096:
+			return x509.SHA512WithRSA
+		case kr.Size() >= 3072:
+			return x509.SHA384WithRSA
+		case kr.Size() >= 2048:
+			return x509.SHA256WithRSA
+		default:
+			return x509.SHA1WithRSA
+		}
+	case "ecdsa":
+		switch kr.Size() {
+		case curveP521:
+			return x509.ECDSAWithSHA512
+		case curveP384:
+			return x509.ECDSAWithSHA384
+		case curveP256:
+			return x509.ECDSAWithSHA256
+		default:
+			return x509.ECDSAWithSHA1
+		}
+	default:
+		return x509.UnknownSignatureAlgorithm
+	}
+}
+
+// CAConfig is a section used in the requests initialising a new CA.
+type CAConfig struct {
+	PathLength  int    `json:"pathlen"`
+	PathLenZero bool   `json:"pathlenzero"`
+	Expiry      string `json:"expiry"`
+}
+
+// A CertificateRequest encapsulates the API interface to the
+// certificate request functionality.
+type CertificateRequest struct {
+	CN           string
+	Names        []Name     `json:"names"`
+	Hosts        []string   `json:"hosts"`
+	KeyRequest   KeyRequest `json:"key,omitempty"`
+	CA           *CAConfig  `json:"ca,omitempty"`
+	SerialNumber string     `json:"serialnumber,omitempty"`
+}
+
+// New returns a new, empty CertificateRequest with a
+// BasicKeyRequest.
+func New() *CertificateRequest {
+	return &CertificateRequest{
+		KeyRequest: NewBasicKeyRequest(),
+	}
+}
+
+// appendIf appends to a if s is not an empty string.
+func appendIf(s string, a *[]string) {
+	if s != "" {
+		*a = append(*a, s)
+	}
+}
+
+// Name returns the PKIX name for the request.
+func (cr *CertificateRequest) Name() pkix.Name {
+	var name pkix.Name
+	name.CommonName = cr.CN
+
+	for _, n := range cr.Names {
+		appendIf(n.C, &name.Country)
+		appendIf(n.ST, &name.Province)
+		appendIf(n.L, &name.Locality)
+		appendIf(n.O, &name.Organization)
+		appendIf(n.OU, &name.OrganizationalUnit)
+	}
+	name.SerialNumber = cr.SerialNumber
+	return name
+}
+
+// BasicConstraints CSR information RFC 5280, 4.2.1.9
+type BasicConstraints struct {
+	IsCA       bool `asn1:"optional"`
+	MaxPathLen int  `asn1:"optional,default:-1"`
+}
+
+// ParseRequest takes a certificate request and generates a key and
+// CSR from it. It does no validation -- caveat emptor. It will,
+// however, fail if the key request is not valid (i.e., an unsupported
+// curve or RSA key size). The lack of validation was specifically
+// chosen to allow the end user to define a policy and validate the
+// request appropriately before calling this function.
+func ParseRequest(req *CertificateRequest) (csr, key []byte, err error) {
+	log.Info("received CSR")
+	if req.KeyRequest == nil {
+		req.KeyRequest = NewBasicKeyRequest()
+	}
+
+	log.Infof("generating key: %s-%d", req.KeyRequest.Algo(), req.KeyRequest.Size())
+	priv, err := req.KeyRequest.Generate()
+	if err != nil {
+		err = cferr.Wrap(cferr.PrivateKeyError, cferr.GenerationFailed, err)
+		return
+	}
+
+	switch priv := priv.(type) {
+	case *rsa.PrivateKey:
+		key = x509.MarshalPKCS1PrivateKey(priv)
+		block := pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: key,
+		}
+		key = pem.EncodeToMemory(&block)
+	case *ecdsa.PrivateKey:
+		key, err = x509.MarshalECPrivateKey(priv)
+		if err != nil {
+			err = cferr.Wrap(cferr.PrivateKeyError, cferr.Unknown, err)
+			return
+		}
+		block := pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: key,
+		}
+		key = pem.EncodeToMemory(&block)
+	default:
+		panic("Generate should have failed to produce a valid key.")
+	}
+
+	csr, err = Generate(priv.(crypto.Signer), req)
+	if err != nil {
+		log.Errorf("failed to generate a CSR: %v", err)
+		err = cferr.Wrap(cferr.CSRError, cferr.BadRequest, err)
+	}
+	return
+}
+
+// ExtractCertificateRequest extracts a CertificateRequest from
+// x509.Certificate. It is aimed to used for generating a new certificate
+// from an existing certificate. For a root certificate, the CA expiry
+// length is calculated as the duration between cert.NotAfter and cert.NotBefore.
+func ExtractCertificateRequest(cert *x509.Certificate) *CertificateRequest {
+	req := New()
+	req.CN = cert.Subject.CommonName
+	req.Names = getNames(cert.Subject)
+	req.Hosts = getHosts(cert)
+	req.SerialNumber = cert.Subject.SerialNumber
+
+	if cert.IsCA {
+		req.CA = new(CAConfig)
+		// CA expiry length is calculated based on the input cert
+		// issue date and expiry date.
+		req.CA.Expiry = cert.NotAfter.Sub(cert.NotBefore).String()
+		req.CA.PathLength = cert.MaxPathLen
+		req.CA.PathLenZero = cert.MaxPathLenZero
+	}
+
+	return req
+}
+
+func getHosts(cert *x509.Certificate) []string {
+	var hosts []string
+	for _, ip := range cert.IPAddresses {
+		hosts = append(hosts, ip.String())
+	}
+	for _, dns := range cert.DNSNames {
+		hosts = append(hosts, dns)
+	}
+	for _, email := range cert.EmailAddresses {
+		hosts = append(hosts, email)
+	}
+
+	return hosts
+}
+
+// getNames returns an array of Names from the certificate
+// It onnly cares about Country, Organization, OrganizationalUnit, Locality, Province
+func getNames(sub pkix.Name) []Name {
+	// anonymous func for finding the max of a list of interger
+	max := func(v1 int, vn ...int) (max int) {
+		max = v1
+		for i := 0; i < len(vn); i++ {
+			if vn[i] > max {
+				max = vn[i]
+			}
+		}
+		return max
+	}
+
+	nc := len(sub.Country)
+	norg := len(sub.Organization)
+	nou := len(sub.OrganizationalUnit)
+	nl := len(sub.Locality)
+	np := len(sub.Province)
+
+	n := max(nc, norg, nou, nl, np)
+
+	names := make([]Name, n)
+	for i := range names {
+		if i < nc {
+			names[i].C = sub.Country[i]
+		}
+		if i < norg {
+			names[i].O = sub.Organization[i]
+		}
+		if i < nou {
+			names[i].OU = sub.OrganizationalUnit[i]
+		}
+		if i < nl {
+			names[i].L = sub.Locality[i]
+		}
+		if i < np {
+			names[i].ST = sub.Province[i]
+		}
+	}
+	return names
+}
+
+// A Generator is responsible for validating certificate requests.
+type Generator struct {
+	Validator func(*CertificateRequest) error
+}
+
+// ProcessRequest validates and processes the incoming request. It is
+// a wrapper around a validator and the ParseRequest function.
+func (g *Generator) ProcessRequest(req *CertificateRequest) (csr, key []byte, err error) {
+
+	log.Info("generate received request")
+	err = g.Validator(req)
+	if err != nil {
+		log.Warningf("invalid request: %v", err)
+		return
+	}
+
+	csr, key, err = ParseRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	return
+}
+
+// IsNameEmpty returns true if the name has no identifying information in it.
+func IsNameEmpty(n Name) bool {
+	empty := func(s string) bool { return strings.TrimSpace(s) == "" }
+
+	if empty(n.C) && empty(n.ST) && empty(n.L) && empty(n.O) && empty(n.OU) {
+		return true
+	}
+	return false
+}
+
+// Regenerate uses the provided CSR as a template for signing a new
+// CSR using priv.
+func Regenerate(priv crypto.Signer, csr []byte) ([]byte, error) {
+	req, extra, err := helpers.ParseCSR(csr)
+	if err != nil {
+		return nil, err
+	} else if len(extra) > 0 {
+		return nil, errors.New("csr: trailing data in certificate request")
+	}
+
+	return x509.CreateCertificateRequest(rand.Reader, req, priv)
+}
+
+// Generate creates a new CSR from a CertificateRequest structure and
+// an existing key. The KeyRequest field is ignored.
+func Generate(priv crypto.Signer, req *CertificateRequest) (csr []byte, err error) {
+	sigAlgo := helpers.SignerAlgo(priv)
+	if sigAlgo == x509.UnknownSignatureAlgorithm {
+		return nil, cferr.New(cferr.PrivateKeyError, cferr.Unavailable)
+	}
+
+	var tpl = x509.CertificateRequest{
+		Subject:            req.Name(),
+		SignatureAlgorithm: sigAlgo,
+	}
+
+	for i := range req.Hosts {
+		if ip := net.ParseIP(req.Hosts[i]); ip != nil {
+			tpl.IPAddresses = append(tpl.IPAddresses, ip)
+		} else if email, err := mail.ParseAddress(req.Hosts[i]); err == nil && email != nil {
+			tpl.EmailAddresses = append(tpl.EmailAddresses, email.Address)
+		} else {
+			tpl.DNSNames = append(tpl.DNSNames, req.Hosts[i])
+		}
+	}
+
+	if req.CA != nil {
+		err = appendCAInfoToCSR(req.CA, &tpl)
+		if err != nil {
+			err = cferr.Wrap(cferr.CSRError, cferr.GenerationFailed, err)
+			return
+		}
+	}
+
+	csr, err = x509.CreateCertificateRequest(rand.Reader, &tpl, priv)
+	if err != nil {
+		log.Errorf("failed to generate a CSR: %v", err)
+		err = cferr.Wrap(cferr.CSRError, cferr.BadRequest, err)
+		return
+	}
+	block := pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csr,
+	}
+
+	log.Info("encoded CSR")
+	csr = pem.EncodeToMemory(&block)
+	return
+}
+
+// appendCAInfoToCSR appends CAConfig BasicConstraint extension to a CSR
+func appendCAInfoToCSR(reqConf *CAConfig, csr *x509.CertificateRequest) error {
+	pathlen := reqConf.PathLength
+	if pathlen == 0 && !reqConf.PathLenZero {
+		pathlen = -1
+	}
+	val, err := asn1.Marshal(BasicConstraints{true, pathlen})
+
+	if err != nil {
+		return err
+	}
+
+	csr.ExtraExtensions = []pkix.Extension{
+		{
+			Id:       asn1.ObjectIdentifier{2, 5, 29, 19},
+			Value:    val,
+			Critical: true,
+		},
+	}
+
+	return nil
+}

--- a/vendor/github.com/cloudflare/cfssl/errors/doc.go
+++ b/vendor/github.com/cloudflare/cfssl/errors/doc.go
@@ -1,0 +1,46 @@
+/*
+Package errors provides error types returned in CF SSL.
+
+1. Type Error is intended for errors produced by CF SSL packages.
+It formats to a json object that consists of an error message and a 4-digit code for error reasoning.
+
+Example: {"code":1002, "message": "Failed to decode certificate"}
+
+The index of codes are listed below:
+	1XXX: CertificateError
+	    1000: Unknown
+	    1001: ReadFailed
+	    1002: DecodeFailed
+	    1003: ParseFailed
+	    1100: SelfSigned
+	    12XX: VerifyFailed
+	        121X: CertificateInvalid
+	            1210: NotAuthorizedToSign
+	            1211: Expired
+	            1212: CANotAuthorizedForThisName
+	            1213: TooManyIntermediates
+	            1214: IncompatibleUsage
+	        1220: UnknownAuthority
+	2XXX: PrivatekeyError
+	    2000: Unknown
+	    2001: ReadFailed
+	    2002: DecodeFailed
+	    2003: ParseFailed
+	    2100: Encrypted
+	    2200: NotRSA
+	    2300: KeyMismatch
+	    2400: GenerationFailed
+	    2500: Unavailable
+	3XXX: IntermediatesError
+	4XXX: RootError
+	5XXX: PolicyError
+	    5100: NoKeyUsages
+	    5200: InvalidPolicy
+	    5300: InvalidRequest
+	    5400: UnknownProfile
+	    6XXX: DialError
+
+2. Type HttpError is intended for CF SSL API to consume. It contains a HTTP status code that will be read and returned
+by the API server.
+*/
+package errors

--- a/vendor/github.com/cloudflare/cfssl/errors/error.go
+++ b/vendor/github.com/cloudflare/cfssl/errors/error.go
@@ -1,0 +1,424 @@
+package errors
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+)
+
+// Error is the error type usually returned by functions in CF SSL package.
+// It contains a 4-digit error code where the most significant digit
+// describes the category where the error occurred and the rest 3 digits
+// describe the specific error reason.
+type Error struct {
+	ErrorCode int    `json:"code"`
+	Message   string `json:"message"`
+}
+
+// Category is the most significant digit of the error code.
+type Category int
+
+// Reason is the last 3 digits of the error code.
+type Reason int
+
+const (
+	// Success indicates no error occurred.
+	Success Category = 1000 * iota // 0XXX
+
+	// CertificateError indicates a fault in a certificate.
+	CertificateError // 1XXX
+
+	// PrivateKeyError indicates a fault in a private key.
+	PrivateKeyError // 2XXX
+
+	// IntermediatesError indicates a fault in an intermediate.
+	IntermediatesError // 3XXX
+
+	// RootError indicates a fault in a root.
+	RootError // 4XXX
+
+	// PolicyError indicates an error arising from a malformed or
+	// non-existent policy, or a breach of policy.
+	PolicyError // 5XXX
+
+	// DialError indicates a network fault.
+	DialError // 6XXX
+
+	// APIClientError indicates a problem with the API client.
+	APIClientError // 7XXX
+
+	// OCSPError indicates a problem with OCSP signing
+	OCSPError // 8XXX
+
+	// CSRError indicates a problem with CSR parsing
+	CSRError // 9XXX
+
+	// CTError indicates a problem with the certificate transparency process
+	CTError // 10XXX
+
+	// CertStoreError indicates a problem with the certificate store
+	CertStoreError // 11XXX
+)
+
+// None is a non-specified error.
+const (
+	None Reason = iota
+)
+
+// Warning code for a success
+const (
+	BundleExpiringBit      int = 1 << iota // 0x01
+	BundleNotUbiquitousBit                 // 0x02
+)
+
+// Parsing errors
+const (
+	Unknown      Reason = iota // X000
+	ReadFailed                 // X001
+	DecodeFailed               // X002
+	ParseFailed                // X003
+)
+
+// The following represent certificate non-parsing errors, and must be
+// specified along with CertificateError.
+const (
+	// SelfSigned indicates that a certificate is self-signed and
+	// cannot be used in the manner being attempted.
+	SelfSigned Reason = 100 * (iota + 1) // Code 11XX
+
+	// VerifyFailed is an X.509 verification failure. The least two
+	// significant digits of 12XX is determined as the actual x509
+	// error is examined.
+	VerifyFailed // Code 12XX
+
+	// BadRequest indicates that the certificate request is invalid.
+	BadRequest // Code 13XX
+
+	// MissingSerial indicates that the profile specified
+	// 'ClientProvidesSerialNumbers', but the SignRequest did not include a serial
+	// number.
+	MissingSerial // Code 14XX
+)
+
+const (
+	certificateInvalid = 10 * (iota + 1) //121X
+	unknownAuthority                     //122x
+)
+
+// The following represent private-key non-parsing errors, and must be
+// specified with PrivateKeyError.
+const (
+	// Encrypted indicates that the private key is a PKCS #8 encrypted
+	// private key. At this time, CFSSL does not support decrypting
+	// these keys.
+	Encrypted Reason = 100 * (iota + 1) //21XX
+
+	// NotRSAOrECC indicates that they key is not an RSA or ECC
+	// private key; these are the only two private key types supported
+	// at this time by CFSSL.
+	NotRSAOrECC //22XX
+
+	// KeyMismatch indicates that the private key does not match
+	// the public key or certificate being presented with the key.
+	KeyMismatch //23XX
+
+	// GenerationFailed indicates that a private key could not
+	// be generated.
+	GenerationFailed //24XX
+
+	// Unavailable indicates that a private key mechanism (such as
+	// PKCS #11) was requested but support for that mechanism is
+	// not available.
+	Unavailable
+)
+
+// The following are policy-related non-parsing errors, and must be
+// specified along with PolicyError.
+const (
+	// NoKeyUsages indicates that the profile does not permit any
+	// key usages for the certificate.
+	NoKeyUsages Reason = 100 * (iota + 1) // 51XX
+
+	// InvalidPolicy indicates that policy being requested is not
+	// a valid policy or does not exist.
+	InvalidPolicy // 52XX
+
+	// InvalidRequest indicates a certificate request violated the
+	// constraints of the policy being applied to the request.
+	InvalidRequest // 53XX
+
+	// UnknownProfile indicates that the profile does not exist.
+	UnknownProfile // 54XX
+
+	UnmatchedWhitelist // 55xx
+)
+
+// The following are API client related errors, and should be
+// specified with APIClientError.
+const (
+	// AuthenticationFailure occurs when the client is unable
+	// to obtain an authentication token for the request.
+	AuthenticationFailure Reason = 100 * (iota + 1)
+
+	// JSONError wraps an encoding/json error.
+	JSONError
+
+	// IOError wraps an io/ioutil error.
+	IOError
+
+	// ClientHTTPError wraps a net/http error.
+	ClientHTTPError
+
+	// ServerRequestFailed covers any other failures from the API
+	// client.
+	ServerRequestFailed
+)
+
+// The following are OCSP related errors, and should be
+// specified with OCSPError
+const (
+	// IssuerMismatch ocurs when the certificate in the OCSP signing
+	// request was not issued by the CA that this responder responds for.
+	IssuerMismatch Reason = 100 * (iota + 1) // 81XX
+
+	// InvalidStatus occurs when the OCSP signing requests includes an
+	// invalid value for the certificate status.
+	InvalidStatus
+)
+
+// Certificate transparency related errors specified with CTError
+const (
+	// PrecertSubmissionFailed occurs when submitting a precertificate to
+	// a log server fails
+	PrecertSubmissionFailed = 100 * (iota + 1)
+)
+
+// Certificate persistence related errors specified with CertStoreError
+const (
+	// InsertionFailed occurs when a SQL insert query failes to complete.
+	InsertionFailed = 100 * (iota + 1)
+	// RecordNotFound occurs when a SQL query targeting on one unique
+	// record failes to update the specified row in the table.
+	RecordNotFound
+)
+
+// The error interface implementation, which formats to a JSON object string.
+func (e *Error) Error() string {
+	marshaled, err := json.Marshal(e)
+	if err != nil {
+		panic(err)
+	}
+	return string(marshaled)
+
+}
+
+// New returns an error that contains  an error code and message derived from
+// the given category, reason. Currently, to avoid confusion, it is not
+// allowed to create an error of category Success
+func New(category Category, reason Reason) *Error {
+	errorCode := int(category) + int(reason)
+	var msg string
+	switch category {
+	case OCSPError:
+		switch reason {
+		case ReadFailed:
+			msg = "No certificate provided"
+		case IssuerMismatch:
+			msg = "Certificate not issued by this issuer"
+		case InvalidStatus:
+			msg = "Invalid revocation status"
+		}
+	case CertificateError:
+		switch reason {
+		case Unknown:
+			msg = "Unknown certificate error"
+		case ReadFailed:
+			msg = "Failed to read certificate"
+		case DecodeFailed:
+			msg = "Failed to decode certificate"
+		case ParseFailed:
+			msg = "Failed to parse certificate"
+		case SelfSigned:
+			msg = "Certificate is self signed"
+		case VerifyFailed:
+			msg = "Unable to verify certificate"
+		case BadRequest:
+			msg = "Invalid certificate request"
+		case MissingSerial:
+			msg = "Missing serial number in request"
+		default:
+			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category CertificateError.",
+				reason))
+
+		}
+	case PrivateKeyError:
+		switch reason {
+		case Unknown:
+			msg = "Unknown private key error"
+		case ReadFailed:
+			msg = "Failed to read private key"
+		case DecodeFailed:
+			msg = "Failed to decode private key"
+		case ParseFailed:
+			msg = "Failed to parse private key"
+		case Encrypted:
+			msg = "Private key is encrypted."
+		case NotRSAOrECC:
+			msg = "Private key algorithm is not RSA or ECC"
+		case KeyMismatch:
+			msg = "Private key does not match public key"
+		case GenerationFailed:
+			msg = "Failed to new private key"
+		case Unavailable:
+			msg = "Private key is unavailable"
+		default:
+			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category PrivateKeyError.",
+				reason))
+		}
+	case IntermediatesError:
+		switch reason {
+		case Unknown:
+			msg = "Unknown intermediate certificate error"
+		case ReadFailed:
+			msg = "Failed to read intermediate certificate"
+		case DecodeFailed:
+			msg = "Failed to decode intermediate certificate"
+		case ParseFailed:
+			msg = "Failed to parse intermediate certificate"
+		default:
+			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category IntermediatesError.",
+				reason))
+		}
+	case RootError:
+		switch reason {
+		case Unknown:
+			msg = "Unknown root certificate error"
+		case ReadFailed:
+			msg = "Failed to read root certificate"
+		case DecodeFailed:
+			msg = "Failed to decode root certificate"
+		case ParseFailed:
+			msg = "Failed to parse root certificate"
+		default:
+			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category RootError.",
+				reason))
+		}
+	case PolicyError:
+		switch reason {
+		case Unknown:
+			msg = "Unknown policy error"
+		case NoKeyUsages:
+			msg = "Invalid policy: no key usage available"
+		case InvalidPolicy:
+			msg = "Invalid or unknown policy"
+		case InvalidRequest:
+			msg = "Policy violation request"
+		case UnknownProfile:
+			msg = "Unknown policy profile"
+		case UnmatchedWhitelist:
+			msg = "Request does not match policy whitelist"
+		default:
+			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category PolicyError.",
+				reason))
+		}
+	case DialError:
+		switch reason {
+		case Unknown:
+			msg = "Failed to dial remote server"
+		default:
+			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category DialError.",
+				reason))
+		}
+	case APIClientError:
+		switch reason {
+		case AuthenticationFailure:
+			msg = "API client authentication failure"
+		case JSONError:
+			msg = "API client JSON config error"
+		case ClientHTTPError:
+			msg = "API client HTTP error"
+		case IOError:
+			msg = "API client IO error"
+		case ServerRequestFailed:
+			msg = "API client error: Server request failed"
+		default:
+			panic(fmt.Sprintf("Unsupported CFSSL error reason %d under category APIClientError.",
+				reason))
+		}
+	case CSRError:
+		switch reason {
+		case Unknown:
+			msg = "CSR parsing failed due to unknown error"
+		case ReadFailed:
+			msg = "CSR file read failed"
+		case ParseFailed:
+			msg = "CSR Parsing failed"
+		case DecodeFailed:
+			msg = "CSR Decode failed"
+		case BadRequest:
+			msg = "CSR Bad request"
+		default:
+			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category APIClientError.", reason))
+		}
+	case CTError:
+		switch reason {
+		case Unknown:
+			msg = "Certificate transparency parsing failed due to unknown error"
+		case PrecertSubmissionFailed:
+			msg = "Certificate transparency precertificate submission failed"
+		default:
+			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category CTError.", reason))
+		}
+	case CertStoreError:
+		switch reason {
+		case Unknown:
+			msg = "Certificate store action failed due to unknown error"
+		default:
+			panic(fmt.Sprintf("Unsupported CF-SSL error reason %d under category CertStoreError.", reason))
+		}
+
+	default:
+		panic(fmt.Sprintf("Unsupported CFSSL error type: %d.",
+			category))
+	}
+	return &Error{ErrorCode: errorCode, Message: msg}
+}
+
+// Wrap returns an error that contains the given error and an error code derived from
+// the given category, reason and the error. Currently, to avoid confusion, it is not
+// allowed to create an error of category Success
+func Wrap(category Category, reason Reason, err error) *Error {
+	errorCode := int(category) + int(reason)
+	if err == nil {
+		panic("Wrap needs a supplied error to initialize.")
+	}
+
+	// do not double wrap a error
+	switch err.(type) {
+	case *Error:
+		panic("Unable to wrap a wrapped error.")
+	}
+
+	switch category {
+	case CertificateError:
+		// given VerifyFailed , report the status with more detailed status code
+		// for some certificate errors we care.
+		if reason == VerifyFailed {
+			switch errorType := err.(type) {
+			case x509.CertificateInvalidError:
+				errorCode += certificateInvalid + int(errorType.Reason)
+			case x509.UnknownAuthorityError:
+				errorCode += unknownAuthority
+			}
+		}
+	case PrivateKeyError, IntermediatesError, RootError, PolicyError, DialError,
+		APIClientError, CSRError, CTError, CertStoreError:
+	// no-op, just use the error
+	default:
+		panic(fmt.Sprintf("Unsupported CFSSL error type: %d.",
+			category))
+	}
+
+	return &Error{ErrorCode: errorCode, Message: err.Error()}
+
+}

--- a/vendor/github.com/cloudflare/cfssl/errors/http.go
+++ b/vendor/github.com/cloudflare/cfssl/errors/http.go
@@ -1,0 +1,47 @@
+package errors
+
+import (
+	"errors"
+	"net/http"
+)
+
+// HTTPError is an augmented error with a HTTP status code.
+type HTTPError struct {
+	StatusCode int
+	error
+}
+
+// Error implements the error interface.
+func (e *HTTPError) Error() string {
+	return e.error.Error()
+}
+
+// NewMethodNotAllowed returns an appropriate error in the case that
+// an HTTP client uses an invalid method (i.e. a GET in place of a POST)
+// on an API endpoint.
+func NewMethodNotAllowed(method string) *HTTPError {
+	return &HTTPError{http.StatusMethodNotAllowed, errors.New(`Method is not allowed:"` + method + `"`)}
+}
+
+// NewBadRequest creates a HttpError with the given error and error code 400.
+func NewBadRequest(err error) *HTTPError {
+	return &HTTPError{http.StatusBadRequest, err}
+}
+
+// NewBadRequestString returns a HttpError with the supplied message
+// and error code 400.
+func NewBadRequestString(s string) *HTTPError {
+	return NewBadRequest(errors.New(s))
+}
+
+// NewBadRequestMissingParameter returns a 400 HttpError as a required
+// parameter is missing in the HTTP request.
+func NewBadRequestMissingParameter(s string) *HTTPError {
+	return NewBadRequestString(`Missing parameter "` + s + `"`)
+}
+
+// NewBadRequestUnwantedParameter returns a 400 HttpError as a unnecessary
+// parameter is present in the HTTP request.
+func NewBadRequestUnwantedParameter(s string) *HTTPError {
+	return NewBadRequestString(`Unwanted parameter "` + s + `"`)
+}

--- a/vendor/github.com/cloudflare/cfssl/helpers/derhelpers/derhelpers.go
+++ b/vendor/github.com/cloudflare/cfssl/helpers/derhelpers/derhelpers.go
@@ -1,0 +1,42 @@
+// Package derhelpers implements common functionality
+// on DER encoded data
+package derhelpers
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+
+	cferr "github.com/cloudflare/cfssl/errors"
+)
+
+// ParsePrivateKeyDER parses a PKCS #1, PKCS #8, or elliptic curve
+// DER-encoded private key. The key must not be in PEM format.
+func ParsePrivateKeyDER(keyDER []byte) (key crypto.Signer, err error) {
+	generalKey, err := x509.ParsePKCS8PrivateKey(keyDER)
+	if err != nil {
+		generalKey, err = x509.ParsePKCS1PrivateKey(keyDER)
+		if err != nil {
+			generalKey, err = x509.ParseECPrivateKey(keyDER)
+			if err != nil {
+				// We don't include the actual error into
+				// the final error. The reason might be
+				// we don't want to leak any info about
+				// the private key.
+				return nil, cferr.New(cferr.PrivateKeyError,
+					cferr.ParseFailed)
+			}
+		}
+	}
+
+	switch generalKey.(type) {
+	case *rsa.PrivateKey:
+		return generalKey.(*rsa.PrivateKey), nil
+	case *ecdsa.PrivateKey:
+		return generalKey.(*ecdsa.PrivateKey), nil
+	}
+
+	// should never reach here
+	return nil, cferr.New(cferr.PrivateKeyError, cferr.ParseFailed)
+}

--- a/vendor/github.com/cloudflare/cfssl/helpers/helpers.go
+++ b/vendor/github.com/cloudflare/cfssl/helpers/helpers.go
@@ -1,0 +1,518 @@
+// Package helpers implements utility functionality common to many
+// CFSSL packages.
+package helpers
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+	"math/big"
+
+	"strings"
+	"time"
+
+	"github.com/cloudflare/cfssl/crypto/pkcs7"
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers/derhelpers"
+	"github.com/cloudflare/cfssl/log"
+	"golang.org/x/crypto/pkcs12"
+)
+
+// OneYear is a time.Duration representing a year's worth of seconds.
+const OneYear = 8760 * time.Hour
+
+// OneDay is a time.Duration representing a day's worth of seconds.
+const OneDay = 24 * time.Hour
+
+// InclusiveDate returns the time.Time representation of a date - 1
+// nanosecond. This allows time.After to be used inclusively.
+func InclusiveDate(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC).Add(-1 * time.Nanosecond)
+}
+
+// Jul2012 is the July 2012 CAB Forum deadline for when CAs must stop
+// issuing certificates valid for more than 5 years.
+var Jul2012 = InclusiveDate(2012, time.July, 01)
+
+// Apr2015 is the April 2015 CAB Forum deadline for when CAs must stop
+// issuing certificates valid for more than 39 months.
+var Apr2015 = InclusiveDate(2015, time.April, 01)
+
+// KeyLength returns the bit size of ECDSA or RSA PublicKey
+func KeyLength(key interface{}) int {
+	if key == nil {
+		return 0
+	}
+	if ecdsaKey, ok := key.(*ecdsa.PublicKey); ok {
+		return ecdsaKey.Curve.Params().BitSize
+	} else if rsaKey, ok := key.(*rsa.PublicKey); ok {
+		return rsaKey.N.BitLen()
+	}
+
+	return 0
+}
+
+// ExpiryTime returns the time when the certificate chain is expired.
+func ExpiryTime(chain []*x509.Certificate) (notAfter time.Time) {
+	if len(chain) == 0 {
+		return
+	}
+
+	notAfter = chain[0].NotAfter
+	for _, cert := range chain {
+		if notAfter.After(cert.NotAfter) {
+			notAfter = cert.NotAfter
+		}
+	}
+	return
+}
+
+// MonthsValid returns the number of months for which a certificate is valid.
+func MonthsValid(c *x509.Certificate) int {
+	issued := c.NotBefore
+	expiry := c.NotAfter
+	years := (expiry.Year() - issued.Year())
+	months := years*12 + int(expiry.Month()) - int(issued.Month())
+
+	// Round up if valid for less than a full month
+	if expiry.Day() > issued.Day() {
+		months++
+	}
+	return months
+}
+
+// ValidExpiry determines if a certificate is valid for an acceptable
+// length of time per the CA/Browser Forum baseline requirements.
+// See https://cabforum.org/wp-content/uploads/CAB-Forum-BR-1.3.0.pdf
+func ValidExpiry(c *x509.Certificate) bool {
+	issued := c.NotBefore
+
+	var maxMonths int
+	switch {
+	case issued.After(Apr2015):
+		maxMonths = 39
+	case issued.After(Jul2012):
+		maxMonths = 60
+	case issued.Before(Jul2012):
+		maxMonths = 120
+	}
+
+	if MonthsValid(c) > maxMonths {
+		return false
+	}
+	return true
+}
+
+// SignatureString returns the TLS signature string corresponding to
+// an X509 signature algorithm.
+func SignatureString(alg x509.SignatureAlgorithm) string {
+	switch alg {
+	case x509.MD2WithRSA:
+		return "MD2WithRSA"
+	case x509.MD5WithRSA:
+		return "MD5WithRSA"
+	case x509.SHA1WithRSA:
+		return "SHA1WithRSA"
+	case x509.SHA256WithRSA:
+		return "SHA256WithRSA"
+	case x509.SHA384WithRSA:
+		return "SHA384WithRSA"
+	case x509.SHA512WithRSA:
+		return "SHA512WithRSA"
+	case x509.DSAWithSHA1:
+		return "DSAWithSHA1"
+	case x509.DSAWithSHA256:
+		return "DSAWithSHA256"
+	case x509.ECDSAWithSHA1:
+		return "ECDSAWithSHA1"
+	case x509.ECDSAWithSHA256:
+		return "ECDSAWithSHA256"
+	case x509.ECDSAWithSHA384:
+		return "ECDSAWithSHA384"
+	case x509.ECDSAWithSHA512:
+		return "ECDSAWithSHA512"
+	default:
+		return "Unknown Signature"
+	}
+}
+
+// HashAlgoString returns the hash algorithm name contains in the signature
+// method.
+func HashAlgoString(alg x509.SignatureAlgorithm) string {
+	switch alg {
+	case x509.MD2WithRSA:
+		return "MD2"
+	case x509.MD5WithRSA:
+		return "MD5"
+	case x509.SHA1WithRSA:
+		return "SHA1"
+	case x509.SHA256WithRSA:
+		return "SHA256"
+	case x509.SHA384WithRSA:
+		return "SHA384"
+	case x509.SHA512WithRSA:
+		return "SHA512"
+	case x509.DSAWithSHA1:
+		return "SHA1"
+	case x509.DSAWithSHA256:
+		return "SHA256"
+	case x509.ECDSAWithSHA1:
+		return "SHA1"
+	case x509.ECDSAWithSHA256:
+		return "SHA256"
+	case x509.ECDSAWithSHA384:
+		return "SHA384"
+	case x509.ECDSAWithSHA512:
+		return "SHA512"
+	default:
+		return "Unknown Hash Algorithm"
+	}
+}
+
+// EncodeCertificatesPEM encodes a number of x509 certficates to PEM
+func EncodeCertificatesPEM(certs []*x509.Certificate) []byte {
+	var buffer bytes.Buffer
+	for _, cert := range certs {
+		pem.Encode(&buffer, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		})
+	}
+
+	return buffer.Bytes()
+}
+
+// EncodeCertificatePEM encodes a single x509 certficates to PEM
+func EncodeCertificatePEM(cert *x509.Certificate) []byte {
+	return EncodeCertificatesPEM([]*x509.Certificate{cert})
+}
+
+// ParseCertificatesPEM parses a sequence of PEM-encoded certificate and returns them,
+// can handle PEM encoded PKCS #7 structures.
+func ParseCertificatesPEM(certsPEM []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	var err error
+	certsPEM = bytes.TrimSpace(certsPEM)
+	for len(certsPEM) > 0 {
+		var cert []*x509.Certificate
+		cert, certsPEM, err = ParseOneCertificateFromPEM(certsPEM)
+		if err != nil {
+
+			return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed)
+		} else if cert == nil {
+			break
+		}
+
+		certs = append(certs, cert...)
+	}
+	if len(certsPEM) > 0 {
+		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed)
+	}
+	return certs, nil
+}
+
+// ParseCertificatesDER parses a DER encoding of a certificate object and possibly private key,
+// either PKCS #7, PKCS #12, or raw x509.
+func ParseCertificatesDER(certsDER []byte, password string) (certs []*x509.Certificate, key crypto.Signer, err error) {
+	certsDER = bytes.TrimSpace(certsDER)
+	pkcs7data, err := pkcs7.ParsePKCS7(certsDER)
+	if err != nil {
+		var pkcs12data interface{}
+		certs = make([]*x509.Certificate, 1)
+		pkcs12data, certs[0], err = pkcs12.Decode(certsDER, password)
+		if err != nil {
+			certs, err = x509.ParseCertificates(certsDER)
+			if err != nil {
+				return nil, nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed)
+			}
+		} else {
+			key = pkcs12data.(crypto.Signer)
+		}
+	} else {
+		if pkcs7data.ContentInfo != "SignedData" {
+			return nil, nil, cferr.Wrap(cferr.CertificateError, cferr.DecodeFailed, errors.New("can only extract certificates from signed data content info"))
+		}
+		certs = pkcs7data.Content.SignedData.Certificates
+	}
+	if certs == nil {
+		return nil, key, cferr.New(cferr.CertificateError, cferr.DecodeFailed)
+	}
+	return certs, key, nil
+}
+
+// ParseSelfSignedCertificatePEM parses a PEM-encoded certificate and check if it is self-signed.
+func ParseSelfSignedCertificatePEM(certPEM []byte) (*x509.Certificate, error) {
+	cert, err := ParseCertificatePEM(certPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature); err != nil {
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.VerifyFailed, err)
+	}
+	return cert, nil
+}
+
+// ParseCertificatePEM parses and returns a PEM-encoded certificate,
+// can handle PEM encoded PKCS #7 structures.
+func ParseCertificatePEM(certPEM []byte) (*x509.Certificate, error) {
+	certPEM = bytes.TrimSpace(certPEM)
+	cert, rest, err := ParseOneCertificateFromPEM(certPEM)
+	if err != nil {
+		// Log the actual parsing error but throw a default parse error message.
+		log.Debugf("Certificate parsing error: %v", err)
+		return nil, cferr.New(cferr.CertificateError, cferr.ParseFailed)
+	} else if cert == nil {
+		return nil, cferr.New(cferr.CertificateError, cferr.DecodeFailed)
+	} else if len(rest) > 0 {
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, errors.New("the PEM file should contain only one object"))
+	} else if len(cert) > 1 {
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, errors.New("the PKCS7 object in the PEM file should contain only one certificate"))
+	}
+	return cert[0], nil
+}
+
+// ParseOneCertificateFromPEM attempts to parse one PEM encoded certificate object,
+// either a raw x509 certificate or a PKCS #7 structure possibly containing
+// multiple certificates, from the top of certsPEM, which itself may
+// contain multiple PEM encoded certificate objects.
+func ParseOneCertificateFromPEM(certsPEM []byte) ([]*x509.Certificate, []byte, error) {
+
+	block, rest := pem.Decode(certsPEM)
+	if block == nil {
+		return nil, rest, nil
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		pkcs7data, err := pkcs7.ParsePKCS7(block.Bytes)
+		if err != nil {
+			return nil, rest, err
+		}
+		if pkcs7data.ContentInfo != "SignedData" {
+			return nil, rest, errors.New("only PKCS #7 Signed Data Content Info supported for certificate parsing")
+		}
+		certs := pkcs7data.Content.SignedData.Certificates
+		if certs == nil {
+			return nil, rest, errors.New("PKCS #7 structure contains no certificates")
+		}
+		return certs, rest, nil
+	}
+	var certs = []*x509.Certificate{cert}
+	return certs, rest, nil
+}
+
+// LoadPEMCertPool loads a pool of PEM certificates from file.
+func LoadPEMCertPool(certsFile string) (*x509.CertPool, error) {
+	if certsFile == "" {
+		return nil, nil
+	}
+	pemCerts, err := ioutil.ReadFile(certsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return PEMToCertPool(pemCerts)
+}
+
+// PEMToCertPool concerts PEM certificates to a CertPool.
+func PEMToCertPool(pemCerts []byte) (*x509.CertPool, error) {
+	if len(pemCerts) == 0 {
+		return nil, nil
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(pemCerts) {
+		return nil, errors.New("failed to load cert pool")
+	}
+
+	return certPool, nil
+}
+
+// ParsePrivateKeyPEM parses and returns a PEM-encoded private
+// key. The private key may be either an unencrypted PKCS#8, PKCS#1,
+// or elliptic private key.
+func ParsePrivateKeyPEM(keyPEM []byte) (key crypto.Signer, err error) {
+	return ParsePrivateKeyPEMWithPassword(keyPEM, nil)
+}
+
+// ParsePrivateKeyPEMWithPassword parses and returns a PEM-encoded private
+// key. The private key may be a potentially encrypted PKCS#8, PKCS#1,
+// or elliptic private key.
+func ParsePrivateKeyPEMWithPassword(keyPEM []byte, password []byte) (key crypto.Signer, err error) {
+	keyDER, err := GetKeyDERFromPEM(keyPEM, password)
+	if err != nil {
+		return nil, err
+	}
+
+	return derhelpers.ParsePrivateKeyDER(keyDER)
+}
+
+// GetKeyDERFromPEM parses a PEM-encoded private key and returns DER-format key bytes.
+func GetKeyDERFromPEM(in []byte, password []byte) ([]byte, error) {
+	keyDER, _ := pem.Decode(in)
+	if keyDER != nil {
+		if procType, ok := keyDER.Headers["Proc-Type"]; ok {
+			if strings.Contains(procType, "ENCRYPTED") {
+				if password != nil {
+					return x509.DecryptPEMBlock(keyDER, password)
+				}
+				return nil, cferr.New(cferr.PrivateKeyError, cferr.Encrypted)
+			}
+		}
+		return keyDER.Bytes, nil
+	}
+
+	return nil, cferr.New(cferr.PrivateKeyError, cferr.DecodeFailed)
+}
+
+// CheckSignature verifies a signature made by the key on a CSR, such
+// as on the CSR itself.
+func CheckSignature(csr *x509.CertificateRequest, algo x509.SignatureAlgorithm, signed, signature []byte) error {
+	var hashType crypto.Hash
+
+	switch algo {
+	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
+		hashType = crypto.SHA1
+	case x509.SHA256WithRSA, x509.ECDSAWithSHA256:
+		hashType = crypto.SHA256
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384:
+		hashType = crypto.SHA384
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512:
+		hashType = crypto.SHA512
+	default:
+		return x509.ErrUnsupportedAlgorithm
+	}
+
+	if !hashType.Available() {
+		return x509.ErrUnsupportedAlgorithm
+	}
+	h := hashType.New()
+
+	h.Write(signed)
+	digest := h.Sum(nil)
+
+	switch pub := csr.PublicKey.(type) {
+	case *rsa.PublicKey:
+		return rsa.VerifyPKCS1v15(pub, hashType, digest, signature)
+	case *ecdsa.PublicKey:
+		ecdsaSig := new(struct{ R, S *big.Int })
+		if _, err := asn1.Unmarshal(signature, ecdsaSig); err != nil {
+			return err
+		}
+		if ecdsaSig.R.Sign() <= 0 || ecdsaSig.S.Sign() <= 0 {
+			return errors.New("x509: ECDSA signature contained zero or negative values")
+		}
+		if !ecdsa.Verify(pub, digest, ecdsaSig.R, ecdsaSig.S) {
+			return errors.New("x509: ECDSA verification failure")
+		}
+		return nil
+	}
+	return x509.ErrUnsupportedAlgorithm
+}
+
+// ParseCSR parses a PEM- or DER-encoded PKCS #10 certificate signing request.
+func ParseCSR(in []byte) (csr *x509.CertificateRequest, rest []byte, err error) {
+	in = bytes.TrimSpace(in)
+	p, rest := pem.Decode(in)
+	if p != nil {
+		if p.Type != "NEW CERTIFICATE REQUEST" && p.Type != "CERTIFICATE REQUEST" {
+			return nil, rest, cferr.New(cferr.CSRError, cferr.BadRequest)
+		}
+
+		csr, err = x509.ParseCertificateRequest(p.Bytes)
+	} else {
+		csr, err = x509.ParseCertificateRequest(in)
+	}
+
+	if err != nil {
+		return nil, rest, err
+	}
+
+	err = CheckSignature(csr, csr.SignatureAlgorithm, csr.RawTBSCertificateRequest, csr.Signature)
+	if err != nil {
+		return nil, rest, err
+	}
+
+	return csr, rest, nil
+}
+
+// ParseCSRPEM parses a PEM-encoded certificiate signing request.
+// It does not check the signature. This is useful for dumping data from a CSR
+// locally.
+func ParseCSRPEM(csrPEM []byte) (*x509.CertificateRequest, error) {
+	block, _ := pem.Decode([]byte(csrPEM))
+	der := block.Bytes
+	csrObject, err := x509.ParseCertificateRequest(der)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return csrObject, nil
+}
+
+// SignerAlgo returns an X.509 signature algorithm from a crypto.Signer.
+func SignerAlgo(priv crypto.Signer) x509.SignatureAlgorithm {
+	switch pub := priv.Public().(type) {
+	case *rsa.PublicKey:
+		bitLength := pub.N.BitLen()
+		switch {
+		case bitLength >= 4096:
+			return x509.SHA512WithRSA
+		case bitLength >= 3072:
+			return x509.SHA384WithRSA
+		case bitLength >= 2048:
+			return x509.SHA256WithRSA
+		default:
+			return x509.SHA1WithRSA
+		}
+	case *ecdsa.PublicKey:
+		switch pub.Curve {
+		case elliptic.P521():
+			return x509.ECDSAWithSHA512
+		case elliptic.P384():
+			return x509.ECDSAWithSHA384
+		case elliptic.P256():
+			return x509.ECDSAWithSHA256
+		default:
+			return x509.ECDSAWithSHA1
+		}
+	default:
+		return x509.UnknownSignatureAlgorithm
+	}
+}
+
+// LoadClientCertificate load key/certificate from pem files
+func LoadClientCertificate(certFile string, keyFile string) (*tls.Certificate, error) {
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			log.Critical("Unable to read client certificate from file: %s or key from file: %s", certFile, keyFile)
+			return nil, err
+		}
+		log.Debug("Client certificate loaded ")
+		return &cert, nil
+	}
+	return nil, nil
+}
+
+// CreateTLSConfig creates a tls.Config object from certs and roots
+func CreateTLSConfig(remoteCAs *x509.CertPool, cert *tls.Certificate) *tls.Config {
+	var certs []tls.Certificate
+	if cert != nil {
+		certs = []tls.Certificate{*cert}
+	}
+	return &tls.Config{
+		Certificates: certs,
+		RootCAs:      remoteCAs,
+	}
+}

--- a/vendor/github.com/cloudflare/cfssl/info/info.go
+++ b/vendor/github.com/cloudflare/cfssl/info/info.go
@@ -1,0 +1,15 @@
+// Package info contains the definitions for the info endpoint
+package info
+
+// Req is the request struct for an info API request.
+type Req struct {
+	Label   string `json:"label"`
+	Profile string `json:"profile"`
+}
+
+// Resp is the response for an Info API request.
+type Resp struct {
+	Certificate  string   `json:"certificate"`
+	Usage        []string `json:"usages"`
+	ExpiryString string   `json:"expiry"`
+}

--- a/vendor/github.com/cloudflare/cfssl/initca/initca.go
+++ b/vendor/github.com/cloudflare/cfssl/initca/initca.go
@@ -1,0 +1,224 @@
+// Package initca contains code to initialise a certificate authority,
+// generating a new root key and certificate.
+package initca
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	"time"
+
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/cloudflare/cfssl/signer/local"
+)
+
+// validator contains the default validation logic for certificate
+// authority certificates. The only requirement here is that the
+// certificate have a non-empty subject field.
+func validator(req *csr.CertificateRequest) error {
+	if req.CN != "" {
+		return nil
+	}
+
+	if len(req.Names) == 0 {
+		return cferr.Wrap(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing subject information"))
+	}
+
+	for i := range req.Names {
+		if csr.IsNameEmpty(req.Names[i]) {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidRequest, errors.New("missing subject information"))
+		}
+	}
+
+	return nil
+}
+
+// New creates a new root certificate from the certificate request.
+func New(req *csr.CertificateRequest) (cert, csrPEM, key []byte, err error) {
+	policy := CAPolicy()
+	if req.CA != nil {
+		if req.CA.Expiry != "" {
+			policy.Default.ExpiryString = req.CA.Expiry
+			policy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
+			if err != nil {
+				return
+			}
+		}
+
+		policy.Default.CAConstraint.MaxPathLen = req.CA.PathLength
+		if req.CA.PathLength != 0 && req.CA.PathLenZero == true {
+			log.Infof("ignore invalid 'pathlenzero' value")
+		} else {
+			policy.Default.CAConstraint.MaxPathLenZero = req.CA.PathLenZero
+		}
+	}
+
+	g := &csr.Generator{Validator: validator}
+	csrPEM, key, err = g.ProcessRequest(req)
+	if err != nil {
+		log.Errorf("failed to process request: %v", err)
+		key = nil
+		return
+	}
+
+	priv, err := helpers.ParsePrivateKeyPEM(key)
+	if err != nil {
+		log.Errorf("failed to parse private key: %v", err)
+		return
+	}
+
+	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), policy)
+	if err != nil {
+		log.Errorf("failed to create signer: %v", err)
+		return
+	}
+
+	signReq := signer.SignRequest{Hosts: req.Hosts, Request: string(csrPEM)}
+	cert, err = s.Sign(signReq)
+
+	return
+
+}
+
+// NewFromPEM creates a new root certificate from the key file passed in.
+func NewFromPEM(req *csr.CertificateRequest, keyFile string) (cert, csrPEM []byte, err error) {
+	privData, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	priv, err := helpers.ParsePrivateKeyPEM(privData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return NewFromSigner(req, priv)
+}
+
+// RenewFromPEM re-creates a root certificate from the CA cert and key
+// files. The resulting root certificate will have the input CA certificate
+// as the template and have the same expiry length. E.g. the exsiting CA
+// is valid for a year from Jan 01 2015 to Jan 01 2016, the renewed certificate
+// will be valid from now and expire in one year as well.
+func RenewFromPEM(caFile, keyFile string) ([]byte, error) {
+	caBytes, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, err
+	}
+
+	ca, err := helpers.ParseCertificatePEM(caBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	keyBytes, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := helpers.ParsePrivateKeyPEM(keyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return RenewFromSigner(ca, key)
+
+}
+
+// NewFromSigner creates a new root certificate from a crypto.Signer.
+func NewFromSigner(req *csr.CertificateRequest, priv crypto.Signer) (cert, csrPEM []byte, err error) {
+	policy := CAPolicy()
+	if req.CA != nil {
+		if req.CA.Expiry != "" {
+			policy.Default.ExpiryString = req.CA.Expiry
+			policy.Default.Expiry, err = time.ParseDuration(req.CA.Expiry)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		policy.Default.CAConstraint.MaxPathLen = req.CA.PathLength
+		if req.CA.PathLength != 0 && req.CA.PathLenZero == true {
+			log.Infof("ignore invalid 'pathlenzero' value")
+		} else {
+			policy.Default.CAConstraint.MaxPathLenZero = req.CA.PathLenZero
+		}
+	}
+
+	csrPEM, err = csr.Generate(priv, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	s, err := local.NewSigner(priv, nil, signer.DefaultSigAlgo(priv), policy)
+	if err != nil {
+		log.Errorf("failed to create signer: %v", err)
+		return
+	}
+
+	signReq := signer.SignRequest{Request: string(csrPEM)}
+	cert, err = s.Sign(signReq)
+	return
+}
+
+// RenewFromSigner re-creates a root certificate from the CA cert and crypto.Signer.
+// The resulting root certificate will have ca certificate
+// as the template and have the same expiry length. E.g. the exsiting CA
+// is valid for a year from Jan 01 2015 to Jan 01 2016, the renewed certificate
+// will be valid from now and expire in one year as well.
+func RenewFromSigner(ca *x509.Certificate, priv crypto.Signer) ([]byte, error) {
+	if !ca.IsCA {
+		return nil, errors.New("input certificate is not a CA cert")
+	}
+
+	// matching certificate public key vs private key
+	switch {
+	case ca.PublicKeyAlgorithm == x509.RSA:
+
+		var rsaPublicKey *rsa.PublicKey
+		var ok bool
+		if rsaPublicKey, ok = priv.Public().(*rsa.PublicKey); !ok {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+		if ca.PublicKey.(*rsa.PublicKey).N.Cmp(rsaPublicKey.N) != 0 {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+	case ca.PublicKeyAlgorithm == x509.ECDSA:
+		var ecdsaPublicKey *ecdsa.PublicKey
+		var ok bool
+		if ecdsaPublicKey, ok = priv.Public().(*ecdsa.PublicKey); !ok {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+		if ca.PublicKey.(*ecdsa.PublicKey).X.Cmp(ecdsaPublicKey.X) != 0 {
+			return nil, cferr.New(cferr.PrivateKeyError, cferr.KeyMismatch)
+		}
+	default:
+		return nil, cferr.New(cferr.PrivateKeyError, cferr.NotRSAOrECC)
+	}
+
+	req := csr.ExtractCertificateRequest(ca)
+
+	cert, _, err := NewFromSigner(req, priv)
+	return cert, err
+
+}
+
+// CAPolicy contains the CA issuing policy as default policy.
+var CAPolicy = func() *config.Signing {
+	return &config.Signing{
+		Default: &config.SigningProfile{
+			Usage:        []string{"cert sign", "crl sign"},
+			ExpiryString: "43800h",
+			Expiry:       5 * helpers.OneYear,
+			CAConstraint: config.CAConstraint{IsCA: true},
+		},
+	}
+}

--- a/vendor/github.com/cloudflare/cfssl/log/log.go
+++ b/vendor/github.com/cloudflare/cfssl/log/log.go
@@ -1,0 +1,162 @@
+// Package log implements a wrapper around the Go standard library's
+// logging package. Clients should set the current log level; only
+// messages below that level will actually be logged. For example, if
+// Level is set to LevelWarning, only log messages at the Warning,
+// Error, and Critical levels will be logged.
+package log
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+// The following constants represent logging levels in increasing levels of seriousness.
+const (
+	// LevelDebug is the log level for Debug statements.
+	LevelDebug = iota
+	// LevelInfo is the log level for Info statements.
+	LevelInfo
+	// LevelWarning is the log level for Warning statements.
+	LevelWarning
+	// LevelError is the log level for Error statements.
+	LevelError
+	// LevelCritical is the log level for Critical statements.
+	LevelCritical
+	// LevelFatal is the log level for Fatal statements.
+	LevelFatal
+)
+
+var levelPrefix = [...]string{
+	LevelDebug:    "DEBUG",
+	LevelInfo:     "INFO",
+	LevelWarning:  "WARNING",
+	LevelError:    "ERROR",
+	LevelCritical: "CRITICAL",
+	LevelFatal:    "FATAL",
+}
+
+// Level stores the current logging level.
+var Level = LevelInfo
+
+// SyslogWriter specifies the necessary methods for an alternate output
+// destination passed in via SetLogger.
+//
+// SyslogWriter is satisfied by *syslog.Writer.
+type SyslogWriter interface {
+	Debug(string)
+	Info(string)
+	Warning(string)
+	Err(string)
+	Crit(string)
+	Emerg(string)
+}
+
+// syslogWriter stores the SetLogger() parameter.
+var syslogWriter SyslogWriter
+
+// SetLogger sets the output used for output by this package.
+// A *syslog.Writer is a good choice for the logger parameter.
+// Call with a nil parameter to revert to default behavior.
+func SetLogger(logger SyslogWriter) {
+	syslogWriter = logger
+}
+
+func print(l int, msg string) {
+	if l >= Level {
+		if syslogWriter != nil {
+			switch l {
+			case LevelDebug:
+				syslogWriter.Debug(msg)
+			case LevelInfo:
+				syslogWriter.Info(msg)
+			case LevelWarning:
+				syslogWriter.Warning(msg)
+			case LevelError:
+				syslogWriter.Err(msg)
+			case LevelCritical:
+				syslogWriter.Crit(msg)
+			case LevelFatal:
+				syslogWriter.Emerg(msg)
+			}
+		} else {
+			log.Printf("[%s] %s", levelPrefix[l], msg)
+		}
+	}
+}
+
+func outputf(l int, format string, v []interface{}) {
+	print(l, fmt.Sprintf(format, v...))
+}
+
+func output(l int, v []interface{}) {
+	print(l, fmt.Sprint(v...))
+}
+
+// Fatalf logs a formatted message at the "fatal" level and then exits. The
+// arguments are handled in the same manner as fmt.Printf.
+func Fatalf(format string, v ...interface{}) {
+	outputf(LevelFatal, format, v)
+	os.Exit(1)
+}
+
+// Fatal logs its arguments at the "fatal" level and then exits.
+func Fatal(v ...interface{}) {
+	output(LevelFatal, v)
+	os.Exit(1)
+}
+
+// Criticalf logs a formatted message at the "critical" level. The
+// arguments are handled in the same manner as fmt.Printf.
+func Criticalf(format string, v ...interface{}) {
+	outputf(LevelCritical, format, v)
+}
+
+// Critical logs its arguments at the "critical" level.
+func Critical(v ...interface{}) {
+	output(LevelCritical, v)
+}
+
+// Errorf logs a formatted message at the "error" level. The arguments
+// are handled in the same manner as fmt.Printf.
+func Errorf(format string, v ...interface{}) {
+	outputf(LevelError, format, v)
+}
+
+// Error logs its arguments at the "error" level.
+func Error(v ...interface{}) {
+	output(LevelError, v)
+}
+
+// Warningf logs a formatted message at the "warning" level. The
+// arguments are handled in the same manner as fmt.Printf.
+func Warningf(format string, v ...interface{}) {
+	outputf(LevelWarning, format, v)
+}
+
+// Warning logs its arguments at the "warning" level.
+func Warning(v ...interface{}) {
+	output(LevelWarning, v)
+}
+
+// Infof logs a formatted message at the "info" level. The arguments
+// are handled in the same manner as fmt.Printf.
+func Infof(format string, v ...interface{}) {
+	outputf(LevelInfo, format, v)
+}
+
+// Info logs its arguments at the "info" level.
+func Info(v ...interface{}) {
+	output(LevelInfo, v)
+}
+
+// Debugf logs a formatted message at the "debug" level. The arguments
+// are handled in the same manner as fmt.Printf.
+func Debugf(format string, v ...interface{}) {
+	outputf(LevelDebug, format, v)
+}
+
+// Debug logs its arguments at the "debug" level.
+func Debug(v ...interface{}) {
+	output(LevelDebug, v)
+}

--- a/vendor/github.com/cloudflare/cfssl/ocsp/config/config.go
+++ b/vendor/github.com/cloudflare/cfssl/ocsp/config/config.go
@@ -1,0 +1,13 @@
+// Package config in the ocsp directory provides configuration data for an OCSP
+// signer.
+package config
+
+import "time"
+
+// Config contains configuration information required to set up an OCSP signer.
+type Config struct {
+	CACertFile        string
+	ResponderCertFile string
+	KeyFile           string
+	Interval          time.Duration
+}

--- a/vendor/github.com/cloudflare/cfssl/signer/local/local.go
+++ b/vendor/github.com/cloudflare/cfssl/signer/local/local.go
@@ -1,0 +1,469 @@
+// Package local implements certificate signature functionality for CFSSL.
+package local
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/mail"
+	"os"
+
+	"github.com/cloudflare/cfssl/certdb"
+	"github.com/cloudflare/cfssl/config"
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/info"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/cloudflare/cfssl/signer"
+	"github.com/google/certificate-transparency/go"
+	"github.com/google/certificate-transparency/go/client"
+)
+
+// Signer contains a signer that uses the standard library to
+// support both ECDSA and RSA CA keys.
+type Signer struct {
+	ca         *x509.Certificate
+	priv       crypto.Signer
+	policy     *config.Signing
+	sigAlgo    x509.SignatureAlgorithm
+	dbAccessor certdb.Accessor
+}
+
+// NewSigner creates a new Signer directly from a
+// private key and certificate, with optional policy.
+func NewSigner(priv crypto.Signer, cert *x509.Certificate, sigAlgo x509.SignatureAlgorithm, policy *config.Signing) (*Signer, error) {
+	if policy == nil {
+		policy = &config.Signing{
+			Profiles: map[string]*config.SigningProfile{},
+			Default:  config.DefaultConfig()}
+	}
+
+	if !policy.Valid() {
+		return nil, cferr.New(cferr.PolicyError, cferr.InvalidPolicy)
+	}
+
+	return &Signer{
+		ca:      cert,
+		priv:    priv,
+		sigAlgo: sigAlgo,
+		policy:  policy,
+	}, nil
+}
+
+// NewSignerFromFile generates a new local signer from a caFile
+// and a caKey file, both PEM encoded.
+func NewSignerFromFile(caFile, caKeyFile string, policy *config.Signing) (*Signer, error) {
+	log.Debug("Loading CA: ", caFile)
+	ca, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("Loading CA key: ", caKeyFile)
+	cakey, err := ioutil.ReadFile(caKeyFile)
+	if err != nil {
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.ReadFailed, err)
+	}
+
+	parsedCa, err := helpers.ParseCertificatePEM(ca)
+	if err != nil {
+		return nil, err
+	}
+
+	strPassword := os.Getenv("CFSSL_CA_PK_PASSWORD")
+	password := []byte(strPassword)
+	if strPassword == "" {
+		password = nil
+	}
+
+	priv, err := helpers.ParsePrivateKeyPEMWithPassword(cakey, password)
+	if err != nil {
+		log.Debug("Malformed private key %v", err)
+		return nil, err
+	}
+
+	return NewSigner(priv, parsedCa, signer.DefaultSigAlgo(priv), policy)
+}
+
+func (s *Signer) sign(template *x509.Certificate, profile *config.SigningProfile) (cert []byte, err error) {
+	var distPoints = template.CRLDistributionPoints
+	err = signer.FillTemplate(template, s.policy.Default, profile)
+	if distPoints != nil && len(distPoints) > 0 {
+		template.CRLDistributionPoints = distPoints
+	}
+	if err != nil {
+		return
+	}
+
+	var initRoot bool
+	if s.ca == nil {
+		if !template.IsCA {
+			err = cferr.New(cferr.PolicyError, cferr.InvalidRequest)
+			return
+		}
+		template.DNSNames = nil
+		template.EmailAddresses = nil
+		s.ca = template
+		initRoot = true
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, s.ca, template.PublicKey, s.priv)
+	if err != nil {
+		return nil, cferr.Wrap(cferr.CertificateError, cferr.Unknown, err)
+	}
+	if initRoot {
+		s.ca, err = x509.ParseCertificate(derBytes)
+		if err != nil {
+			return nil, cferr.Wrap(cferr.CertificateError, cferr.ParseFailed, err)
+		}
+	}
+
+	cert = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	log.Infof("signed certificate with serial number %d", template.SerialNumber)
+	return
+}
+
+// replaceSliceIfEmpty replaces the contents of replaced with newContents if
+// the slice referenced by replaced is empty
+func replaceSliceIfEmpty(replaced, newContents *[]string) {
+	if len(*replaced) == 0 {
+		*replaced = *newContents
+	}
+}
+
+// PopulateSubjectFromCSR has functionality similar to Name, except
+// it fills the fields of the resulting pkix.Name with req's if the
+// subject's corresponding fields are empty
+func PopulateSubjectFromCSR(s *signer.Subject, req pkix.Name) pkix.Name {
+	// if no subject, use req
+	if s == nil {
+		return req
+	}
+
+	name := s.Name()
+
+	if name.CommonName == "" {
+		name.CommonName = req.CommonName
+	}
+
+	replaceSliceIfEmpty(&name.Country, &req.Country)
+	replaceSliceIfEmpty(&name.Province, &req.Province)
+	replaceSliceIfEmpty(&name.Locality, &req.Locality)
+	replaceSliceIfEmpty(&name.Organization, &req.Organization)
+	replaceSliceIfEmpty(&name.OrganizationalUnit, &req.OrganizationalUnit)
+	if name.SerialNumber == "" {
+		name.SerialNumber = req.SerialNumber
+	}
+	return name
+}
+
+// OverrideHosts fills template's IPAddresses, EmailAddresses, and DNSNames with the
+// content of hosts, if it is not nil.
+func OverrideHosts(template *x509.Certificate, hosts []string) {
+	if hosts != nil {
+		template.IPAddresses = []net.IP{}
+		template.EmailAddresses = []string{}
+		template.DNSNames = []string{}
+	}
+
+	for i := range hosts {
+		if ip := net.ParseIP(hosts[i]); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else if email, err := mail.ParseAddress(hosts[i]); err == nil && email != nil {
+			template.EmailAddresses = append(template.EmailAddresses, email.Address)
+		} else {
+			template.DNSNames = append(template.DNSNames, hosts[i])
+		}
+	}
+
+}
+
+// Sign signs a new certificate based on the PEM-encoded client
+// certificate or certificate request with the signing profile,
+// specified by profileName.
+func (s *Signer) Sign(req signer.SignRequest) (cert []byte, err error) {
+	profile, err := signer.Profile(s, req.Profile)
+	if err != nil {
+		return
+	}
+
+	block, _ := pem.Decode([]byte(req.Request))
+	if block == nil {
+		return nil, cferr.New(cferr.CSRError, cferr.DecodeFailed)
+	}
+
+	if block.Type != "NEW CERTIFICATE REQUEST" && block.Type != "CERTIFICATE REQUEST" {
+		return nil, cferr.Wrap(cferr.CSRError,
+			cferr.BadRequest, errors.New("not a certificate or csr"))
+	}
+
+	csrTemplate, err := signer.ParseCertificateRequest(s, block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy out only the fields from the CSR authorized by policy.
+	safeTemplate := x509.Certificate{}
+	// If the profile contains no explicit whitelist, assume that all fields
+	// should be copied from the CSR.
+	if profile.CSRWhitelist == nil {
+		safeTemplate = *csrTemplate
+	} else {
+		if profile.CSRWhitelist.Subject {
+			safeTemplate.Subject = csrTemplate.Subject
+		}
+		if profile.CSRWhitelist.PublicKeyAlgorithm {
+			safeTemplate.PublicKeyAlgorithm = csrTemplate.PublicKeyAlgorithm
+		}
+		if profile.CSRWhitelist.PublicKey {
+			safeTemplate.PublicKey = csrTemplate.PublicKey
+		}
+		if profile.CSRWhitelist.SignatureAlgorithm {
+			safeTemplate.SignatureAlgorithm = csrTemplate.SignatureAlgorithm
+		}
+		if profile.CSRWhitelist.DNSNames {
+			safeTemplate.DNSNames = csrTemplate.DNSNames
+		}
+		if profile.CSRWhitelist.IPAddresses {
+			safeTemplate.IPAddresses = csrTemplate.IPAddresses
+		}
+		if profile.CSRWhitelist.EmailAddresses {
+			safeTemplate.EmailAddresses = csrTemplate.EmailAddresses
+		}
+	}
+
+	if req.CRLOverride != "" {
+		safeTemplate.CRLDistributionPoints = []string{req.CRLOverride}
+	}
+
+	if safeTemplate.IsCA {
+		if !profile.CAConstraint.IsCA {
+			log.Error("local signer policy disallows issuing CA certificate")
+			return nil, cferr.New(cferr.PolicyError, cferr.InvalidRequest)
+		}
+
+		if s.ca != nil && s.ca.MaxPathLen > 0 {
+			if safeTemplate.MaxPathLen >= s.ca.MaxPathLen {
+				log.Error("local signer certificate disallows CA MaxPathLen extending")
+				// do not sign a cert with pathlen > current
+				return nil, cferr.New(cferr.PolicyError, cferr.InvalidRequest)
+			}
+		} else if s.ca != nil && s.ca.MaxPathLen == 0 && s.ca.MaxPathLenZero {
+			log.Error("local signer certificate disallows issuing CA certificate")
+			// signer has pathlen of 0, do not sign more intermediate CAs
+			return nil, cferr.New(cferr.PolicyError, cferr.InvalidRequest)
+		}
+	}
+
+	OverrideHosts(&safeTemplate, req.Hosts)
+	safeTemplate.Subject = PopulateSubjectFromCSR(req.Subject, safeTemplate.Subject)
+
+	// If there is a whitelist, ensure that both the Common Name and SAN DNSNames match
+	if profile.NameWhitelist != nil {
+		if safeTemplate.Subject.CommonName != "" {
+			if profile.NameWhitelist.Find([]byte(safeTemplate.Subject.CommonName)) == nil {
+				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
+			}
+		}
+		for _, name := range safeTemplate.DNSNames {
+			if profile.NameWhitelist.Find([]byte(name)) == nil {
+				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
+			}
+		}
+		for _, name := range safeTemplate.EmailAddresses {
+			if profile.NameWhitelist.Find([]byte(name)) == nil {
+				return nil, cferr.New(cferr.PolicyError, cferr.UnmatchedWhitelist)
+			}
+		}
+	}
+
+	if profile.ClientProvidesSerialNumbers {
+		if req.Serial == nil {
+			return nil, cferr.New(cferr.CertificateError, cferr.MissingSerial)
+		}
+		safeTemplate.SerialNumber = req.Serial
+	} else {
+		// RFC 5280 4.1.2.2:
+		// Certificate users MUST be able to handle serialNumber
+		// values up to 20 octets.  Conforming CAs MUST NOT use
+		// serialNumber values longer than 20 octets.
+		//
+		// If CFSSL is providing the serial numbers, it makes
+		// sense to use the max supported size.
+		serialNumber := make([]byte, 20)
+		_, err = io.ReadFull(rand.Reader, serialNumber)
+		if err != nil {
+			return nil, cferr.Wrap(cferr.CertificateError, cferr.Unknown, err)
+		}
+
+		// SetBytes interprets buf as the bytes of a big-endian
+		// unsigned integer. The leading byte should be masked
+		// off to ensure it isn't negative.
+		serialNumber[0] &= 0x7F
+
+		safeTemplate.SerialNumber = new(big.Int).SetBytes(serialNumber)
+	}
+
+	if len(req.Extensions) > 0 {
+		for _, ext := range req.Extensions {
+			oid := asn1.ObjectIdentifier(ext.ID)
+			if !profile.ExtensionWhitelist[oid.String()] {
+				return nil, cferr.New(cferr.CertificateError, cferr.InvalidRequest)
+			}
+
+			rawValue, err := hex.DecodeString(ext.Value)
+			if err != nil {
+				return nil, cferr.Wrap(cferr.CertificateError, cferr.InvalidRequest, err)
+			}
+
+			safeTemplate.ExtraExtensions = append(safeTemplate.ExtraExtensions, pkix.Extension{
+				Id:       oid,
+				Critical: ext.Critical,
+				Value:    rawValue,
+			})
+		}
+	}
+
+	var certTBS = safeTemplate
+
+	if len(profile.CTLogServers) > 0 {
+		// Add a poison extension which prevents validation
+		var poisonExtension = pkix.Extension{Id: signer.CTPoisonOID, Critical: true, Value: []byte{0x05, 0x00}}
+		var poisonedPreCert = certTBS
+		poisonedPreCert.ExtraExtensions = append(safeTemplate.ExtraExtensions, poisonExtension)
+		cert, err = s.sign(&poisonedPreCert, profile)
+		if err != nil {
+			return
+		}
+
+		derCert, _ := pem.Decode(cert)
+		prechain := []ct.ASN1Cert{derCert.Bytes, s.ca.Raw}
+		var sctList []ct.SignedCertificateTimestamp
+
+		for _, server := range profile.CTLogServers {
+			log.Infof("submitting poisoned precertificate to %s", server)
+			var ctclient = client.New(server, nil)
+			var resp *ct.SignedCertificateTimestamp
+			resp, err = ctclient.AddPreChain(prechain)
+			if err != nil {
+				return nil, cferr.Wrap(cferr.CTError, cferr.PrecertSubmissionFailed, err)
+			}
+			sctList = append(sctList, *resp)
+		}
+
+		var serializedSCTList []byte
+		serializedSCTList, err = serializeSCTList(sctList)
+		if err != nil {
+			return nil, cferr.Wrap(cferr.CTError, cferr.Unknown, err)
+		}
+
+		// Serialize again as an octet string before embedding
+		serializedSCTList, err = asn1.Marshal(serializedSCTList)
+		if err != nil {
+			return nil, cferr.Wrap(cferr.CTError, cferr.Unknown, err)
+		}
+
+		var SCTListExtension = pkix.Extension{Id: signer.SCTListOID, Critical: false, Value: serializedSCTList}
+		certTBS.ExtraExtensions = append(certTBS.ExtraExtensions, SCTListExtension)
+	}
+	var signedCert []byte
+	signedCert, err = s.sign(&certTBS, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.dbAccessor != nil {
+		var certRecord = certdb.CertificateRecord{
+			Serial: certTBS.SerialNumber.String(),
+			// this relies on the specific behavior of x509.CreateCertificate
+			// which updates certTBS AuthorityKeyId from the signer's SubjectKeyId
+			AKI:     hex.EncodeToString(certTBS.AuthorityKeyId),
+			CALabel: req.Label,
+			Status:  "good",
+			Expiry:  certTBS.NotAfter,
+			PEM:     string(signedCert),
+		}
+
+		err = s.dbAccessor.InsertCertificate(certRecord)
+		if err != nil {
+			return nil, err
+		}
+		log.Debug("saved certificate with serial number ", certTBS.SerialNumber)
+	}
+
+	return signedCert, nil
+}
+
+func serializeSCTList(sctList []ct.SignedCertificateTimestamp) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, sct := range sctList {
+		sct, err := ct.SerializeSCT(sct)
+		if err != nil {
+			return nil, err
+		}
+		binary.Write(&buf, binary.BigEndian, uint16(len(sct)))
+		buf.Write(sct)
+	}
+
+	var sctListLengthField = make([]byte, 2)
+	binary.BigEndian.PutUint16(sctListLengthField, uint16(buf.Len()))
+	return bytes.Join([][]byte{sctListLengthField, buf.Bytes()}, nil), nil
+}
+
+// Info return a populated info.Resp struct or an error.
+func (s *Signer) Info(req info.Req) (resp *info.Resp, err error) {
+	cert, err := s.Certificate(req.Label, req.Profile)
+	if err != nil {
+		return
+	}
+
+	profile, err := signer.Profile(s, req.Profile)
+	if err != nil {
+		return
+	}
+
+	resp = new(info.Resp)
+	if cert.Raw != nil {
+		resp.Certificate = string(bytes.TrimSpace(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})))
+	}
+	resp.Usage = profile.Usage
+	resp.ExpiryString = profile.ExpiryString
+
+	return
+}
+
+// SigAlgo returns the RSA signer's signature algorithm.
+func (s *Signer) SigAlgo() x509.SignatureAlgorithm {
+	return s.sigAlgo
+}
+
+// Certificate returns the signer's certificate.
+func (s *Signer) Certificate(label, profile string) (*x509.Certificate, error) {
+	cert := *s.ca
+	return &cert, nil
+}
+
+// SetPolicy sets the signer's signature policy.
+func (s *Signer) SetPolicy(policy *config.Signing) {
+	s.policy = policy
+}
+
+// SetDBAccessor sets the signers' cert db accessor
+func (s *Signer) SetDBAccessor(dba certdb.Accessor) {
+	s.dbAccessor = dba
+}
+
+// Policy returns the signer's policy.
+func (s *Signer) Policy() *config.Signing {
+	return s.policy
+}

--- a/vendor/github.com/cloudflare/cfssl/signer/signer.go
+++ b/vendor/github.com/cloudflare/cfssl/signer/signer.go
@@ -1,0 +1,412 @@
+// Package signer implements certificate signature functionality for CFSSL.
+package signer
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/cloudflare/cfssl/certdb"
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/csr"
+	cferr "github.com/cloudflare/cfssl/errors"
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/info"
+)
+
+// Subject contains the information that should be used to override the
+// subject information when signing a certificate.
+type Subject struct {
+	CN           string
+	Names        []csr.Name `json:"names"`
+	SerialNumber string
+}
+
+// Extension represents a raw extension to be included in the certificate.  The
+// "value" field must be hex encoded.
+type Extension struct {
+	ID       config.OID `json:"id"`
+	Critical bool       `json:"critical"`
+	Value    string     `json:"value"`
+}
+
+// SignRequest stores a signature request, which contains the hostname,
+// the CSR, optional subject information, and the signature profile.
+//
+// Extensions provided in the signRequest are copied into the certificate, as
+// long as they are in the ExtensionWhitelist for the signer's policy.
+// Extensions requested in the CSR are ignored, except for those processed by
+// ParseCertificateRequest (mainly subjectAltName).
+type SignRequest struct {
+	Hosts       []string    `json:"hosts"`
+	Request     string      `json:"certificate_request"`
+	Subject     *Subject    `json:"subject,omitempty"`
+	Profile     string      `json:"profile"`
+	CRLOverride string      `json:"crl_override"`
+	Label       string      `json:"label"`
+	Serial      *big.Int    `json:"serial,omitempty"`
+	Extensions  []Extension `json:"extensions,omitempty"`
+}
+
+// appendIf appends to a if s is not an empty string.
+func appendIf(s string, a *[]string) {
+	if s != "" {
+		*a = append(*a, s)
+	}
+}
+
+// Name returns the PKIX name for the subject.
+func (s *Subject) Name() pkix.Name {
+	var name pkix.Name
+	name.CommonName = s.CN
+
+	for _, n := range s.Names {
+		appendIf(n.C, &name.Country)
+		appendIf(n.ST, &name.Province)
+		appendIf(n.L, &name.Locality)
+		appendIf(n.O, &name.Organization)
+		appendIf(n.OU, &name.OrganizationalUnit)
+	}
+	name.SerialNumber = s.SerialNumber
+	return name
+}
+
+// SplitHosts takes a comma-spearated list of hosts and returns a slice
+// with the hosts split
+func SplitHosts(hostList string) []string {
+	if hostList == "" {
+		return nil
+	}
+
+	return strings.Split(hostList, ",")
+}
+
+// A Signer contains a CA's certificate and private key for signing
+// certificates, a Signing policy to refer to and a SignatureAlgorithm.
+type Signer interface {
+	Info(info.Req) (*info.Resp, error)
+	Policy() *config.Signing
+	SetDBAccessor(certdb.Accessor)
+	SetPolicy(*config.Signing)
+	SigAlgo() x509.SignatureAlgorithm
+	Sign(req SignRequest) (cert []byte, err error)
+}
+
+// Profile gets the specific profile from the signer
+func Profile(s Signer, profile string) (*config.SigningProfile, error) {
+	var p *config.SigningProfile
+	policy := s.Policy()
+	if policy != nil && policy.Profiles != nil && profile != "" {
+		p = policy.Profiles[profile]
+	}
+
+	if p == nil && policy != nil {
+		p = policy.Default
+	}
+
+	if p == nil {
+		return nil, cferr.Wrap(cferr.APIClientError, cferr.ClientHTTPError, errors.New("profile must not be nil"))
+	}
+	return p, nil
+}
+
+// DefaultSigAlgo returns an appropriate X.509 signature algorithm given
+// the CA's private key.
+func DefaultSigAlgo(priv crypto.Signer) x509.SignatureAlgorithm {
+	pub := priv.Public()
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		keySize := pub.N.BitLen()
+		switch {
+		case keySize >= 4096:
+			return x509.SHA512WithRSA
+		case keySize >= 3072:
+			return x509.SHA384WithRSA
+		case keySize >= 2048:
+			return x509.SHA256WithRSA
+		default:
+			return x509.SHA1WithRSA
+		}
+	case *ecdsa.PublicKey:
+		switch pub.Curve {
+		case elliptic.P256():
+			return x509.ECDSAWithSHA256
+		case elliptic.P384():
+			return x509.ECDSAWithSHA384
+		case elliptic.P521():
+			return x509.ECDSAWithSHA512
+		default:
+			return x509.ECDSAWithSHA1
+		}
+	default:
+		return x509.UnknownSignatureAlgorithm
+	}
+}
+
+// ParseCertificateRequest takes an incoming certificate request and
+// builds a certificate template from it.
+func ParseCertificateRequest(s Signer, csrBytes []byte) (template *x509.Certificate, err error) {
+	csrv, err := x509.ParseCertificateRequest(csrBytes)
+	if err != nil {
+		err = cferr.Wrap(cferr.CSRError, cferr.ParseFailed, err)
+		return
+	}
+
+	err = helpers.CheckSignature(csrv, csrv.SignatureAlgorithm, csrv.RawTBSCertificateRequest, csrv.Signature)
+	if err != nil {
+		err = cferr.Wrap(cferr.CSRError, cferr.KeyMismatch, err)
+		return
+	}
+
+	template = &x509.Certificate{
+		Subject:            csrv.Subject,
+		PublicKeyAlgorithm: csrv.PublicKeyAlgorithm,
+		PublicKey:          csrv.PublicKey,
+		SignatureAlgorithm: s.SigAlgo(),
+		DNSNames:           csrv.DNSNames,
+		IPAddresses:        csrv.IPAddresses,
+		EmailAddresses:     csrv.EmailAddresses,
+	}
+
+	for _, val := range csrv.Extensions {
+		// Check the CSR for the X.509 BasicConstraints (RFC 5280, 4.2.1.9)
+		// extension and append to template if necessary
+		if val.Id.Equal(asn1.ObjectIdentifier{2, 5, 29, 19}) {
+			var constraints csr.BasicConstraints
+			var rest []byte
+
+			if rest, err = asn1.Unmarshal(val.Value, &constraints); err != nil {
+				return nil, cferr.Wrap(cferr.CSRError, cferr.ParseFailed, err)
+			} else if len(rest) != 0 {
+				return nil, cferr.Wrap(cferr.CSRError, cferr.ParseFailed, errors.New("x509: trailing data after X.509 BasicConstraints"))
+			}
+
+			template.BasicConstraintsValid = true
+			template.IsCA = constraints.IsCA
+			template.MaxPathLen = constraints.MaxPathLen
+			template.MaxPathLenZero = template.MaxPathLen == 0
+		}
+	}
+
+	return
+}
+
+type subjectPublicKeyInfo struct {
+	Algorithm        pkix.AlgorithmIdentifier
+	SubjectPublicKey asn1.BitString
+}
+
+// ComputeSKI derives an SKI from the certificate's public key in a
+// standard manner. This is done by computing the SHA-1 digest of the
+// SubjectPublicKeyInfo component of the certificate.
+func ComputeSKI(template *x509.Certificate) ([]byte, error) {
+	pub := template.PublicKey
+	encodedPub, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	var subPKI subjectPublicKeyInfo
+	_, err = asn1.Unmarshal(encodedPub, &subPKI)
+	if err != nil {
+		return nil, err
+	}
+
+	pubHash := sha1.Sum(subPKI.SubjectPublicKey.Bytes)
+	return pubHash[:], nil
+}
+
+// FillTemplate is a utility function that tries to load as much of
+// the certificate template as possible from the profiles and current
+// template. It fills in the key uses, expiration, revocation URLs
+// and SKI.
+func FillTemplate(template *x509.Certificate, defaultProfile, profile *config.SigningProfile) error {
+	ski, err := ComputeSKI(template)
+
+	var (
+		eku             []x509.ExtKeyUsage
+		ku              x509.KeyUsage
+		backdate        time.Duration
+		expiry          time.Duration
+		notBefore       time.Time
+		notAfter        time.Time
+		crlURL, ocspURL string
+		issuerURL       = profile.IssuerURL
+	)
+
+	// The third value returned from Usages is a list of unknown key usages.
+	// This should be used when validating the profile at load, and isn't used
+	// here.
+	ku, eku, _ = profile.Usages()
+	if profile.IssuerURL == nil {
+		issuerURL = defaultProfile.IssuerURL
+	}
+
+	if ku == 0 && len(eku) == 0 {
+		return cferr.New(cferr.PolicyError, cferr.NoKeyUsages)
+	}
+
+	if expiry = profile.Expiry; expiry == 0 {
+		expiry = defaultProfile.Expiry
+	}
+
+	if crlURL = profile.CRL; crlURL == "" {
+		crlURL = defaultProfile.CRL
+	}
+	if ocspURL = profile.OCSP; ocspURL == "" {
+		ocspURL = defaultProfile.OCSP
+	}
+	if backdate = profile.Backdate; backdate == 0 {
+		backdate = -5 * time.Minute
+	} else {
+		backdate = -1 * profile.Backdate
+	}
+
+	if !profile.NotBefore.IsZero() {
+		notBefore = profile.NotBefore.UTC()
+	} else {
+		notBefore = time.Now().Round(time.Minute).Add(backdate).UTC()
+	}
+
+	if !profile.NotAfter.IsZero() {
+		notAfter = profile.NotAfter.UTC()
+	} else {
+		notAfter = notBefore.Add(expiry).UTC()
+	}
+
+	template.NotBefore = notBefore
+	template.NotAfter = notAfter
+	template.KeyUsage = ku
+	template.ExtKeyUsage = eku
+	template.BasicConstraintsValid = true
+	template.IsCA = profile.CAConstraint.IsCA
+	if template.IsCA {
+		template.MaxPathLen = profile.CAConstraint.MaxPathLen
+		if template.MaxPathLen == 0 {
+			template.MaxPathLenZero = profile.CAConstraint.MaxPathLenZero
+		}
+		template.DNSNames = nil
+		template.EmailAddresses = nil
+	}
+	template.SubjectKeyId = ski
+
+	if ocspURL != "" {
+		template.OCSPServer = []string{ocspURL}
+	}
+	if crlURL != "" {
+		template.CRLDistributionPoints = []string{crlURL}
+	}
+
+	if len(issuerURL) != 0 {
+		template.IssuingCertificateURL = issuerURL
+	}
+	if len(profile.Policies) != 0 {
+		err = addPolicies(template, profile.Policies)
+		if err != nil {
+			return cferr.Wrap(cferr.PolicyError, cferr.InvalidPolicy, err)
+		}
+	}
+	if profile.OCSPNoCheck {
+		ocspNoCheckExtension := pkix.Extension{
+			Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 48, 1, 5},
+			Critical: false,
+			Value:    []byte{0x05, 0x00},
+		}
+		template.ExtraExtensions = append(template.ExtraExtensions, ocspNoCheckExtension)
+	}
+
+	return nil
+}
+
+type policyInformation struct {
+	PolicyIdentifier asn1.ObjectIdentifier
+	Qualifiers       []interface{} `asn1:"tag:optional,omitempty"`
+}
+
+type cpsPolicyQualifier struct {
+	PolicyQualifierID asn1.ObjectIdentifier
+	Qualifier         string `asn1:"tag:optional,ia5"`
+}
+
+type userNotice struct {
+	ExplicitText string `asn1:"tag:optional,utf8"`
+}
+type userNoticePolicyQualifier struct {
+	PolicyQualifierID asn1.ObjectIdentifier
+	Qualifier         userNotice
+}
+
+var (
+	// Per https://tools.ietf.org/html/rfc3280.html#page-106, this represents:
+	// iso(1) identified-organization(3) dod(6) internet(1) security(5)
+	//   mechanisms(5) pkix(7) id-qt(2) id-qt-cps(1)
+	iDQTCertificationPracticeStatement = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
+	// iso(1) identified-organization(3) dod(6) internet(1) security(5)
+	//   mechanisms(5) pkix(7) id-qt(2) id-qt-unotice(2)
+	iDQTUserNotice = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
+
+	// CTPoisonOID is the object ID of the critical poison extension for precertificates
+	// https://tools.ietf.org/html/rfc6962#page-9
+	CTPoisonOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
+
+	// SCTListOID is the object ID for the Signed Certificate Timestamp certificate extension
+	// https://tools.ietf.org/html/rfc6962#page-14
+	SCTListOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}
+)
+
+// addPolicies adds Certificate Policies and optional Policy Qualifiers to a
+// certificate, based on the input config. Go's x509 library allows setting
+// Certificate Policies easily, but does not support nested Policy Qualifiers
+// under those policies. So we need to construct the ASN.1 structure ourselves.
+func addPolicies(template *x509.Certificate, policies []config.CertificatePolicy) error {
+	asn1PolicyList := []policyInformation{}
+
+	for _, policy := range policies {
+		pi := policyInformation{
+			// The PolicyIdentifier is an OID assigned to a given issuer.
+			PolicyIdentifier: asn1.ObjectIdentifier(policy.ID),
+		}
+		for _, qualifier := range policy.Qualifiers {
+			switch qualifier.Type {
+			case "id-qt-unotice":
+				pi.Qualifiers = append(pi.Qualifiers,
+					userNoticePolicyQualifier{
+						PolicyQualifierID: iDQTUserNotice,
+						Qualifier: userNotice{
+							ExplicitText: qualifier.Value,
+						},
+					})
+			case "id-qt-cps":
+				pi.Qualifiers = append(pi.Qualifiers,
+					cpsPolicyQualifier{
+						PolicyQualifierID: iDQTCertificationPracticeStatement,
+						Qualifier:         qualifier.Value,
+					})
+			default:
+				return errors.New("Invalid qualifier type in Policies " + qualifier.Type)
+			}
+		}
+		asn1PolicyList = append(asn1PolicyList, pi)
+	}
+
+	asn1Bytes, err := asn1.Marshal(asn1PolicyList)
+	if err != nil {
+		return err
+	}
+
+	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
+		Id:       asn1.ObjectIdentifier{2, 5, 29, 32},
+		Critical: false,
+		Value:    asn1Bytes,
+	})
+	return nil
+}

--- a/vendor/github.com/google/certificate-transparency/LICENSE
+++ b/vendor/github.com/google/certificate-transparency/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/certificate-transparency/README.Fedora
+++ b/vendor/github.com/google/certificate-transparency/README.Fedora
@@ -1,0 +1,91 @@
+## Quickstart on Fedora 22 ##
+
+Please attempt to use the GClient build as documented in the 
+[main readme](README.md) as this is an easier process and will be
+maintained in future.
+
+If GClient works and tests pass then the following procedures are not
+required.
+
+## Deprecated Manual Build Process ##
+
+Note: This assumes a Workstation install for x64. The additional dependency
+packages that need to be installed may vary if you are starting with a
+different base system.
+
+
+Install Dependencies:
+
+```bash
+sudo dnf update
+sudo dnf install cmake gcc-g++ libevent-devel golang autoconf pkgconfig \
+    json-c-devel gflags-devel glog-devel protobuf-devel leveldb-devel \
+    openssl-devel gperftools-devel protobuf-compiler sqlite-devel ant \
+    java-1.8.0-openjdk-devel protobuf-java python-gflags protobuf-python \
+    python-ecdsa python-mock python-httplib2 git ldns-devel automake \
+    libtool shtool libunwind-devel
+```
+
+Other Libraries
+
+
+The `gflags` in Fedora is v2.1 and is using the new default namespace option of
+‘gflags’ rather than ‘google’ so we need to build our own version. 
+
+```bash
+git clone https://github.com/gflags/gflags.git
+cd gflags
+cmake -DGFLAGS_NAMESPACE:STRING=google \
+    -DCMAKE_CXX_FLAGS:STRING=-fPIC .
+make
+cd ..
+```
+
+Next, we need `libevhtp` version `1.2.10` which is not packaged in Fedora, so
+we build from source:
+
+```bash
+wget https://github.com/ellzey/libevhtp/archive/1.2.10.zip
+unzip 1.2.10.zip
+cd libevhtp-1.2.10/
+cmake -DEVHTP_DISABLE_REGEX:STRING=ON -DCMAKE_C_FLAGS:STRING=-fPIC .
+make
+cd ..
+```
+
+And let's get our own Google Test / Google Mock as these vary in incompatible
+ways between packaged releases:
+
+```bash
+wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip
+unzip gmock-1.7.0.zip
+```
+Now, clone the CT repo:
+
+```bash
+git clone https://github.com/google/certificate-transparency.git
+cd certificate-transparency/
+```
+
+One-time setup for Go:
+
+```bash
+export GOPATH=$PWD/go
+mkdir -p $GOPATH/src/github.com/google
+ln -s $PWD $GOPATH/src/github.com/google
+go get -v -d ./...
+```
+
+Build CT server C++ code:
+
+```bash
+./autogen.sh
+./configure GTEST_DIR=../gmock-1.7.0/gtest GMOCK_DIR=../gmock-1.7.0 \
+    CPPFLAGS="-I../libevhtp-1.2.10 -I../libevhtp-1.2.10/evthr \
+    -I../libevhtp-1.2.10/htparse -I../gflags/include" \
+    LDFLAGS=”-L../libevhtp-1.2.10 -L../gflags/lib”
+make check 
+```
+
+The remainder of the Java, Go and Python steps should be very similar to those
+documented for Ubuntu in the [main readme file](README.md).

--- a/vendor/github.com/google/certificate-transparency/README.MacOS
+++ b/vendor/github.com/google/certificate-transparency/README.MacOS
@@ -1,0 +1,57 @@
+## OSX Builds Now Use GClient ##
+
+We recommend that you use GClient to build on OSX. Please follow the 
+instructions in the [main readme](README.md) file.
+
+## Trusted root certificates ##
+
+The CT code requires a set of trusted root certificates in order to:
+   1. Validate outbound HTTPS connections
+   2. (In the case of the log-server) decide whether to accept a certificate
+      chain for inclusion.
+
+On OSX, the system version of OpenSSL (0.9.8gz at time of writing) contains
+Apple-provided patches which intercept failed chain validations and re-attempts
+them using roots obtained from the system keychain. Since we use a much more
+recent (and unpatched) version of OpenSSL this behaviour is unsupported and so
+a PEM file containing the trusted root certs must be used.
+
+## Specifying root certificates to be used
+
+To use a certificate PEM bundle file with the CT C++ code, the following
+methods may be used:
+
+### For verifying outbound HTTPS connections:
+
+Either set the
+`--trusted_roots_certs' flag, or the `SSL_CERT_FILE` environment variable, to
+point to the location of the PEM file containing the root certificates to be
+used to verify the outbound HTTPS connection.
+
+### Incoming inclusion requests (ct-server only)
+
+Set the `--trusted_cert_file` flag to point to the location of the PEM file
+containing the set of root certificates whose chains should be accepted for
+inclusion into the log.
+
+## Sources of trusted roots
+
+Obviously the choice of root certificates to trust for outbound HTTPS
+connections and incoming inclusion requests are a matter of operating policy,
+but it is often useful to have a set of common roots for testing and
+development at the very least.
+
+While OSX ships with a set of common trusted roots, they are not directly
+available to OpenSSL and must be exported from the keychain first.  This can be
+achieved with the following command:
+
+```bash
+security find-certificates -a -p /Library/Keychains/System.keychain > certs.pem
+security find-certificates -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> certs.pem
+```
+
+## Deprecated Build Process ##
+
+This may be out of date and is not guaranteed to work.
+
+gtest: install from source.

--- a/vendor/github.com/google/certificate-transparency/README.md
+++ b/vendor/github.com/google/certificate-transparency/README.md
@@ -1,0 +1,269 @@
+certificate-transparency
+========================
+
+#Auditing for TLS certificates#
+
+[![Build Status](https://travis-ci.org/google/certificate-transparency.svg?branch=master)](https://travis-ci.org/google/certificate-transparency)
+
+
+## Build With GClient ##
+
+This is now the recommended method for all supported platforms. It gives you 
+a reproducible build and avoids the need to build some dependencies manually.
+
+Known to work on FreeBSD 10, OS X (10.10) [tested with XCode + brew installation
+of deps listed below], and Ubuntu 14.04. Tested on Fedora 22 but may require
+manual override of compiler options as documented below. Tested on CentOS 7
+with similar caveats.
+
+### Install Dependencies ###
+
+Depending on which platform you have the exact packages required will vary.
+The following tools must be available for the GClient build to succeed:
+
+ - autoconf/automake etc.
+ - clang++ (>=3.4)
+ - cmake (>=v3.1.2)
+ - git
+ - GNU make
+ - libtool
+ - shtool
+ - Tcl
+ - pkgconf
+ - python27
+ - [depot_tools](https://www.chromium.org/developers/how-tos/install-depot-tools)
+
+### Building with gclient ###
+
+```bash
+export CXX=clang++ CC=clang
+mkdir ct  # or whatever directory you prefer
+cd ct
+gclient config --name="certificate-transparency" https://github.com/google/certificate-transparency.git
+gclient sync
+# substitute gmake or gnumake below if that's what your platform calls it:
+make -C certificate-transparency check
+```
+
+If you're trying to clone from a branch on the CT repo then you'll need to
+substitute the following command for the `gclient config` command above,
+replacing `branch` as appropriate
+
+```bash
+gclient config --name="certificate-transparency" https://github.com/google/certificate-transparency.git@branch
+```
+
+### Platform Specific Notes ###
+
+#### Fedora / CentOS ####
+
+When you issue the `gclient sync` command you may need to set compiler options
+in order to build successfully. If the build fails to work try using:
+
+```bash
+CXXFLAGS="-O2 -Wno-error=unused-variable" gclient sync
+```
+
+If this gives an error about an unused typedef in a `glog` header file try this:
+
+```bash
+CXXFLAGS="-O2 -Wno-error=unused-variable -Wno-error=unused-local-typedefs" gclient sync
+```
+
+When changing `CXXFLAGS` it's safer to remove the existing build directories
+in case not all dependencies are properly accounted for and rebuilt. If 
+problems persist check that the Makefile in `certificate-transparency` 
+contains the options that were passed in `CXXFLAGS`.
+
+If there are still problems using GClient then an older style build can be
+attempted. The process should be similar to the one documented for Ubuntu
+below or in the [Fedora README](README.Fedora) depending on platform.
+
+## Deprecated: Quickstart on Ubuntu ##
+
+This should no longer be needed as the instructions above should work. But in
+case of difficulties the dependencies can be built manually. The following 
+steps will checkout the code and build it on a clean Ubuntu 14.04 LTS 
+installation.  It has also been tested on an Ubuntu 15.04 installation.
+
+First, install packaged dependencies:
+
+    sudo apt-get update -qq
+    sudo apt-get install -qq unzip cmake g++ libevent-dev golang-go autoconf pkg-config \
+        libjson-c-dev libgflags-dev libgoogle-glog-dev libprotobuf-dev libleveldb-dev \
+        libssl-dev libgoogle-perftools-dev protobuf-compiler libsqlite3-dev ant openjdk-7-jdk \
+        libprotobuf-java python-gflags python-protobuf python-ecdsa python-mock \
+        python-httplib2 git libldns-dev
+
+Next, we need `libevhtp` version `1.2.10` which is not packaged in Ubuntu yet, so we build from source:
+
+    wget https://github.com/ellzey/libevhtp/archive/1.2.10.zip
+    unzip 1.2.10.zip
+    cd libevhtp-1.2.10/
+    cmake -DEVHTP_DISABLE_REGEX:STRING=ON -DCMAKE_C_FLAGS:STRING=-fPIC .
+    make
+    cd ..
+
+And let's get our own Google Test / Google Mock as these vary in incompatible ways between packaged releases:
+
+    wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip
+    unzip gmock-1.7.0.zip
+
+Now, clone the CT repo:
+
+    git clone https://github.com/google/certificate-transparency.git
+    cd certificate-transparency/
+
+One-time setup for Go:
+
+    export GOPATH=$PWD/go
+    mkdir -p $GOPATH/src/github.com/google
+    ln -s $PWD $GOPATH/src/github.com/google
+    go get -v -d ./...
+
+Build CT server C++ code:
+
+    ./autogen.sh
+    ./configure GTEST_DIR=../gmock-1.7.0/gtest GMOCK_DIR=../gmock-1.7.0 \
+        CPPFLAGS="-I../libevhtp-1.2.10 -I../libevhtp-1.2.10/evthr \
+        -I../libevhtp-1.2.10/htparse" LDFLAGS=-L../libevhtp-1.2.10
+    make check
+
+Build and test Java code:
+
+    ant build test
+
+Build and test Python code:
+
+    make -C python test
+
+Best and test Go code:
+
+    go test -v ./go/...
+
+
+## Deprecated: Older Build Method ##
+
+ - [OpenSSL](https://www.openssl.org/source/), at least 1.0.0q,
+   preferably 1.0.1l or 1.0.2 (and up)
+
+The checking of SCTs included in the
+[RFC 6962](http://tools.ietf.org/html/rfc6962) TLS extension is only
+included in OpenSSL 1.0.2. As of this writing, this version is not yet
+released, so this means hand building the `OpenSSL_1_0_2-stable`
+branch from the
+[OpenSSL git repository](https://www.openssl.org/source/repos.html).
+
+ - [googlemock](https://github.com/google/googlemock) (tested with 1.7.0)
+
+Gmock provides a bundled version of gtest, which will also be used.
+
+Unpack googlemock, but do not build it. Upstream recommends to build a
+new copy from source for each package to be tested. We follow this
+advice in our `Makefile`, which builds gmock/gtest automatically.
+
+Some systems make the googlemock source available as a package; on
+Debian, this is in the google-mock package, which puts it in
+`/usr/src/gmock`. Our `Makefile` looks in that location by default,
+but if your googlemock sources are in a different location, set the
+`GMOCK_DIR` environment variable to point at them.
+
+If you are on FreeBSD, you may need to apply the patch in gtest.patch
+to the gtest subdirectory of gmock.
+
+ - [protobuf](https://github.com/google/protobuf) (tested with 2.5.0)
+ - [gflags](https://github.com/gflags/gflags) (tested with 1.6
+   and 2.0)
+ - [glog](https://github.com/google/glog) (tested with 0.3.1)
+
+Make sure to install glog **after** gflags, to avoid linking errors.
+
+ - [sqlite3](http://www.sqlite.org/)
+ - [leveldb](https://github.com/google/leveldb)
+ - [JSON-C](https://github.com/json-c/json-c/), at least 0.11
+
+You can specify a JSON-C library in a non-standard location using the
+`JSONCLIBDIR` environment variable. Version 0.10 would work as well,
+except the `json_object_iterator.h` header is not properly copied when
+installing. If you can install the missing header manually, it should
+work.
+
+ - [libevent](http://libevent.org/) (tested with 2.0.21-stable)
+ - [libevhtp](https://github.com/ellzey/libevhtp) (tested with 1.2.10)
+ If building libevhtp from source, you may need to disable the regex support
+ with the following cmake flag: `-DEVHTP_DISABLE_REGEX:STRING=ON`
+
+You can specify a non-installed locally built library using the
+`LIBEVENTDIR` environment variable to point to the local build. Note
+that the FreeBSD port version 2.0.21_2 does not appear to work
+correctly (it only listens on IPv6 for the HTTP server) - for that
+platform we had to build from the source, specifically commit
+6dba1694c89119c44cef03528945e5a5978ab43a.
+
+ - [ldns](http://www.nlnetlabs.nl/projects/ldns/)
+ - [ant](http://ant.apache.org/)
+ - Python libraries:
+  - pyasn1 and pyasn1-modules (optional, needed for `upload_server_cert.sh`)
+  - [dnspython](http://www.dnspython.org/)
+
+### Building ###
+
+You can build the log server with the following commands:
+
+    $ ./autogen.sh  # only necessary if you're building from git
+    $ ./configure
+    $ make
+
+You can give the `configure` script extra parameters, to set
+compilation flags, or point to custom versions of some dependencies
+(notably, googlemock often needs this). For example, to compile with
+Clang, using googlemock in `$HOME/gmock`, and a custom libevent in
+`$HOME/libevent`:
+
+    $ ./configure CXX=clang++ GMOCK_DIR=$HOME CPPFLAGS="-I$HOME/libevent/include" LDFLAGS="-L$HOME/libevent/.libs"
+
+Running `./configure --help` provides more information about various
+variables that can be set.
+
+## Running Unit Tests ##
+
+Run unit tests with this command
+
+    $ make check
+
+If the build still fails because of missing libraries, you may need to
+set the environment variable `LD_LIBRARY_PATH`. On Linux, if you did
+not change the default installation path (such as `/usr/local/lib`),
+running
+
+    $ ldconfig
+
+or, if needed,
+
+    $ sudo ldconfig
+
+should resolve the problem.
+
+## End-To-End Tests ##
+
+For end-to-end server-client tests, you will need to install Apache
+and point the tests to it. See `test/README` for how to do so.
+
+## Testing and Logging Options ##
+
+Note that several tests write files on disk. The default directory for
+storing temporary testdata is `/tmp`. You can change this by setting
+`TMPDIR=<tmpdir>` for make.
+
+End-to-end tests also create temporary certificate and server files in
+`test/tmp`. All these files are cleaned up after a successful test
+run.
+
+For logging options, see
+http://google-glog.googlecode.com/svn/trunk/doc/glog.html
+
+By default, unit tests log to stderr, and log only messages with a FATAL level
+(i.e., those that result in abnormal program termination).
+You can override the defaults with command-line flags.
+
+End-to-end tests log everything at INFO level and above.

--- a/vendor/github.com/google/certificate-transparency/cpp/third_party/curl/hostcheck.c
+++ b/vendor/github.com/google/certificate-transparency/cpp/third_party/curl/hostcheck.c
@@ -1,0 +1,214 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+/* This file is an amalgamation of hostcheck.c and most of rawstr.c
+   from cURL.  The contents of the COPYING file mentioned above are:
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1996 - 2013, Daniel Stenberg, <daniel@haxx.se>.
+
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright
+notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization of the copyright holder.
+*/
+
+#include "hostcheck.h"
+#include <string.h>
+
+/* Portable, consistent toupper (remember EBCDIC). Do not use toupper() because
+   its behavior is altered by the current locale. */
+static char Curl_raw_toupper(char in) {
+  switch (in) {
+    case 'a':
+      return 'A';
+    case 'b':
+      return 'B';
+    case 'c':
+      return 'C';
+    case 'd':
+      return 'D';
+    case 'e':
+      return 'E';
+    case 'f':
+      return 'F';
+    case 'g':
+      return 'G';
+    case 'h':
+      return 'H';
+    case 'i':
+      return 'I';
+    case 'j':
+      return 'J';
+    case 'k':
+      return 'K';
+    case 'l':
+      return 'L';
+    case 'm':
+      return 'M';
+    case 'n':
+      return 'N';
+    case 'o':
+      return 'O';
+    case 'p':
+      return 'P';
+    case 'q':
+      return 'Q';
+    case 'r':
+      return 'R';
+    case 's':
+      return 'S';
+    case 't':
+      return 'T';
+    case 'u':
+      return 'U';
+    case 'v':
+      return 'V';
+    case 'w':
+      return 'W';
+    case 'x':
+      return 'X';
+    case 'y':
+      return 'Y';
+    case 'z':
+      return 'Z';
+  }
+  return in;
+}
+
+/*
+ * Curl_raw_equal() is for doing "raw" case insensitive strings. This is meant
+ * to be locale independent and only compare strings we know are safe for
+ * this.  See http://daniel.haxx.se/blog/2008/10/15/strcasecmp-in-turkish/ for
+ * some further explanation to why this function is necessary.
+ *
+ * The function is capable of comparing a-z case insensitively even for
+ * non-ascii.
+ */
+
+static int Curl_raw_equal(const char *first, const char *second) {
+  while (*first && *second) {
+    if (Curl_raw_toupper(*first) != Curl_raw_toupper(*second))
+      /* get out of the loop as soon as they don't match */
+      break;
+    first++;
+    second++;
+  }
+  /* we do the comparison here (possibly again), just to make sure that if the
+     loop above is skipped because one of the strings reached zero, we must not
+     return this as a successful match */
+  return (Curl_raw_toupper(*first) == Curl_raw_toupper(*second));
+}
+
+static int Curl_raw_nequal(const char *first, const char *second, size_t max) {
+  while (*first && *second && max) {
+    if (Curl_raw_toupper(*first) != Curl_raw_toupper(*second)) {
+      break;
+    }
+    max--;
+    first++;
+    second++;
+  }
+  if (0 == max)
+    return 1; /* they are equal this far */
+
+  return Curl_raw_toupper(*first) == Curl_raw_toupper(*second);
+}
+
+/*
+ * Match a hostname against a wildcard pattern.
+ * E.g.
+ *  "foo.host.com" matches "*.host.com".
+ *
+ * We use the matching rule described in RFC6125, section 6.4.3.
+ * http://tools.ietf.org/html/rfc6125#section-6.4.3
+ */
+
+static int hostmatch(const char *hostname, const char *pattern) {
+  const char *pattern_label_end, *pattern_wildcard, *hostname_label_end;
+  int wildcard_enabled;
+  size_t prefixlen, suffixlen;
+  pattern_wildcard = strchr(pattern, '*');
+  if (pattern_wildcard == NULL)
+    return Curl_raw_equal(pattern, hostname) ? CURL_HOST_MATCH
+                                             : CURL_HOST_NOMATCH;
+
+  /* We require at least 2 dots in pattern to avoid too wide wildcard
+     match. */
+  wildcard_enabled = 1;
+  pattern_label_end = strchr(pattern, '.');
+  if (pattern_label_end == NULL ||
+      strchr(pattern_label_end + 1, '.') == NULL ||
+      pattern_wildcard > pattern_label_end ||
+      Curl_raw_nequal(pattern, "xn--", 4)) {
+    wildcard_enabled = 0;
+  }
+  if (!wildcard_enabled)
+    return Curl_raw_equal(pattern, hostname) ? CURL_HOST_MATCH
+                                             : CURL_HOST_NOMATCH;
+
+  hostname_label_end = strchr(hostname, '.');
+  if (hostname_label_end == NULL ||
+      !Curl_raw_equal(pattern_label_end, hostname_label_end))
+    return CURL_HOST_NOMATCH;
+
+  /* The wildcard must match at least one character, so the left-most
+     label of the hostname is at least as large as the left-most label
+     of the pattern. */
+  if (hostname_label_end - hostname < pattern_label_end - pattern)
+    return CURL_HOST_NOMATCH;
+
+  prefixlen = pattern_wildcard - pattern;
+  suffixlen = pattern_label_end - (pattern_wildcard + 1);
+  return Curl_raw_nequal(pattern, hostname, prefixlen) &&
+                 Curl_raw_nequal(pattern_wildcard + 1,
+                                 hostname_label_end - suffixlen, suffixlen)
+             ? CURL_HOST_MATCH
+             : CURL_HOST_NOMATCH;
+}
+
+int Curl_cert_hostcheck(const char *match_pattern, const char *hostname) {
+  if (!match_pattern || !*match_pattern || !hostname ||
+      !*hostname) /* sanity check */
+    return 0;
+
+  if (Curl_raw_equal(hostname, match_pattern)) /* trivial case */
+    return 1;
+
+  if (hostmatch(hostname, match_pattern) == CURL_HOST_MATCH)
+    return 1;
+  return 0;
+}

--- a/vendor/github.com/google/certificate-transparency/cpp/third_party/curl/hostcheck.h
+++ b/vendor/github.com/google/certificate-transparency/cpp/third_party/curl/hostcheck.h
@@ -1,0 +1,29 @@
+#ifndef HEADER_CURL_HOSTCHECK_H
+#define HEADER_CURL_HOSTCHECK_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#define CURL_HOST_NOMATCH 0
+#define CURL_HOST_MATCH 1
+int Curl_cert_hostcheck(const char* match_pattern, const char* hostname);
+
+#endif /* HEADER_CURL_HOSTCHECK_H */

--- a/vendor/github.com/google/certificate-transparency/cpp/third_party/isec_partners/openssl_hostname_validation.c
+++ b/vendor/github.com/google/certificate-transparency/cpp/third_party/isec_partners/openssl_hostname_validation.c
@@ -1,0 +1,180 @@
+/* Obtained from: https://github.com/iSECPartners/ssl-conservatory */
+
+/*
+Copyright (C) 2012, iSEC Partners.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+/*
+ * Helper functions to perform basic hostname validation using OpenSSL.
+ *
+ * Please read "everything-you-wanted-to-know-about-openssl.pdf" before
+ * attempting to use this code. This whitepaper describes how the code works,
+ * how it should be used, and what its limitations are.
+ *
+ * Author:  Alban Diquet
+ * License: See LICENSE
+ *
+ */
+
+
+#include <openssl/x509v3.h>
+#include <openssl/ssl.h>
+
+#include "third_party/curl/hostcheck.h"
+#include "third_party/isec_partners/openssl_hostname_validation.h"
+
+#define HOSTNAME_MAX_SIZE 255
+
+/**
+* Tries to find a match for hostname in the certificate's Common Name field.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if the Common Name had a NUL character embedded
+* in it.
+* Returns Error if the Common Name could not be extracted.
+*/
+static HostnameValidationResult matches_common_name(const char *hostname,
+                                                    const X509 *server_cert) {
+  int common_name_loc = -1;
+  X509_NAME_ENTRY *common_name_entry = NULL;
+  ASN1_STRING *common_name_asn1 = NULL;
+  char *common_name_str = NULL;
+
+  // Find the position of the CN field in the Subject field of the certificate
+  common_name_loc =
+      X509_NAME_get_index_by_NID(X509_get_subject_name((X509 *)server_cert),
+                                 NID_commonName, -1);
+  if (common_name_loc < 0) {
+    return Error;
+  }
+
+  // Extract the CN field
+  common_name_entry =
+      X509_NAME_get_entry(X509_get_subject_name((X509 *)server_cert),
+                          common_name_loc);
+  if (common_name_entry == NULL) {
+    return Error;
+  }
+
+  // Convert the CN field to a C string
+  common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
+  if (common_name_asn1 == NULL) {
+    return Error;
+  }
+  common_name_str = (char *)ASN1_STRING_data(common_name_asn1);
+
+  // Make sure there isn't an embedded NUL character in the CN
+  if ((size_t)ASN1_STRING_length(common_name_asn1) !=
+      strlen(common_name_str)) {
+    return MalformedCertificate;
+  }
+
+  // Compare expected hostname with the CN
+  if (Curl_cert_hostcheck(common_name_str, hostname) == CURL_HOST_MATCH) {
+    return MatchFound;
+  } else {
+    return MatchNotFound;
+  }
+}
+
+
+/**
+* Tries to find a match for hostname in the certificate's Subject Alternative
+* Name extension.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if any of the hostnames had a NUL character
+* embedded in it.
+* Returns NoSANPresent if the SAN extension was not present in the certificate.
+*/
+static HostnameValidationResult matches_subject_alternative_name(
+    const char *hostname, const X509 *server_cert) {
+  HostnameValidationResult result = MatchNotFound;
+  int i;
+  int san_names_nb = -1;
+  STACK_OF(GENERAL_NAME) *san_names = NULL;
+
+  // Try to extract the names within the SAN extension from the certificate
+  san_names =
+      X509_get_ext_d2i((X509 *)server_cert, NID_subject_alt_name, NULL, NULL);
+  if (san_names == NULL) {
+    return NoSANPresent;
+  }
+  san_names_nb = sk_GENERAL_NAME_num(san_names);
+
+  // Check each name within the extension
+  for (i = 0; i < san_names_nb; i++) {
+    const GENERAL_NAME *current_name = sk_GENERAL_NAME_value(san_names, i);
+
+    if (current_name->type == GEN_DNS) {
+      // Current name is a DNS name, let's check it
+      char *dns_name = (char *)ASN1_STRING_data(current_name->d.dNSName);
+
+      // Make sure there isn't an embedded NUL character in the DNS name
+      if ((size_t)ASN1_STRING_length(current_name->d.dNSName) !=
+          strlen(dns_name)) {
+        result = MalformedCertificate;
+        break;
+      } else {  // Compare expected hostname with the DNS name
+        if (Curl_cert_hostcheck(dns_name, hostname) == CURL_HOST_MATCH) {
+          result = MatchFound;
+          break;
+        }
+      }
+    }
+  }
+  sk_GENERAL_NAME_pop_free(san_names, GENERAL_NAME_free);
+
+  return result;
+}
+
+
+/**
+* Validates the server's identity by looking for the expected hostname in the
+* server's certificate. As described in RFC 6125, it first tries to find a
+* match
+* in the Subject Alternative Name extension. If the extension is not present in
+* the certificate, it checks the Common Name instead.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if any of the hostnames had a NUL character
+* embedded in it.
+* Returns Error if there was an error.
+*/
+HostnameValidationResult validate_hostname(const char *hostname,
+                                           const X509 *server_cert) {
+  HostnameValidationResult result;
+
+  if ((hostname == NULL) || (server_cert == NULL))
+    return Error;
+
+  // First try the Subject Alternative Names extension
+  result = matches_subject_alternative_name(hostname, server_cert);
+  if (result == NoSANPresent) {
+    // Extension was not found: try the Common Name
+    result = matches_common_name(hostname, server_cert);
+  }
+
+  return result;
+}

--- a/vendor/github.com/google/certificate-transparency/cpp/third_party/isec_partners/openssl_hostname_validation.h
+++ b/vendor/github.com/google/certificate-transparency/cpp/third_party/isec_partners/openssl_hostname_validation.h
@@ -1,0 +1,59 @@
+/* Obtained from: https://github.com/iSECPartners/ssl-conservatory */
+
+/*
+Copyright (C) 2012, iSEC Partners.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+/*
+ * Helper functions to perform basic hostname validation using OpenSSL.
+ *
+ * Please read "everything-you-wanted-to-know-about-openssl.pdf" before
+ * attempting to use this code. This whitepaper describes how the code works,
+ * how it should be used, and what its limitations are.
+ *
+ * Author:  Alban Diquet
+ * License: See LICENSE
+ *
+ */
+
+typedef enum {
+  MatchFound,
+  MatchNotFound,
+  NoSANPresent,
+  MalformedCertificate,
+  Error
+} HostnameValidationResult;
+
+/**
+* Validates the server's identity by looking for the expected hostname in the
+* server's certificate. As described in RFC 6125, it first tries to find a
+* match
+* in the Subject Alternative Name extension. If the extension is not present in
+* the certificate, it checks the Common Name instead.
+*
+* Returns MatchFound if a match was found.
+* Returns MatchNotFound if no matches were found.
+* Returns MalformedCertificate if any of the hostnames had a NUL character
+* embedded in it.
+* Returns Error if there was an error.
+*/
+HostnameValidationResult validate_hostname(const char* hostname,
+                                           const X509* server_cert);

--- a/vendor/github.com/google/certificate-transparency/cpp/version.h
+++ b/vendor/github.com/google/certificate-transparency/cpp/version.h
@@ -1,0 +1,12 @@
+#ifndef CERT_TRANS_VERSION_H_
+#define CERT_TRANS_VERSION_H_
+
+namespace cert_trans {
+
+
+extern const char kBuildVersion[];
+
+
+}  // namespace cert_trans
+
+#endif  // CERT_TRANS_VERSION_H_

--- a/vendor/github.com/google/certificate-transparency/go/README.md
+++ b/vendor/github.com/google/certificate-transparency/go/README.md
@@ -1,0 +1,25 @@
+This is the really early beginnings of a certificate transparency log
+client written in Go, along with a log scanner tool.
+
+You'll need go v1.1 or higher to compile.
+
+# Installation
+
+This go code must be imported into your go workspace before you can
+use it, which can be done with:
+
+    go get github.com/google/certificate-transparency/go/client
+    go get github.com/google/certificate-transparency/go/scanner
+    etc.
+
+# Building the binaries
+
+To compile the log scanner run:
+
+    go build github.com/google/certificate-transparency/go/scanner/main/scanner.go
+
+# Contributing
+
+When sending pull requests, please ensure that everything's been run
+through ```gofmt``` beforehand so we can keep everything nice and
+tidy.

--- a/vendor/github.com/google/certificate-transparency/go/asn1/asn1.go
+++ b/vendor/github.com/google/certificate-transparency/go/asn1/asn1.go
@@ -1,0 +1,956 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package asn1 implements parsing of DER-encoded ASN.1 data structures,
+// as defined in ITU-T Rec X.690.
+//
+// See also ``A Layman's Guide to a Subset of ASN.1, BER, and DER,''
+// http://luca.ntop.org/Teaching/Appunti/asn1.html.
+//
+// START CT CHANGES
+// This is a fork of the Go standard library ASN.1 implementation
+// (encoding/asn1).  The main difference is that this version tries to correct
+// for errors (e.g. use of tagPrintableString when the string data is really
+// ISO8859-1 - a common error present in many x509 certificates in the wild.)
+// END CT CHANGES
+package asn1
+
+// ASN.1 is a syntax for specifying abstract objects and BER, DER, PER, XER etc
+// are different encoding formats for those objects. Here, we'll be dealing
+// with DER, the Distinguished Encoding Rules. DER is used in X.509 because
+// it's fast to parse and, unlike BER, has a unique encoding for every object.
+// When calculating hashes over objects, it's important that the resulting
+// bytes be the same at both ends and DER removes this margin of error.
+//
+// ASN.1 is very complex and this package doesn't attempt to implement
+// everything by any means.
+
+import (
+	// START CT CHANGES
+	"errors"
+	"fmt"
+	// END CT CHANGES
+	"math/big"
+	"reflect"
+	// START CT CHANGES
+	"strings"
+	// END CT CHANGES
+	"time"
+)
+
+// A StructuralError suggests that the ASN.1 data is valid, but the Go type
+// which is receiving it doesn't match.
+type StructuralError struct {
+	Msg string
+}
+
+func (e StructuralError) Error() string { return "asn1: structure error: " + e.Msg }
+
+// A SyntaxError suggests that the ASN.1 data is invalid.
+type SyntaxError struct {
+	Msg string
+}
+
+func (e SyntaxError) Error() string { return "asn1: syntax error: " + e.Msg }
+
+// We start by dealing with each of the primitive types in turn.
+
+// BOOLEAN
+
+func parseBool(bytes []byte) (ret bool, err error) {
+	if len(bytes) != 1 {
+		err = SyntaxError{"invalid boolean"}
+		return
+	}
+
+	// DER demands that "If the encoding represents the boolean value TRUE,
+	// its single contents octet shall have all eight bits set to one."
+	// Thus only 0 and 255 are valid encoded values.
+	switch bytes[0] {
+	case 0:
+		ret = false
+	case 0xff:
+		ret = true
+	default:
+		err = SyntaxError{"invalid boolean"}
+	}
+
+	return
+}
+
+// INTEGER
+
+// parseInt64 treats the given bytes as a big-endian, signed integer and
+// returns the result.
+func parseInt64(bytes []byte) (ret int64, err error) {
+	if len(bytes) > 8 {
+		// We'll overflow an int64 in this case.
+		err = StructuralError{"integer too large"}
+		return
+	}
+	for bytesRead := 0; bytesRead < len(bytes); bytesRead++ {
+		ret <<= 8
+		ret |= int64(bytes[bytesRead])
+	}
+
+	// Shift up and down in order to sign extend the result.
+	ret <<= 64 - uint8(len(bytes))*8
+	ret >>= 64 - uint8(len(bytes))*8
+	return
+}
+
+// parseInt treats the given bytes as a big-endian, signed integer and returns
+// the result.
+func parseInt32(bytes []byte) (int32, error) {
+	ret64, err := parseInt64(bytes)
+	if err != nil {
+		return 0, err
+	}
+	if ret64 != int64(int32(ret64)) {
+		return 0, StructuralError{"integer too large"}
+	}
+	return int32(ret64), nil
+}
+
+var bigOne = big.NewInt(1)
+
+// parseBigInt treats the given bytes as a big-endian, signed integer and returns
+// the result.
+func parseBigInt(bytes []byte) *big.Int {
+	ret := new(big.Int)
+	if len(bytes) > 0 && bytes[0]&0x80 == 0x80 {
+		// This is a negative number.
+		notBytes := make([]byte, len(bytes))
+		for i := range notBytes {
+			notBytes[i] = ^bytes[i]
+		}
+		ret.SetBytes(notBytes)
+		ret.Add(ret, bigOne)
+		ret.Neg(ret)
+		return ret
+	}
+	ret.SetBytes(bytes)
+	return ret
+}
+
+// BIT STRING
+
+// BitString is the structure to use when you want an ASN.1 BIT STRING type. A
+// bit string is padded up to the nearest byte in memory and the number of
+// valid bits is recorded. Padding bits will be zero.
+type BitString struct {
+	Bytes     []byte // bits packed into bytes.
+	BitLength int    // length in bits.
+}
+
+// At returns the bit at the given index. If the index is out of range it
+// returns false.
+func (b BitString) At(i int) int {
+	if i < 0 || i >= b.BitLength {
+		return 0
+	}
+	x := i / 8
+	y := 7 - uint(i%8)
+	return int(b.Bytes[x]>>y) & 1
+}
+
+// RightAlign returns a slice where the padding bits are at the beginning. The
+// slice may share memory with the BitString.
+func (b BitString) RightAlign() []byte {
+	shift := uint(8 - (b.BitLength % 8))
+	if shift == 8 || len(b.Bytes) == 0 {
+		return b.Bytes
+	}
+
+	a := make([]byte, len(b.Bytes))
+	a[0] = b.Bytes[0] >> shift
+	for i := 1; i < len(b.Bytes); i++ {
+		a[i] = b.Bytes[i-1] << (8 - shift)
+		a[i] |= b.Bytes[i] >> shift
+	}
+
+	return a
+}
+
+// parseBitString parses an ASN.1 bit string from the given byte slice and returns it.
+func parseBitString(bytes []byte) (ret BitString, err error) {
+	if len(bytes) == 0 {
+		err = SyntaxError{"zero length BIT STRING"}
+		return
+	}
+	paddingBits := int(bytes[0])
+	if paddingBits > 7 ||
+		len(bytes) == 1 && paddingBits > 0 ||
+		bytes[len(bytes)-1]&((1<<bytes[0])-1) != 0 {
+		err = SyntaxError{"invalid padding bits in BIT STRING"}
+		return
+	}
+	ret.BitLength = (len(bytes)-1)*8 - paddingBits
+	ret.Bytes = bytes[1:]
+	return
+}
+
+// OBJECT IDENTIFIER
+
+// An ObjectIdentifier represents an ASN.1 OBJECT IDENTIFIER.
+type ObjectIdentifier []int
+
+// Equal reports whether oi and other represent the same identifier.
+func (oi ObjectIdentifier) Equal(other ObjectIdentifier) bool {
+	if len(oi) != len(other) {
+		return false
+	}
+	for i := 0; i < len(oi); i++ {
+		if oi[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// parseObjectIdentifier parses an OBJECT IDENTIFIER from the given bytes and
+// returns it. An object identifier is a sequence of variable length integers
+// that are assigned in a hierarchy.
+func parseObjectIdentifier(bytes []byte) (s []int, err error) {
+	if len(bytes) == 0 {
+		err = SyntaxError{"zero length OBJECT IDENTIFIER"}
+		return
+	}
+
+	// In the worst case, we get two elements from the first byte (which is
+	// encoded differently) and then every varint is a single byte long.
+	s = make([]int, len(bytes)+1)
+
+	// The first varint is 40*value1 + value2:
+	// According to this packing, value1 can take the values 0, 1 and 2 only.
+	// When value1 = 0 or value1 = 1, then value2 is <= 39. When value1 = 2,
+	// then there are no restrictions on value2.
+	v, offset, err := parseBase128Int(bytes, 0)
+	if err != nil {
+		return
+	}
+	if v < 80 {
+		s[0] = v / 40
+		s[1] = v % 40
+	} else {
+		s[0] = 2
+		s[1] = v - 80
+	}
+
+	i := 2
+	for ; offset < len(bytes); i++ {
+		v, offset, err = parseBase128Int(bytes, offset)
+		if err != nil {
+			return
+		}
+		s[i] = v
+	}
+	s = s[0:i]
+	return
+}
+
+// ENUMERATED
+
+// An Enumerated is represented as a plain int.
+type Enumerated int
+
+// FLAG
+
+// A Flag accepts any data and is set to true if present.
+type Flag bool
+
+// parseBase128Int parses a base-128 encoded int from the given offset in the
+// given byte slice. It returns the value and the new offset.
+func parseBase128Int(bytes []byte, initOffset int) (ret, offset int, err error) {
+	offset = initOffset
+	for shifted := 0; offset < len(bytes); shifted++ {
+		if shifted > 4 {
+			err = StructuralError{"base 128 integer too large"}
+			return
+		}
+		ret <<= 7
+		b := bytes[offset]
+		ret |= int(b & 0x7f)
+		offset++
+		if b&0x80 == 0 {
+			return
+		}
+	}
+	err = SyntaxError{"truncated base 128 integer"}
+	return
+}
+
+// UTCTime
+
+func parseUTCTime(bytes []byte) (ret time.Time, err error) {
+	s := string(bytes)
+	ret, err = time.Parse("0601021504Z0700", s)
+	if err != nil {
+		ret, err = time.Parse("060102150405Z0700", s)
+	}
+	if err == nil && ret.Year() >= 2050 {
+		// UTCTime only encodes times prior to 2050. See https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1
+		ret = ret.AddDate(-100, 0, 0)
+	}
+
+	return
+}
+
+// parseGeneralizedTime parses the GeneralizedTime from the given byte slice
+// and returns the resulting time.
+func parseGeneralizedTime(bytes []byte) (ret time.Time, err error) {
+	return time.Parse("20060102150405Z0700", string(bytes))
+}
+
+// PrintableString
+
+// parsePrintableString parses a ASN.1 PrintableString from the given byte
+// array and returns it.
+func parsePrintableString(bytes []byte) (ret string, err error) {
+	for _, b := range bytes {
+		if !isPrintable(b) {
+			err = SyntaxError{"PrintableString contains invalid character"}
+			return
+		}
+	}
+	ret = string(bytes)
+	return
+}
+
+// isPrintable returns true iff the given b is in the ASN.1 PrintableString set.
+func isPrintable(b byte) bool {
+	return 'a' <= b && b <= 'z' ||
+		'A' <= b && b <= 'Z' ||
+		'0' <= b && b <= '9' ||
+		'\'' <= b && b <= ')' ||
+		'+' <= b && b <= '/' ||
+		b == ' ' ||
+		b == ':' ||
+		b == '=' ||
+		b == '?' ||
+		// This is technically not allowed in a PrintableString.
+		// However, x509 certificates with wildcard strings don't
+		// always use the correct string type so we permit it.
+		b == '*'
+}
+
+// IA5String
+
+// parseIA5String parses a ASN.1 IA5String (ASCII string) from the given
+// byte slice and returns it.
+func parseIA5String(bytes []byte) (ret string, err error) {
+	for _, b := range bytes {
+		if b >= 0x80 {
+			err = SyntaxError{"IA5String contains invalid character"}
+			return
+		}
+	}
+	ret = string(bytes)
+	return
+}
+
+// T61String
+
+// parseT61String parses a ASN.1 T61String (8-bit clean string) from the given
+// byte slice and returns it.
+func parseT61String(bytes []byte) (ret string, err error) {
+	return string(bytes), nil
+}
+
+// UTF8String
+
+// parseUTF8String parses a ASN.1 UTF8String (raw UTF-8) from the given byte
+// array and returns it.
+func parseUTF8String(bytes []byte) (ret string, err error) {
+	return string(bytes), nil
+}
+
+// A RawValue represents an undecoded ASN.1 object.
+type RawValue struct {
+	Class, Tag int
+	IsCompound bool
+	Bytes      []byte
+	FullBytes  []byte // includes the tag and length
+}
+
+// RawContent is used to signal that the undecoded, DER data needs to be
+// preserved for a struct. To use it, the first field of the struct must have
+// this type. It's an error for any of the other fields to have this type.
+type RawContent []byte
+
+// Tagging
+
+// parseTagAndLength parses an ASN.1 tag and length pair from the given offset
+// into a byte slice. It returns the parsed data and the new offset. SET and
+// SET OF (tag 17) are mapped to SEQUENCE and SEQUENCE OF (tag 16) since we
+// don't distinguish between ordered and unordered objects in this code.
+func parseTagAndLength(bytes []byte, initOffset int) (ret tagAndLength, offset int, err error) {
+	offset = initOffset
+	b := bytes[offset]
+	offset++
+	ret.class = int(b >> 6)
+	ret.isCompound = b&0x20 == 0x20
+	ret.tag = int(b & 0x1f)
+
+	// If the bottom five bits are set, then the tag number is actually base 128
+	// encoded afterwards
+	if ret.tag == 0x1f {
+		ret.tag, offset, err = parseBase128Int(bytes, offset)
+		if err != nil {
+			return
+		}
+	}
+	if offset >= len(bytes) {
+		err = SyntaxError{"truncated tag or length"}
+		return
+	}
+	b = bytes[offset]
+	offset++
+	if b&0x80 == 0 {
+		// The length is encoded in the bottom 7 bits.
+		ret.length = int(b & 0x7f)
+	} else {
+		// Bottom 7 bits give the number of length bytes to follow.
+		numBytes := int(b & 0x7f)
+		if numBytes == 0 {
+			err = SyntaxError{"indefinite length found (not DER)"}
+			return
+		}
+		ret.length = 0
+		for i := 0; i < numBytes; i++ {
+			if offset >= len(bytes) {
+				err = SyntaxError{"truncated tag or length"}
+				return
+			}
+			b = bytes[offset]
+			offset++
+			if ret.length >= 1<<23 {
+				// We can't shift ret.length up without
+				// overflowing.
+				err = StructuralError{"length too large"}
+				return
+			}
+			ret.length <<= 8
+			ret.length |= int(b)
+			if ret.length == 0 {
+				// DER requires that lengths be minimal.
+				err = StructuralError{"superfluous leading zeros in length"}
+				return
+			}
+		}
+	}
+
+	return
+}
+
+// parseSequenceOf is used for SEQUENCE OF and SET OF values. It tries to parse
+// a number of ASN.1 values from the given byte slice and returns them as a
+// slice of Go values of the given type.
+func parseSequenceOf(bytes []byte, sliceType reflect.Type, elemType reflect.Type) (ret reflect.Value, err error) {
+	expectedTag, compoundType, ok := getUniversalType(elemType)
+	if !ok {
+		err = StructuralError{"unknown Go type for slice"}
+		return
+	}
+
+	// First we iterate over the input and count the number of elements,
+	// checking that the types are correct in each case.
+	numElements := 0
+	for offset := 0; offset < len(bytes); {
+		var t tagAndLength
+		t, offset, err = parseTagAndLength(bytes, offset)
+		if err != nil {
+			return
+		}
+		// We pretend that GENERAL STRINGs are PRINTABLE STRINGs so
+		// that a sequence of them can be parsed into a []string.
+		if t.tag == tagGeneralString {
+			t.tag = tagPrintableString
+		}
+		if t.class != classUniversal || t.isCompound != compoundType || t.tag != expectedTag {
+			err = StructuralError{"sequence tag mismatch"}
+			return
+		}
+		if invalidLength(offset, t.length, len(bytes)) {
+			err = SyntaxError{"truncated sequence"}
+			return
+		}
+		offset += t.length
+		numElements++
+	}
+	ret = reflect.MakeSlice(sliceType, numElements, numElements)
+	params := fieldParameters{}
+	offset := 0
+	for i := 0; i < numElements; i++ {
+		offset, err = parseField(ret.Index(i), bytes, offset, params)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+var (
+	bitStringType        = reflect.TypeOf(BitString{})
+	objectIdentifierType = reflect.TypeOf(ObjectIdentifier{})
+	enumeratedType       = reflect.TypeOf(Enumerated(0))
+	flagType             = reflect.TypeOf(Flag(false))
+	timeType             = reflect.TypeOf(time.Time{})
+	rawValueType         = reflect.TypeOf(RawValue{})
+	rawContentsType      = reflect.TypeOf(RawContent(nil))
+	bigIntType           = reflect.TypeOf(new(big.Int))
+)
+
+// invalidLength returns true iff offset + length > sliceLength, or if the
+// addition would overflow.
+func invalidLength(offset, length, sliceLength int) bool {
+	return offset+length < offset || offset+length > sliceLength
+}
+
+// START CT CHANGES
+
+// Tests whether the data in |bytes| would be a valid ISO8859-1 string.
+// Clearly, a sequence of bytes comprised solely of valid ISO8859-1
+// codepoints does not imply that the encoding MUST be ISO8859-1, rather that
+// you would not encounter an error trying to interpret the data as such.
+func couldBeISO8859_1(bytes []byte) bool {
+	for _, b := range bytes {
+		if b < 0x20 || (b >= 0x7F && b < 0xA0) {
+			return false
+		}
+	}
+	return true
+}
+
+// Checks whether the data in |bytes| would be a valid T.61 string.
+// Clearly, a sequence of bytes comprised solely of valid T.61
+// codepoints does not imply that the encoding MUST be T.61, rather that
+// you would not encounter an error trying to interpret the data as such.
+func couldBeT61(bytes []byte) bool {
+	for _, b := range bytes {
+		switch b {
+		case 0x00:
+			// Since we're guessing at (incorrect) encodings for a
+			// PrintableString, we'll err on the side of caution and disallow
+			// strings with a NUL in them, don't want to re-create a PayPal NUL
+			// situation in monitors.
+			fallthrough
+		case 0x23, 0x24, 0x5C, 0x5E, 0x60, 0x7B, 0x7D, 0x7E, 0xA5, 0xA6, 0xAC, 0xAD, 0xAE, 0xAF,
+			0xB9, 0xBA, 0xC0, 0xC9, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9,
+			0xDA, 0xDB, 0xDC, 0xDE, 0xDF, 0xE5, 0xFF:
+			// These are all invalid code points in T.61, so it can't be a T.61 string.
+			return false
+		}
+	}
+	return true
+}
+
+// Converts the data in |bytes| to the equivalent UTF-8 string.
+func iso8859_1ToUTF8(bytes []byte) string {
+	buf := make([]rune, len(bytes))
+	for i, b := range bytes {
+		buf[i] = rune(b)
+	}
+	return string(buf)
+}
+
+// END CT CHANGES
+
+// parseField is the main parsing function. Given a byte slice and an offset
+// into the array, it will try to parse a suitable ASN.1 value out and store it
+// in the given Value.
+func parseField(v reflect.Value, bytes []byte, initOffset int, params fieldParameters) (offset int, err error) {
+	offset = initOffset
+	fieldType := v.Type()
+
+	// If we have run out of data, it may be that there are optional elements at the end.
+	if offset == len(bytes) {
+		if !setDefaultValue(v, params) {
+			err = SyntaxError{"sequence truncated"}
+		}
+		return
+	}
+
+	// Deal with raw values.
+	if fieldType == rawValueType {
+		var t tagAndLength
+		t, offset, err = parseTagAndLength(bytes, offset)
+		if err != nil {
+			return
+		}
+		if invalidLength(offset, t.length, len(bytes)) {
+			err = SyntaxError{"data truncated"}
+			return
+		}
+		result := RawValue{t.class, t.tag, t.isCompound, bytes[offset : offset+t.length], bytes[initOffset : offset+t.length]}
+		offset += t.length
+		v.Set(reflect.ValueOf(result))
+		return
+	}
+
+	// Deal with the ANY type.
+	if ifaceType := fieldType; ifaceType.Kind() == reflect.Interface && ifaceType.NumMethod() == 0 {
+		var t tagAndLength
+		t, offset, err = parseTagAndLength(bytes, offset)
+		if err != nil {
+			return
+		}
+		if invalidLength(offset, t.length, len(bytes)) {
+			err = SyntaxError{"data truncated"}
+			return
+		}
+		var result interface{}
+		if !t.isCompound && t.class == classUniversal {
+			innerBytes := bytes[offset : offset+t.length]
+			switch t.tag {
+			case tagPrintableString:
+				result, err = parsePrintableString(innerBytes)
+				// START CT CHANGES
+				if err != nil && strings.Contains(err.Error(), "PrintableString contains invalid character") {
+					// Probably an ISO8859-1 string stuffed in, check if it
+					// would be valid and assume that's what's happened if so,
+					// otherwise try T.61, failing that give up and just assign
+					// the bytes
+					switch {
+					case couldBeISO8859_1(innerBytes):
+						result, err = iso8859_1ToUTF8(innerBytes), nil
+					case couldBeT61(innerBytes):
+						result, err = parseT61String(innerBytes)
+					default:
+						result = nil
+						err = errors.New("PrintableString contains invalid character, but couldn't determine correct String type.")
+					}
+				}
+				// END CT CHANGES
+			case tagIA5String:
+				result, err = parseIA5String(innerBytes)
+			case tagT61String:
+				result, err = parseT61String(innerBytes)
+			case tagUTF8String:
+				result, err = parseUTF8String(innerBytes)
+			case tagInteger:
+				result, err = parseInt64(innerBytes)
+			case tagBitString:
+				result, err = parseBitString(innerBytes)
+			case tagOID:
+				result, err = parseObjectIdentifier(innerBytes)
+			case tagUTCTime:
+				result, err = parseUTCTime(innerBytes)
+			case tagOctetString:
+				result = innerBytes
+			default:
+				// If we don't know how to handle the type, we just leave Value as nil.
+			}
+		}
+		offset += t.length
+		if err != nil {
+			return
+		}
+		if result != nil {
+			v.Set(reflect.ValueOf(result))
+		}
+		return
+	}
+	universalTag, compoundType, ok1 := getUniversalType(fieldType)
+	if !ok1 {
+		err = StructuralError{fmt.Sprintf("unknown Go type: %v", fieldType)}
+		return
+	}
+
+	t, offset, err := parseTagAndLength(bytes, offset)
+	if err != nil {
+		return
+	}
+	if params.explicit {
+		expectedClass := classContextSpecific
+		if params.application {
+			expectedClass = classApplication
+		}
+		if t.class == expectedClass && t.tag == *params.tag && (t.length == 0 || t.isCompound) {
+			if t.length > 0 {
+				t, offset, err = parseTagAndLength(bytes, offset)
+				if err != nil {
+					return
+				}
+			} else {
+				if fieldType != flagType {
+					err = StructuralError{"zero length explicit tag was not an asn1.Flag"}
+					return
+				}
+				v.SetBool(true)
+				return
+			}
+		} else {
+			// The tags didn't match, it might be an optional element.
+			ok := setDefaultValue(v, params)
+			if ok {
+				offset = initOffset
+			} else {
+				err = StructuralError{"explicitly tagged member didn't match"}
+			}
+			return
+		}
+	}
+
+	// Special case for strings: all the ASN.1 string types map to the Go
+	// type string. getUniversalType returns the tag for PrintableString
+	// when it sees a string, so if we see a different string type on the
+	// wire, we change the universal type to match.
+	if universalTag == tagPrintableString {
+		switch t.tag {
+		case tagIA5String, tagGeneralString, tagT61String, tagUTF8String:
+			universalTag = t.tag
+		}
+	}
+
+	// Special case for time: UTCTime and GeneralizedTime both map to the
+	// Go type time.Time.
+	if universalTag == tagUTCTime && t.tag == tagGeneralizedTime {
+		universalTag = tagGeneralizedTime
+	}
+
+	expectedClass := classUniversal
+	expectedTag := universalTag
+
+	if !params.explicit && params.tag != nil {
+		expectedClass = classContextSpecific
+		expectedTag = *params.tag
+	}
+
+	if !params.explicit && params.application && params.tag != nil {
+		expectedClass = classApplication
+		expectedTag = *params.tag
+	}
+
+	// We have unwrapped any explicit tagging at this point.
+	if t.class != expectedClass || t.tag != expectedTag || t.isCompound != compoundType {
+		// Tags don't match. Again, it could be an optional element.
+		ok := setDefaultValue(v, params)
+		if ok {
+			offset = initOffset
+		} else {
+			err = StructuralError{fmt.Sprintf("tags don't match (%d vs %+v) %+v %s @%d", expectedTag, t, params, fieldType.Name(), offset)}
+		}
+		return
+	}
+	if invalidLength(offset, t.length, len(bytes)) {
+		err = SyntaxError{"data truncated"}
+		return
+	}
+	innerBytes := bytes[offset : offset+t.length]
+	offset += t.length
+
+	// We deal with the structures defined in this package first.
+	switch fieldType {
+	case objectIdentifierType:
+		newSlice, err1 := parseObjectIdentifier(innerBytes)
+		v.Set(reflect.MakeSlice(v.Type(), len(newSlice), len(newSlice)))
+		if err1 == nil {
+			reflect.Copy(v, reflect.ValueOf(newSlice))
+		}
+		err = err1
+		return
+	case bitStringType:
+		bs, err1 := parseBitString(innerBytes)
+		if err1 == nil {
+			v.Set(reflect.ValueOf(bs))
+		}
+		err = err1
+		return
+	case timeType:
+		var time time.Time
+		var err1 error
+		if universalTag == tagUTCTime {
+			time, err1 = parseUTCTime(innerBytes)
+		} else {
+			time, err1 = parseGeneralizedTime(innerBytes)
+		}
+		if err1 == nil {
+			v.Set(reflect.ValueOf(time))
+		}
+		err = err1
+		return
+	case enumeratedType:
+		parsedInt, err1 := parseInt32(innerBytes)
+		if err1 == nil {
+			v.SetInt(int64(parsedInt))
+		}
+		err = err1
+		return
+	case flagType:
+		v.SetBool(true)
+		return
+	case bigIntType:
+		parsedInt := parseBigInt(innerBytes)
+		v.Set(reflect.ValueOf(parsedInt))
+		return
+	}
+	switch val := v; val.Kind() {
+	case reflect.Bool:
+		parsedBool, err1 := parseBool(innerBytes)
+		if err1 == nil {
+			val.SetBool(parsedBool)
+		}
+		err = err1
+		return
+	case reflect.Int, reflect.Int32, reflect.Int64:
+		if val.Type().Size() == 4 {
+			parsedInt, err1 := parseInt32(innerBytes)
+			if err1 == nil {
+				val.SetInt(int64(parsedInt))
+			}
+			err = err1
+		} else {
+			parsedInt, err1 := parseInt64(innerBytes)
+			if err1 == nil {
+				val.SetInt(parsedInt)
+			}
+			err = err1
+		}
+		return
+	// TODO(dfc) Add support for the remaining integer types
+	case reflect.Struct:
+		structType := fieldType
+
+		if structType.NumField() > 0 &&
+			structType.Field(0).Type == rawContentsType {
+			bytes := bytes[initOffset:offset]
+			val.Field(0).Set(reflect.ValueOf(RawContent(bytes)))
+		}
+
+		innerOffset := 0
+		for i := 0; i < structType.NumField(); i++ {
+			field := structType.Field(i)
+			if i == 0 && field.Type == rawContentsType {
+				continue
+			}
+			innerOffset, err = parseField(val.Field(i), innerBytes, innerOffset, parseFieldParameters(field.Tag.Get("asn1")))
+			if err != nil {
+				return
+			}
+		}
+		// We allow extra bytes at the end of the SEQUENCE because
+		// adding elements to the end has been used in X.509 as the
+		// version numbers have increased.
+		return
+	case reflect.Slice:
+		sliceType := fieldType
+		if sliceType.Elem().Kind() == reflect.Uint8 {
+			val.Set(reflect.MakeSlice(sliceType, len(innerBytes), len(innerBytes)))
+			reflect.Copy(val, reflect.ValueOf(innerBytes))
+			return
+		}
+		newSlice, err1 := parseSequenceOf(innerBytes, sliceType, sliceType.Elem())
+		if err1 == nil {
+			val.Set(newSlice)
+		}
+		err = err1
+		return
+	case reflect.String:
+		var v string
+		switch universalTag {
+		case tagPrintableString:
+			v, err = parsePrintableString(innerBytes)
+		case tagIA5String:
+			v, err = parseIA5String(innerBytes)
+		case tagT61String:
+			v, err = parseT61String(innerBytes)
+		case tagUTF8String:
+			v, err = parseUTF8String(innerBytes)
+		case tagGeneralString:
+			// GeneralString is specified in ISO-2022/ECMA-35,
+			// A brief review suggests that it includes structures
+			// that allow the encoding to change midstring and
+			// such. We give up and pass it as an 8-bit string.
+			v, err = parseT61String(innerBytes)
+		default:
+			err = SyntaxError{fmt.Sprintf("internal error: unknown string type %d", universalTag)}
+		}
+		if err == nil {
+			val.SetString(v)
+		}
+		return
+	}
+	err = StructuralError{"unsupported: " + v.Type().String()}
+	return
+}
+
+// setDefaultValue is used to install a default value, from a tag string, into
+// a Value. It is successful is the field was optional, even if a default value
+// wasn't provided or it failed to install it into the Value.
+func setDefaultValue(v reflect.Value, params fieldParameters) (ok bool) {
+	if !params.optional {
+		return
+	}
+	ok = true
+	if params.defaultValue == nil {
+		return
+	}
+	switch val := v; val.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		val.SetInt(*params.defaultValue)
+	}
+	return
+}
+
+// Unmarshal parses the DER-encoded ASN.1 data structure b
+// and uses the reflect package to fill in an arbitrary value pointed at by val.
+// Because Unmarshal uses the reflect package, the structs
+// being written to must use upper case field names.
+//
+// An ASN.1 INTEGER can be written to an int, int32, int64,
+// or *big.Int (from the math/big package).
+// If the encoded value does not fit in the Go type,
+// Unmarshal returns a parse error.
+//
+// An ASN.1 BIT STRING can be written to a BitString.
+//
+// An ASN.1 OCTET STRING can be written to a []byte.
+//
+// An ASN.1 OBJECT IDENTIFIER can be written to an
+// ObjectIdentifier.
+//
+// An ASN.1 ENUMERATED can be written to an Enumerated.
+//
+// An ASN.1 UTCTIME or GENERALIZEDTIME can be written to a time.Time.
+//
+// An ASN.1 PrintableString or IA5String can be written to a string.
+//
+// Any of the above ASN.1 values can be written to an interface{}.
+// The value stored in the interface has the corresponding Go type.
+// For integers, that type is int64.
+//
+// An ASN.1 SEQUENCE OF x or SET OF x can be written
+// to a slice if an x can be written to the slice's element type.
+//
+// An ASN.1 SEQUENCE or SET can be written to a struct
+// if each of the elements in the sequence can be
+// written to the corresponding element in the struct.
+//
+// The following tags on struct fields have special meaning to Unmarshal:
+//
+//	optional		marks the field as ASN.1 OPTIONAL
+//	[explicit] tag:x	specifies the ASN.1 tag number; implies ASN.1 CONTEXT SPECIFIC
+//	default:x		sets the default value for optional integer fields
+//
+// If the type of the first field of a structure is RawContent then the raw
+// ASN1 contents of the struct will be stored in it.
+//
+// Other ASN.1 types are not supported; if it encounters them,
+// Unmarshal returns a parse error.
+func Unmarshal(b []byte, val interface{}) (rest []byte, err error) {
+	return UnmarshalWithParams(b, val, "")
+}
+
+// UnmarshalWithParams allows field parameters to be specified for the
+// top-level element. The form of the params is the same as the field tags.
+func UnmarshalWithParams(b []byte, val interface{}, params string) (rest []byte, err error) {
+	v := reflect.ValueOf(val).Elem()
+	offset, err := parseField(v, b, 0, parseFieldParameters(params))
+	if err != nil {
+		return nil, err
+	}
+	return b[offset:], nil
+}

--- a/vendor/github.com/google/certificate-transparency/go/asn1/common.go
+++ b/vendor/github.com/google/certificate-transparency/go/asn1/common.go
@@ -1,0 +1,163 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package asn1
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// ASN.1 objects have metadata preceding them:
+//   the tag: the type of the object
+//   a flag denoting if this object is compound or not
+//   the class type: the namespace of the tag
+//   the length of the object, in bytes
+
+// Here are some standard tags and classes
+
+const (
+	tagBoolean         = 1
+	tagInteger         = 2
+	tagBitString       = 3
+	tagOctetString     = 4
+	tagOID             = 6
+	tagEnum            = 10
+	tagUTF8String      = 12
+	tagSequence        = 16
+	tagSet             = 17
+	tagPrintableString = 19
+	tagT61String       = 20
+	tagIA5String       = 22
+	tagUTCTime         = 23
+	tagGeneralizedTime = 24
+	tagGeneralString   = 27
+)
+
+const (
+	classUniversal       = 0
+	classApplication     = 1
+	classContextSpecific = 2
+	classPrivate         = 3
+)
+
+type tagAndLength struct {
+	class, tag, length int
+	isCompound         bool
+}
+
+// ASN.1 has IMPLICIT and EXPLICIT tags, which can be translated as "instead
+// of" and "in addition to". When not specified, every primitive type has a
+// default tag in the UNIVERSAL class.
+//
+// For example: a BIT STRING is tagged [UNIVERSAL 3] by default (although ASN.1
+// doesn't actually have a UNIVERSAL keyword). However, by saying [IMPLICIT
+// CONTEXT-SPECIFIC 42], that means that the tag is replaced by another.
+//
+// On the other hand, if it said [EXPLICIT CONTEXT-SPECIFIC 10], then an
+// /additional/ tag would wrap the default tag. This explicit tag will have the
+// compound flag set.
+//
+// (This is used in order to remove ambiguity with optional elements.)
+//
+// You can layer EXPLICIT and IMPLICIT tags to an arbitrary depth, however we
+// don't support that here. We support a single layer of EXPLICIT or IMPLICIT
+// tagging with tag strings on the fields of a structure.
+
+// fieldParameters is the parsed representation of tag string from a structure field.
+type fieldParameters struct {
+	optional     bool   // true iff the field is OPTIONAL
+	explicit     bool   // true iff an EXPLICIT tag is in use.
+	application  bool   // true iff an APPLICATION tag is in use.
+	defaultValue *int64 // a default value for INTEGER typed fields (maybe nil).
+	tag          *int   // the EXPLICIT or IMPLICIT tag (maybe nil).
+	stringType   int    // the string tag to use when marshaling.
+	set          bool   // true iff this should be encoded as a SET
+	omitEmpty    bool   // true iff this should be omitted if empty when marshaling.
+
+	// Invariants:
+	//   if explicit is set, tag is non-nil.
+}
+
+// Given a tag string with the format specified in the package comment,
+// parseFieldParameters will parse it into a fieldParameters structure,
+// ignoring unknown parts of the string.
+func parseFieldParameters(str string) (ret fieldParameters) {
+	for _, part := range strings.Split(str, ",") {
+		switch {
+		case part == "optional":
+			ret.optional = true
+		case part == "explicit":
+			ret.explicit = true
+			if ret.tag == nil {
+				ret.tag = new(int)
+			}
+		case part == "ia5":
+			ret.stringType = tagIA5String
+		case part == "printable":
+			ret.stringType = tagPrintableString
+		case part == "utf8":
+			ret.stringType = tagUTF8String
+		case strings.HasPrefix(part, "default:"):
+			i, err := strconv.ParseInt(part[8:], 10, 64)
+			if err == nil {
+				ret.defaultValue = new(int64)
+				*ret.defaultValue = i
+			}
+		case strings.HasPrefix(part, "tag:"):
+			i, err := strconv.Atoi(part[4:])
+			if err == nil {
+				ret.tag = new(int)
+				*ret.tag = i
+			}
+		case part == "set":
+			ret.set = true
+		case part == "application":
+			ret.application = true
+			if ret.tag == nil {
+				ret.tag = new(int)
+			}
+		case part == "omitempty":
+			ret.omitEmpty = true
+		}
+	}
+	return
+}
+
+// Given a reflected Go type, getUniversalType returns the default tag number
+// and expected compound flag.
+func getUniversalType(t reflect.Type) (tagNumber int, isCompound, ok bool) {
+	switch t {
+	case objectIdentifierType:
+		return tagOID, false, true
+	case bitStringType:
+		return tagBitString, false, true
+	case timeType:
+		return tagUTCTime, false, true
+	case enumeratedType:
+		return tagEnum, false, true
+	case bigIntType:
+		return tagInteger, false, true
+	}
+	switch t.Kind() {
+	case reflect.Bool:
+		return tagBoolean, false, true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return tagInteger, false, true
+	case reflect.Struct:
+		return tagSequence, true, true
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.Uint8 {
+			return tagOctetString, false, true
+		}
+		if strings.HasSuffix(t.Name(), "SET") {
+			return tagSet, true, true
+		}
+		return tagSequence, true, true
+	case reflect.String:
+		return tagPrintableString, false, true
+	}
+	return 0, false, false
+}

--- a/vendor/github.com/google/certificate-transparency/go/asn1/marshal.go
+++ b/vendor/github.com/google/certificate-transparency/go/asn1/marshal.go
@@ -1,0 +1,581 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package asn1
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"reflect"
+	"time"
+	"unicode/utf8"
+)
+
+// A forkableWriter is an in-memory buffer that can be
+// 'forked' to create new forkableWriters that bracket the
+// original.  After
+//    pre, post := w.fork();
+// the overall sequence of bytes represented is logically w+pre+post.
+type forkableWriter struct {
+	*bytes.Buffer
+	pre, post *forkableWriter
+}
+
+func newForkableWriter() *forkableWriter {
+	return &forkableWriter{new(bytes.Buffer), nil, nil}
+}
+
+func (f *forkableWriter) fork() (pre, post *forkableWriter) {
+	if f.pre != nil || f.post != nil {
+		panic("have already forked")
+	}
+	f.pre = newForkableWriter()
+	f.post = newForkableWriter()
+	return f.pre, f.post
+}
+
+func (f *forkableWriter) Len() (l int) {
+	l += f.Buffer.Len()
+	if f.pre != nil {
+		l += f.pre.Len()
+	}
+	if f.post != nil {
+		l += f.post.Len()
+	}
+	return
+}
+
+func (f *forkableWriter) writeTo(out io.Writer) (n int, err error) {
+	n, err = out.Write(f.Bytes())
+	if err != nil {
+		return
+	}
+
+	var nn int
+
+	if f.pre != nil {
+		nn, err = f.pre.writeTo(out)
+		n += nn
+		if err != nil {
+			return
+		}
+	}
+
+	if f.post != nil {
+		nn, err = f.post.writeTo(out)
+		n += nn
+	}
+	return
+}
+
+func marshalBase128Int(out *forkableWriter, n int64) (err error) {
+	if n == 0 {
+		err = out.WriteByte(0)
+		return
+	}
+
+	l := 0
+	for i := n; i > 0; i >>= 7 {
+		l++
+	}
+
+	for i := l - 1; i >= 0; i-- {
+		o := byte(n >> uint(i*7))
+		o &= 0x7f
+		if i != 0 {
+			o |= 0x80
+		}
+		err = out.WriteByte(o)
+		if err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+func marshalInt64(out *forkableWriter, i int64) (err error) {
+	n := int64Length(i)
+
+	for ; n > 0; n-- {
+		err = out.WriteByte(byte(i >> uint((n-1)*8)))
+		if err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+func int64Length(i int64) (numBytes int) {
+	numBytes = 1
+
+	for i > 127 {
+		numBytes++
+		i >>= 8
+	}
+
+	for i < -128 {
+		numBytes++
+		i >>= 8
+	}
+
+	return
+}
+
+func marshalBigInt(out *forkableWriter, n *big.Int) (err error) {
+	if n.Sign() < 0 {
+		// A negative number has to be converted to two's-complement
+		// form. So we'll subtract 1 and invert. If the
+		// most-significant-bit isn't set then we'll need to pad the
+		// beginning with 0xff in order to keep the number negative.
+		nMinus1 := new(big.Int).Neg(n)
+		nMinus1.Sub(nMinus1, bigOne)
+		bytes := nMinus1.Bytes()
+		for i := range bytes {
+			bytes[i] ^= 0xff
+		}
+		if len(bytes) == 0 || bytes[0]&0x80 == 0 {
+			err = out.WriteByte(0xff)
+			if err != nil {
+				return
+			}
+		}
+		_, err = out.Write(bytes)
+	} else if n.Sign() == 0 {
+		// Zero is written as a single 0 zero rather than no bytes.
+		err = out.WriteByte(0x00)
+	} else {
+		bytes := n.Bytes()
+		if len(bytes) > 0 && bytes[0]&0x80 != 0 {
+			// We'll have to pad this with 0x00 in order to stop it
+			// looking like a negative number.
+			err = out.WriteByte(0)
+			if err != nil {
+				return
+			}
+		}
+		_, err = out.Write(bytes)
+	}
+	return
+}
+
+func marshalLength(out *forkableWriter, i int) (err error) {
+	n := lengthLength(i)
+
+	for ; n > 0; n-- {
+		err = out.WriteByte(byte(i >> uint((n-1)*8)))
+		if err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+func lengthLength(i int) (numBytes int) {
+	numBytes = 1
+	for i > 255 {
+		numBytes++
+		i >>= 8
+	}
+	return
+}
+
+func marshalTagAndLength(out *forkableWriter, t tagAndLength) (err error) {
+	b := uint8(t.class) << 6
+	if t.isCompound {
+		b |= 0x20
+	}
+	if t.tag >= 31 {
+		b |= 0x1f
+		err = out.WriteByte(b)
+		if err != nil {
+			return
+		}
+		err = marshalBase128Int(out, int64(t.tag))
+		if err != nil {
+			return
+		}
+	} else {
+		b |= uint8(t.tag)
+		err = out.WriteByte(b)
+		if err != nil {
+			return
+		}
+	}
+
+	if t.length >= 128 {
+		l := lengthLength(t.length)
+		err = out.WriteByte(0x80 | byte(l))
+		if err != nil {
+			return
+		}
+		err = marshalLength(out, t.length)
+		if err != nil {
+			return
+		}
+	} else {
+		err = out.WriteByte(byte(t.length))
+		if err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+func marshalBitString(out *forkableWriter, b BitString) (err error) {
+	paddingBits := byte((8 - b.BitLength%8) % 8)
+	err = out.WriteByte(paddingBits)
+	if err != nil {
+		return
+	}
+	_, err = out.Write(b.Bytes)
+	return
+}
+
+func marshalObjectIdentifier(out *forkableWriter, oid []int) (err error) {
+	if len(oid) < 2 || oid[0] > 2 || (oid[0] < 2 && oid[1] >= 40) {
+		return StructuralError{"invalid object identifier"}
+	}
+
+	err = marshalBase128Int(out, int64(oid[0]*40+oid[1]))
+	if err != nil {
+		return
+	}
+	for i := 2; i < len(oid); i++ {
+		err = marshalBase128Int(out, int64(oid[i]))
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func marshalPrintableString(out *forkableWriter, s string) (err error) {
+	b := []byte(s)
+	for _, c := range b {
+		if !isPrintable(c) {
+			return StructuralError{"PrintableString contains invalid character"}
+		}
+	}
+
+	_, err = out.Write(b)
+	return
+}
+
+func marshalIA5String(out *forkableWriter, s string) (err error) {
+	b := []byte(s)
+	for _, c := range b {
+		if c > 127 {
+			return StructuralError{"IA5String contains invalid character"}
+		}
+	}
+
+	_, err = out.Write(b)
+	return
+}
+
+func marshalUTF8String(out *forkableWriter, s string) (err error) {
+	_, err = out.Write([]byte(s))
+	return
+}
+
+func marshalTwoDigits(out *forkableWriter, v int) (err error) {
+	err = out.WriteByte(byte('0' + (v/10)%10))
+	if err != nil {
+		return
+	}
+	return out.WriteByte(byte('0' + v%10))
+}
+
+func marshalUTCTime(out *forkableWriter, t time.Time) (err error) {
+	year, month, day := t.Date()
+
+	switch {
+	case 1950 <= year && year < 2000:
+		err = marshalTwoDigits(out, int(year-1900))
+	case 2000 <= year && year < 2050:
+		err = marshalTwoDigits(out, int(year-2000))
+	default:
+		return StructuralError{"cannot represent time as UTCTime"}
+	}
+	if err != nil {
+		return
+	}
+
+	err = marshalTwoDigits(out, int(month))
+	if err != nil {
+		return
+	}
+
+	err = marshalTwoDigits(out, day)
+	if err != nil {
+		return
+	}
+
+	hour, min, sec := t.Clock()
+
+	err = marshalTwoDigits(out, hour)
+	if err != nil {
+		return
+	}
+
+	err = marshalTwoDigits(out, min)
+	if err != nil {
+		return
+	}
+
+	err = marshalTwoDigits(out, sec)
+	if err != nil {
+		return
+	}
+
+	_, offset := t.Zone()
+
+	switch {
+	case offset/60 == 0:
+		err = out.WriteByte('Z')
+		return
+	case offset > 0:
+		err = out.WriteByte('+')
+	case offset < 0:
+		err = out.WriteByte('-')
+	}
+
+	if err != nil {
+		return
+	}
+
+	offsetMinutes := offset / 60
+	if offsetMinutes < 0 {
+		offsetMinutes = -offsetMinutes
+	}
+
+	err = marshalTwoDigits(out, offsetMinutes/60)
+	if err != nil {
+		return
+	}
+
+	err = marshalTwoDigits(out, offsetMinutes%60)
+	return
+}
+
+func stripTagAndLength(in []byte) []byte {
+	_, offset, err := parseTagAndLength(in, 0)
+	if err != nil {
+		return in
+	}
+	return in[offset:]
+}
+
+func marshalBody(out *forkableWriter, value reflect.Value, params fieldParameters) (err error) {
+	switch value.Type() {
+	case timeType:
+		return marshalUTCTime(out, value.Interface().(time.Time))
+	case bitStringType:
+		return marshalBitString(out, value.Interface().(BitString))
+	case objectIdentifierType:
+		return marshalObjectIdentifier(out, value.Interface().(ObjectIdentifier))
+	case bigIntType:
+		return marshalBigInt(out, value.Interface().(*big.Int))
+	}
+
+	switch v := value; v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			return out.WriteByte(255)
+		} else {
+			return out.WriteByte(0)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return marshalInt64(out, int64(v.Int()))
+	case reflect.Struct:
+		t := v.Type()
+
+		startingField := 0
+
+		// If the first element of the structure is a non-empty
+		// RawContents, then we don't bother serializing the rest.
+		if t.NumField() > 0 && t.Field(0).Type == rawContentsType {
+			s := v.Field(0)
+			if s.Len() > 0 {
+				bytes := make([]byte, s.Len())
+				for i := 0; i < s.Len(); i++ {
+					bytes[i] = uint8(s.Index(i).Uint())
+				}
+				/* The RawContents will contain the tag and
+				 * length fields but we'll also be writing
+				 * those ourselves, so we strip them out of
+				 * bytes */
+				_, err = out.Write(stripTagAndLength(bytes))
+				return
+			} else {
+				startingField = 1
+			}
+		}
+
+		for i := startingField; i < t.NumField(); i++ {
+			var pre *forkableWriter
+			pre, out = out.fork()
+			err = marshalField(pre, v.Field(i), parseFieldParameters(t.Field(i).Tag.Get("asn1")))
+			if err != nil {
+				return
+			}
+		}
+		return
+	case reflect.Slice:
+		sliceType := v.Type()
+		if sliceType.Elem().Kind() == reflect.Uint8 {
+			bytes := make([]byte, v.Len())
+			for i := 0; i < v.Len(); i++ {
+				bytes[i] = uint8(v.Index(i).Uint())
+			}
+			_, err = out.Write(bytes)
+			return
+		}
+
+		var fp fieldParameters
+		for i := 0; i < v.Len(); i++ {
+			var pre *forkableWriter
+			pre, out = out.fork()
+			err = marshalField(pre, v.Index(i), fp)
+			if err != nil {
+				return
+			}
+		}
+		return
+	case reflect.String:
+		switch params.stringType {
+		case tagIA5String:
+			return marshalIA5String(out, v.String())
+		case tagPrintableString:
+			return marshalPrintableString(out, v.String())
+		default:
+			return marshalUTF8String(out, v.String())
+		}
+	}
+
+	return StructuralError{"unknown Go type"}
+}
+
+func marshalField(out *forkableWriter, v reflect.Value, params fieldParameters) (err error) {
+	// If the field is an interface{} then recurse into it.
+	if v.Kind() == reflect.Interface && v.Type().NumMethod() == 0 {
+		return marshalField(out, v.Elem(), params)
+	}
+
+	if v.Kind() == reflect.Slice && v.Len() == 0 && params.omitEmpty {
+		return
+	}
+
+	if params.optional && reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()).Interface()) {
+		return
+	}
+
+	if v.Type() == rawValueType {
+		rv := v.Interface().(RawValue)
+		if len(rv.FullBytes) != 0 {
+			_, err = out.Write(rv.FullBytes)
+		} else {
+			err = marshalTagAndLength(out, tagAndLength{rv.Class, rv.Tag, len(rv.Bytes), rv.IsCompound})
+			if err != nil {
+				return
+			}
+			_, err = out.Write(rv.Bytes)
+		}
+		return
+	}
+
+	tag, isCompound, ok := getUniversalType(v.Type())
+	if !ok {
+		err = StructuralError{fmt.Sprintf("unknown Go type: %v", v.Type())}
+		return
+	}
+	class := classUniversal
+
+	if params.stringType != 0 && tag != tagPrintableString {
+		return StructuralError{"explicit string type given to non-string member"}
+	}
+
+	if tag == tagPrintableString {
+		if params.stringType == 0 {
+			// This is a string without an explicit string type. We'll use
+			// a PrintableString if the character set in the string is
+			// sufficiently limited, otherwise we'll use a UTF8String.
+			for _, r := range v.String() {
+				if r >= utf8.RuneSelf || !isPrintable(byte(r)) {
+					if !utf8.ValidString(v.String()) {
+						return errors.New("asn1: string not valid UTF-8")
+					}
+					tag = tagUTF8String
+					break
+				}
+			}
+		} else {
+			tag = params.stringType
+		}
+	}
+
+	if params.set {
+		if tag != tagSequence {
+			return StructuralError{"non sequence tagged as set"}
+		}
+		tag = tagSet
+	}
+
+	tags, body := out.fork()
+
+	err = marshalBody(body, v, params)
+	if err != nil {
+		return
+	}
+
+	bodyLen := body.Len()
+
+	var explicitTag *forkableWriter
+	if params.explicit {
+		explicitTag, tags = tags.fork()
+	}
+
+	if !params.explicit && params.tag != nil {
+		// implicit tag.
+		tag = *params.tag
+		class = classContextSpecific
+	}
+
+	err = marshalTagAndLength(tags, tagAndLength{class, tag, bodyLen, isCompound})
+	if err != nil {
+		return
+	}
+
+	if params.explicit {
+		err = marshalTagAndLength(explicitTag, tagAndLength{
+			class:      classContextSpecific,
+			tag:        *params.tag,
+			length:     bodyLen + tags.Len(),
+			isCompound: true,
+		})
+	}
+
+	return nil
+}
+
+// Marshal returns the ASN.1 encoding of val.
+func Marshal(val interface{}) ([]byte, error) {
+	var out bytes.Buffer
+	v := reflect.ValueOf(val)
+	f := newForkableWriter()
+	err := marshalField(f, v, fieldParameters{})
+	if err != nil {
+		return nil, err
+	}
+	_, err = f.writeTo(&out)
+	return out.Bytes(), nil
+}

--- a/vendor/github.com/google/certificate-transparency/go/client/logclient.go
+++ b/vendor/github.com/google/certificate-transparency/go/client/logclient.go
@@ -1,0 +1,387 @@
+// Package client is a CT log client implementation and contains types and code
+// for interacting with RFC6962-compliant CT Log instances.
+// See http://tools.ietf.org/html/rfc6962 for details
+package client
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/certificate-transparency/go"
+	"golang.org/x/net/context"
+)
+
+// URI paths for CT Log endpoints
+const (
+	AddChainPath    = "/ct/v1/add-chain"
+	AddPreChainPath = "/ct/v1/add-pre-chain"
+	AddJSONPath     = "/ct/v1/add-json"
+	GetSTHPath      = "/ct/v1/get-sth"
+	GetEntriesPath  = "/ct/v1/get-entries"
+)
+
+// LogClient represents a client for a given CT Log instance
+type LogClient struct {
+	uri        string       // the base URI of the log. e.g. http://ct.googleapis/pilot
+	httpClient *http.Client // used to interact with the log via HTTP
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+// JSON structures follow.
+// These represent the structures returned by the CT Log server.
+//////////////////////////////////////////////////////////////////////////////////
+
+// addChainRequest represents the JSON request body sent to the add-chain CT
+// method.
+type addChainRequest struct {
+	Chain []string `json:"chain"`
+}
+
+// addChainResponse represents the JSON response to the add-chain CT method.
+// An SCT represents a Log's promise to integrate a [pre-]certificate into the
+// log within a defined period of time.
+type addChainResponse struct {
+	SCTVersion ct.Version `json:"sct_version"` // SCT structure version
+	ID         string     `json:"id"`          // Log ID
+	Timestamp  uint64     `json:"timestamp"`   // Timestamp of issuance
+	Extensions string     `json:"extensions"`  // Holder for any CT extensions
+	Signature  string     `json:"signature"`   // Log signature for this SCT
+}
+
+// addJSONRequest represents the JSON request body sent ot the add-json CT
+// method.
+type addJSONRequest struct {
+	Data interface{} `json:"data"`
+}
+
+// getSTHResponse respresents the JSON response to the get-sth CT method
+type getSTHResponse struct {
+	TreeSize          uint64 `json:"tree_size"`           // Number of certs in the current tree
+	Timestamp         uint64 `json:"timestamp"`           // Time that the tree was created
+	SHA256RootHash    string `json:"sha256_root_hash"`    // Root hash of the tree
+	TreeHeadSignature string `json:"tree_head_signature"` // Log signature for this STH
+}
+
+// base64LeafEntry respresents a Base64 encoded leaf entry
+type base64LeafEntry struct {
+	LeafInput string `json:"leaf_input"`
+	ExtraData string `json:"extra_data"`
+}
+
+// getEntriesReponse respresents the JSON response to the CT get-entries method
+type getEntriesResponse struct {
+	Entries []base64LeafEntry `json:"entries"` // the list of returned entries
+}
+
+// getConsistencyProofResponse represents the JSON response to the CT get-consistency-proof method
+type getConsistencyProofResponse struct {
+	Consistency []string `json:"consistency"`
+}
+
+// getAuditProofResponse represents the JSON response to the CT get-audit-proof method
+type getAuditProofResponse struct {
+	Hash     []string `json:"hash"`      // the hashes which make up the proof
+	TreeSize uint64   `json:"tree_size"` // the tree size against which this proof is constructed
+}
+
+// getAcceptedRootsResponse represents the JSON response to the CT get-roots method.
+type getAcceptedRootsResponse struct {
+	Certificates []string `json:"certificates"`
+}
+
+// getEntryAndProodReponse represents the JSON response to the CT get-entry-and-proof method
+type getEntryAndProofResponse struct {
+	LeafInput string   `json:"leaf_input"` // the entry itself
+	ExtraData string   `json:"extra_data"` // any chain provided when the entry was added to the log
+	AuditPath []string `json:"audit_path"` // the corresponding proof
+}
+
+// New constructs a new LogClient instance.
+// |uri| is the base URI of the CT log instance to interact with, e.g.
+// http://ct.googleapis.com/pilot
+// |hc| is the underlying client to be used for HTTP requests to the CT log.
+func New(uri string, hc *http.Client) *LogClient {
+	if hc == nil {
+		hc = new(http.Client)
+	}
+	return &LogClient{uri: uri, httpClient: hc}
+}
+
+// Makes a HTTP call to |uri|, and attempts to parse the response as a JSON
+// representation of the structure in |res|.
+// Returns a non-nil |error| if there was a problem.
+func (c *LogClient) fetchAndParse(uri string, res interface{}) error {
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	var body []byte
+	if resp != nil {
+		body, err = ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal(body, &res); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Makes a HTTP POST call to |uri|, and attempts to parse the response as a JSON
+// representation of the structure in |res|.
+// Returns a non-nil |error| if there was a problem.
+func (c *LogClient) postAndParse(uri string, req interface{}, res interface{}) (*http.Response, string, error) {
+	postBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, "", err
+	}
+	httpReq, err := http.NewRequest("POST", uri, bytes.NewReader(postBody))
+	if err != nil {
+		return nil, "", err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(httpReq)
+	// Read all of the body, if there is one, so that the http.Client can do
+	// Keep-Alive:
+	var body []byte
+	if resp != nil {
+		body, err = ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+	if err != nil {
+		return resp, string(body), err
+	}
+	if resp.StatusCode == 200 {
+		if err != nil {
+			return resp, string(body), err
+		}
+		if err = json.Unmarshal(body, &res); err != nil {
+			return resp, string(body), err
+		}
+	}
+	return resp, string(body), nil
+}
+
+func backoffForRetry(ctx context.Context, d time.Duration) error {
+	backoffTimer := time.NewTimer(d)
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-backoffTimer.C:
+		}
+	} else {
+		<-backoffTimer.C
+	}
+	return nil
+}
+
+// Attempts to add |chain| to the log, using the api end-point specified by
+// |path|. If provided context expires before submission is complete an
+// error will be returned.
+func (c *LogClient) addChainWithRetry(ctx context.Context, path string, chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
+	var resp addChainResponse
+	var req addChainRequest
+	for _, link := range chain {
+		req.Chain = append(req.Chain, base64.StdEncoding.EncodeToString(link))
+	}
+	httpStatus := "Unknown"
+	backoffSeconds := 0
+	done := false
+	for !done {
+		if backoffSeconds > 0 {
+			log.Printf("Got %s, backing-off %d seconds", httpStatus, backoffSeconds)
+		}
+		err := backoffForRetry(ctx, time.Second*time.Duration(backoffSeconds))
+		if err != nil {
+			return nil, err
+		}
+		if backoffSeconds > 0 {
+			backoffSeconds = 0
+		}
+		httpResp, errorBody, err := c.postAndParse(c.uri+path, &req, &resp)
+		if err != nil {
+			backoffSeconds = 10
+			continue
+		}
+		switch {
+		case httpResp.StatusCode == 200:
+			done = true
+		case httpResp.StatusCode == 408:
+			// request timeout, retry immediately
+		case httpResp.StatusCode == 503:
+			// Retry
+			backoffSeconds = 10
+			if retryAfter := httpResp.Header.Get("Retry-After"); retryAfter != "" {
+				if seconds, err := strconv.Atoi(retryAfter); err == nil {
+					backoffSeconds = seconds
+				}
+			}
+		default:
+			return nil, fmt.Errorf("got HTTP Status %s: %s", httpResp.Status, errorBody)
+		}
+		httpStatus = httpResp.Status
+	}
+
+	rawLogID, err := base64.StdEncoding.DecodeString(resp.ID)
+	if err != nil {
+		return nil, err
+	}
+	rawSignature, err := base64.StdEncoding.DecodeString(resp.Signature)
+	if err != nil {
+		return nil, err
+	}
+	ds, err := ct.UnmarshalDigitallySigned(bytes.NewReader(rawSignature))
+	if err != nil {
+		return nil, err
+	}
+	var logID ct.SHA256Hash
+	copy(logID[:], rawLogID)
+	return &ct.SignedCertificateTimestamp{
+		SCTVersion: resp.SCTVersion,
+		LogID:      logID,
+		Timestamp:  resp.Timestamp,
+		Extensions: ct.CTExtensions(resp.Extensions),
+		Signature:  *ds}, nil
+}
+
+// AddChain adds the (DER represented) X509 |chain| to the log.
+func (c *LogClient) AddChain(chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
+	return c.addChainWithRetry(nil, AddChainPath, chain)
+}
+
+// AddPreChain adds the (DER represented) Precertificate |chain| to the log.
+func (c *LogClient) AddPreChain(chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
+	return c.addChainWithRetry(nil, AddPreChainPath, chain)
+}
+
+// AddChainWithContext adds the (DER represented) X509 |chain| to the log and
+// fails if the provided context expires before the chain is submitted.
+func (c *LogClient) AddChainWithContext(ctx context.Context, chain []ct.ASN1Cert) (*ct.SignedCertificateTimestamp, error) {
+	return c.addChainWithRetry(ctx, AddChainPath, chain)
+}
+
+func (c *LogClient) AddJSON(data interface{}) (*ct.SignedCertificateTimestamp, error) {
+	req := addJSONRequest{
+		Data: data,
+	}
+	var resp addChainResponse
+	_, _, err := c.postAndParse(c.uri+AddJSONPath, &req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	rawLogID, err := base64.StdEncoding.DecodeString(resp.ID)
+	if err != nil {
+		return nil, err
+	}
+	rawSignature, err := base64.StdEncoding.DecodeString(resp.Signature)
+	if err != nil {
+		return nil, err
+	}
+	ds, err := ct.UnmarshalDigitallySigned(bytes.NewReader(rawSignature))
+	if err != nil {
+		return nil, err
+	}
+	var logID ct.SHA256Hash
+	copy(logID[:], rawLogID)
+	return &ct.SignedCertificateTimestamp{
+		SCTVersion: resp.SCTVersion,
+		LogID:      logID,
+		Timestamp:  resp.Timestamp,
+		Extensions: ct.CTExtensions(resp.Extensions),
+		Signature:  *ds}, nil
+}
+
+// GetSTH retrieves the current STH from the log.
+// Returns a populated SignedTreeHead, or a non-nil error.
+func (c *LogClient) GetSTH() (sth *ct.SignedTreeHead, err error) {
+	var resp getSTHResponse
+	if err = c.fetchAndParse(c.uri+GetSTHPath, &resp); err != nil {
+		return
+	}
+	sth = &ct.SignedTreeHead{
+		TreeSize:  resp.TreeSize,
+		Timestamp: resp.Timestamp,
+	}
+
+	rawRootHash, err := base64.StdEncoding.DecodeString(resp.SHA256RootHash)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base64 encoding in sha256_root_hash: %v", err)
+	}
+	if len(rawRootHash) != sha256.Size {
+		return nil, fmt.Errorf("sha256_root_hash is invalid length, expected %d got %d", sha256.Size, len(rawRootHash))
+	}
+	copy(sth.SHA256RootHash[:], rawRootHash)
+
+	rawSignature, err := base64.StdEncoding.DecodeString(resp.TreeHeadSignature)
+	if err != nil {
+		return nil, errors.New("invalid base64 encoding in tree_head_signature")
+	}
+	ds, err := ct.UnmarshalDigitallySigned(bytes.NewReader(rawSignature))
+	if err != nil {
+		return nil, err
+	}
+	// TODO(alcutter): Verify signature
+	sth.TreeHeadSignature = *ds
+	return
+}
+
+// GetEntries attempts to retrieve the entries in the sequence [|start|, |end|] from the CT
+// log server. (see section 4.6.)
+// Returns a slice of LeafInputs or a non-nil error.
+func (c *LogClient) GetEntries(start, end int64) ([]ct.LogEntry, error) {
+	if end < 0 {
+		return nil, errors.New("end should be >= 0")
+	}
+	if end < start {
+		return nil, errors.New("start should be <= end")
+	}
+	var resp getEntriesResponse
+	err := c.fetchAndParse(fmt.Sprintf("%s%s?start=%d&end=%d", c.uri, GetEntriesPath, start, end), &resp)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]ct.LogEntry, len(resp.Entries))
+	for index, entry := range resp.Entries {
+		leafBytes, err := base64.StdEncoding.DecodeString(entry.LeafInput)
+		leaf, err := ct.ReadMerkleTreeLeaf(bytes.NewBuffer(leafBytes))
+		if err != nil {
+			return nil, err
+		}
+		entries[index].Leaf = *leaf
+		chainBytes, err := base64.StdEncoding.DecodeString(entry.ExtraData)
+
+		var chain []ct.ASN1Cert
+		switch leaf.TimestampedEntry.EntryType {
+		case ct.X509LogEntryType:
+			chain, err = ct.UnmarshalX509ChainArray(chainBytes)
+
+		case ct.PrecertLogEntryType:
+			chain, err = ct.UnmarshalPrecertChainArray(chainBytes)
+
+		default:
+			return nil, fmt.Errorf("saw unknown entry type: %v", leaf.TimestampedEntry.EntryType)
+		}
+		if err != nil {
+			return nil, err
+		}
+		entries[index].Chain = chain
+		entries[index].Index = start + int64(index)
+	}
+	return entries, nil
+}

--- a/vendor/github.com/google/certificate-transparency/go/serialization.go
+++ b/vendor/github.com/google/certificate-transparency/go/serialization.go
@@ -1,0 +1,563 @@
+package ct
+
+import (
+	"bytes"
+	"container/list"
+	"crypto"
+	"encoding/asn1"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Variable size structure prefix-header byte lengths
+const (
+	CertificateLengthBytes      = 3
+	PreCertificateLengthBytes   = 3
+	ExtensionsLengthBytes       = 2
+	CertificateChainLengthBytes = 3
+	SignatureLengthBytes        = 2
+)
+
+// Max lengths
+const (
+	MaxCertificateLength = (1 << 24) - 1
+	MaxExtensionsLength  = (1 << 16) - 1
+	MaxSCTInListLength   = (1 << 16) - 1
+	MaxSCTListLength     = (1 << 16) - 1
+)
+
+func writeUint(w io.Writer, value uint64, numBytes int) error {
+	buf := make([]uint8, numBytes)
+	for i := 0; i < numBytes; i++ {
+		buf[numBytes-i-1] = uint8(value & 0xff)
+		value >>= 8
+	}
+	if value != 0 {
+		return errors.New("numBytes was insufficiently large to represent value")
+	}
+	if _, err := w.Write(buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeVarBytes(w io.Writer, value []byte, numLenBytes int) error {
+	if err := writeUint(w, uint64(len(value)), numLenBytes); err != nil {
+		return err
+	}
+	if _, err := w.Write(value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readUint(r io.Reader, numBytes int) (uint64, error) {
+	var l uint64
+	for i := 0; i < numBytes; i++ {
+		l <<= 8
+		var t uint8
+		if err := binary.Read(r, binary.BigEndian, &t); err != nil {
+			return 0, err
+		}
+		l |= uint64(t)
+	}
+	return l, nil
+}
+
+// Reads a variable length array of bytes from |r|. |numLenBytes| specifies the
+// number of (BigEndian) prefix-bytes which contain the length of the actual
+// array data bytes that follow.
+// Allocates an array to hold the contents and returns a slice view into it if
+// the read was successful, or an error otherwise.
+func readVarBytes(r io.Reader, numLenBytes int) ([]byte, error) {
+	switch {
+	case numLenBytes > 8:
+		return nil, fmt.Errorf("numLenBytes too large (%d)", numLenBytes)
+	case numLenBytes == 0:
+		return nil, errors.New("numLenBytes should be > 0")
+	}
+	l, err := readUint(r, numLenBytes)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]byte, l)
+	if n, err := io.ReadFull(r, data); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return nil, fmt.Errorf("short read: expected %d but got %d", l, n)
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
+// Reads a list of ASN1Cert types from |r|
+func readASN1CertList(r io.Reader, totalLenBytes int, elementLenBytes int) ([]ASN1Cert, error) {
+	listBytes, err := readVarBytes(r, totalLenBytes)
+	if err != nil {
+		return []ASN1Cert{}, err
+	}
+	list := list.New()
+	listReader := bytes.NewReader(listBytes)
+	var entry []byte
+	for err == nil {
+		entry, err = readVarBytes(listReader, elementLenBytes)
+		if err != nil {
+			if err != io.EOF {
+				return []ASN1Cert{}, err
+			}
+		} else {
+			list.PushBack(entry)
+		}
+	}
+	ret := make([]ASN1Cert, list.Len())
+	i := 0
+	for e := list.Front(); e != nil; e = e.Next() {
+		ret[i] = e.Value.([]byte)
+		i++
+	}
+	return ret, nil
+}
+
+// ReadTimestampedEntryInto parses the byte-stream representation of a
+// TimestampedEntry from |r| and populates the struct |t| with the data.  See
+// RFC section 3.4 for details on the format.
+// Returns a non-nil error if there was a problem.
+func ReadTimestampedEntryInto(r io.Reader, t *TimestampedEntry) error {
+	var err error
+	if err = binary.Read(r, binary.BigEndian, &t.Timestamp); err != nil {
+		return err
+	}
+	if err = binary.Read(r, binary.BigEndian, &t.EntryType); err != nil {
+		return err
+	}
+	switch t.EntryType {
+	case X509LogEntryType:
+		if t.X509Entry, err = readVarBytes(r, CertificateLengthBytes); err != nil {
+			return err
+		}
+	case PrecertLogEntryType:
+		if err := binary.Read(r, binary.BigEndian, &t.PrecertEntry.IssuerKeyHash); err != nil {
+			return err
+		}
+		if t.PrecertEntry.TBSCertificate, err = readVarBytes(r, PreCertificateLengthBytes); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown EntryType: %d", t.EntryType)
+	}
+	t.Extensions, err = readVarBytes(r, ExtensionsLengthBytes)
+	return nil
+}
+
+// ReadMerkleTreeLeaf parses the byte-stream representation of a MerkleTreeLeaf
+// and returns a pointer to a new MerkleTreeLeaf structure containing the
+// parsed data.
+// See RFC section 3.4 for details on the format.
+// Returns a pointer to a new MerkleTreeLeaf or non-nil error if there was a
+// problem
+func ReadMerkleTreeLeaf(r io.Reader) (*MerkleTreeLeaf, error) {
+	var m MerkleTreeLeaf
+	if err := binary.Read(r, binary.BigEndian, &m.Version); err != nil {
+		return nil, err
+	}
+	if m.Version != V1 {
+		return nil, fmt.Errorf("unknown Version %d", m.Version)
+	}
+	if err := binary.Read(r, binary.BigEndian, &m.LeafType); err != nil {
+		return nil, err
+	}
+	if m.LeafType != TimestampedEntryLeafType {
+		return nil, fmt.Errorf("unknown LeafType %d", m.LeafType)
+	}
+	if err := ReadTimestampedEntryInto(r, &m.TimestampedEntry); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// UnmarshalX509ChainArray unmarshalls the contents of the "chain:" entry in a
+// GetEntries response in the case where the entry refers to an X509 leaf.
+func UnmarshalX509ChainArray(b []byte) ([]ASN1Cert, error) {
+	return readASN1CertList(bytes.NewReader(b), CertificateChainLengthBytes, CertificateLengthBytes)
+}
+
+// UnmarshalPrecertChainArray unmarshalls the contents of the "chain:" entry in
+// a GetEntries response in the case where the entry refers to a Precertificate
+// leaf.
+func UnmarshalPrecertChainArray(b []byte) ([]ASN1Cert, error) {
+	var chain []ASN1Cert
+
+	reader := bytes.NewReader(b)
+	// read the pre-cert entry:
+	precert, err := readVarBytes(reader, CertificateLengthBytes)
+	if err != nil {
+		return chain, err
+	}
+	chain = append(chain, precert)
+	// and then read and return the chain up to the root:
+	remainingChain, err := readASN1CertList(reader, CertificateChainLengthBytes, CertificateLengthBytes)
+	if err != nil {
+		return chain, err
+	}
+	chain = append(chain, remainingChain...)
+	return chain, nil
+}
+
+// UnmarshalDigitallySigned reconstructs a DigitallySigned structure from a Reader
+func UnmarshalDigitallySigned(r io.Reader) (*DigitallySigned, error) {
+	var h byte
+	if err := binary.Read(r, binary.BigEndian, &h); err != nil {
+		return nil, fmt.Errorf("failed to read HashAlgorithm: %v", err)
+	}
+
+	var s byte
+	if err := binary.Read(r, binary.BigEndian, &s); err != nil {
+		return nil, fmt.Errorf("failed to read SignatureAlgorithm: %v", err)
+	}
+
+	sig, err := readVarBytes(r, SignatureLengthBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Signature bytes: %v", err)
+	}
+
+	return &DigitallySigned{
+		HashAlgorithm:      HashAlgorithm(h),
+		SignatureAlgorithm: SignatureAlgorithm(s),
+		Signature:          sig,
+	}, nil
+}
+
+func marshalDigitallySignedHere(ds DigitallySigned, here []byte) ([]byte, error) {
+	sigLen := len(ds.Signature)
+	dsOutLen := 2 + SignatureLengthBytes + sigLen
+	if here == nil {
+		here = make([]byte, dsOutLen)
+	}
+	if len(here) < dsOutLen {
+		return nil, ErrNotEnoughBuffer
+	}
+	here = here[0:dsOutLen]
+
+	here[0] = byte(ds.HashAlgorithm)
+	here[1] = byte(ds.SignatureAlgorithm)
+	binary.BigEndian.PutUint16(here[2:4], uint16(sigLen))
+	copy(here[4:], ds.Signature)
+
+	return here, nil
+}
+
+// MarshalDigitallySigned marshalls a DigitallySigned structure into a byte array
+func MarshalDigitallySigned(ds DigitallySigned) ([]byte, error) {
+	return marshalDigitallySignedHere(ds, nil)
+}
+
+func checkCertificateFormat(cert ASN1Cert) error {
+	if len(cert) == 0 {
+		return errors.New("certificate is zero length")
+	}
+	if len(cert) > MaxCertificateLength {
+		return errors.New("certificate too large")
+	}
+	return nil
+}
+
+func checkExtensionsFormat(ext CTExtensions) error {
+	if len(ext) > MaxExtensionsLength {
+		return errors.New("extensions too large")
+	}
+	return nil
+}
+
+func serializeV1CertSCTSignatureInput(timestamp uint64, cert ASN1Cert, ext CTExtensions) ([]byte, error) {
+	if err := checkCertificateFormat(cert); err != nil {
+		return nil, err
+	}
+	if err := checkExtensionsFormat(ext); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, V1); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, CertificateTimestampSignatureType); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, timestamp); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, X509LogEntryType); err != nil {
+		return nil, err
+	}
+	if err := writeVarBytes(&buf, cert, CertificateLengthBytes); err != nil {
+		return nil, err
+	}
+	if err := writeVarBytes(&buf, ext, ExtensionsLengthBytes); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func serializeV1PrecertSCTSignatureInput(timestamp uint64, issuerKeyHash [issuerKeyHashLength]byte, tbs []byte, ext CTExtensions) ([]byte, error) {
+	if err := checkCertificateFormat(tbs); err != nil {
+		return nil, err
+	}
+	if err := checkExtensionsFormat(ext); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, V1); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, CertificateTimestampSignatureType); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, timestamp); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, PrecertLogEntryType); err != nil {
+		return nil, err
+	}
+	if _, err := buf.Write(issuerKeyHash[:]); err != nil {
+		return nil, err
+	}
+	if err := writeVarBytes(&buf, tbs, CertificateLengthBytes); err != nil {
+		return nil, err
+	}
+	if err := writeVarBytes(&buf, ext, ExtensionsLengthBytes); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func serializeV1SCTSignatureInput(sct SignedCertificateTimestamp, entry LogEntry) ([]byte, error) {
+	if sct.SCTVersion != V1 {
+		return nil, fmt.Errorf("unsupported SCT version, expected V1, but got %s", sct.SCTVersion)
+	}
+	if entry.Leaf.LeafType != TimestampedEntryLeafType {
+		return nil, fmt.Errorf("Unsupported leaf type %s", entry.Leaf.LeafType)
+	}
+	switch entry.Leaf.TimestampedEntry.EntryType {
+	case X509LogEntryType:
+		return serializeV1CertSCTSignatureInput(sct.Timestamp, entry.Leaf.TimestampedEntry.X509Entry, entry.Leaf.TimestampedEntry.Extensions)
+	case PrecertLogEntryType:
+		return serializeV1PrecertSCTSignatureInput(sct.Timestamp, entry.Leaf.TimestampedEntry.PrecertEntry.IssuerKeyHash,
+			entry.Leaf.TimestampedEntry.PrecertEntry.TBSCertificate,
+			entry.Leaf.TimestampedEntry.Extensions)
+	default:
+		return nil, fmt.Errorf("unknown TimestampedEntryLeafType %s", entry.Leaf.TimestampedEntry.EntryType)
+	}
+}
+
+// SerializeSCTSignatureInput serializes the passed in sct and log entry into
+// the correct format for signing.
+func SerializeSCTSignatureInput(sct SignedCertificateTimestamp, entry LogEntry) ([]byte, error) {
+	switch sct.SCTVersion {
+	case V1:
+		return serializeV1SCTSignatureInput(sct, entry)
+	default:
+		return nil, fmt.Errorf("unknown SCT version %d", sct.SCTVersion)
+	}
+}
+
+// SerializedLength will return the space (in bytes)
+func (sct SignedCertificateTimestamp) SerializedLength() (int, error) {
+	switch sct.SCTVersion {
+	case V1:
+		extLen := len(sct.Extensions)
+		sigLen := len(sct.Signature.Signature)
+		return 1 + 32 + 8 + 2 + extLen + 2 + 2 + sigLen, nil
+	default:
+		return 0, ErrInvalidVersion
+	}
+}
+
+func serializeV1SCTHere(sct SignedCertificateTimestamp, here []byte) ([]byte, error) {
+	if sct.SCTVersion != V1 {
+		return nil, ErrInvalidVersion
+	}
+	sctLen, err := sct.SerializedLength()
+	if err != nil {
+		return nil, err
+	}
+	if here == nil {
+		here = make([]byte, sctLen)
+	}
+	if len(here) < sctLen {
+		return nil, ErrNotEnoughBuffer
+	}
+	if err := checkExtensionsFormat(sct.Extensions); err != nil {
+		return nil, err
+	}
+
+	here = here[0:sctLen]
+
+	// Write Version
+	here[0] = byte(sct.SCTVersion)
+
+	// Write LogID
+	copy(here[1:33], sct.LogID[:])
+
+	// Write Timestamp
+	binary.BigEndian.PutUint64(here[33:41], sct.Timestamp)
+
+	// Write Extensions
+	extLen := len(sct.Extensions)
+	binary.BigEndian.PutUint16(here[41:43], uint16(extLen))
+	n := 43 + extLen
+	copy(here[43:n], sct.Extensions)
+
+	// Write Signature
+	_, err = marshalDigitallySignedHere(sct.Signature, here[n:])
+	if err != nil {
+		return nil, err
+	}
+	return here, nil
+}
+
+// SerializeSCTHere serializes the passed in sct into the format specified
+// by RFC6962 section 3.2.
+// If a bytes slice here is provided then it will attempt to serialize into the
+// provided byte slice, ErrNotEnoughBuffer will be returned if the buffer is
+// too small.
+// If a nil byte slice is provided, a buffer for will be allocated for you
+// The returned slice will be sliced to the correct length.
+func SerializeSCTHere(sct SignedCertificateTimestamp, here []byte) ([]byte, error) {
+	switch sct.SCTVersion {
+	case V1:
+		return serializeV1SCTHere(sct, here)
+	default:
+		return nil, fmt.Errorf("unknown SCT version %d", sct.SCTVersion)
+	}
+}
+
+// SerializeSCT serializes the passed in sct into the format specified
+// by RFC6962 section 3.2
+// Equivalent to SerializeSCTHere(sct, nil)
+func SerializeSCT(sct SignedCertificateTimestamp) ([]byte, error) {
+	return SerializeSCTHere(sct, nil)
+}
+
+func deserializeSCTV1(r io.Reader, sct *SignedCertificateTimestamp) error {
+	if err := binary.Read(r, binary.BigEndian, &sct.LogID); err != nil {
+		return err
+	}
+	if err := binary.Read(r, binary.BigEndian, &sct.Timestamp); err != nil {
+		return err
+	}
+	ext, err := readVarBytes(r, ExtensionsLengthBytes)
+	if err != nil {
+		return err
+	}
+	sct.Extensions = ext
+	ds, err := UnmarshalDigitallySigned(r)
+	if err != nil {
+		return err
+	}
+	sct.Signature = *ds
+	return nil
+}
+
+func DeserializeSCT(r io.Reader) (*SignedCertificateTimestamp, error) {
+	var sct SignedCertificateTimestamp
+	if err := binary.Read(r, binary.BigEndian, &sct.SCTVersion); err != nil {
+		return nil, err
+	}
+	switch sct.SCTVersion {
+	case V1:
+		return &sct, deserializeSCTV1(r, &sct)
+	default:
+		return nil, fmt.Errorf("unknown SCT version %d", sct.SCTVersion)
+	}
+}
+
+func serializeV1STHSignatureInput(sth SignedTreeHead) ([]byte, error) {
+	if sth.Version != V1 {
+		return nil, fmt.Errorf("invalid STH version %d", sth.Version)
+	}
+	if sth.TreeSize < 0 {
+		return nil, fmt.Errorf("invalid tree size %d", sth.TreeSize)
+	}
+	if len(sth.SHA256RootHash) != crypto.SHA256.Size() {
+		return nil, fmt.Errorf("invalid TreeHash length, got %d expected %d", len(sth.SHA256RootHash), crypto.SHA256.Size())
+	}
+
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, V1); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, TreeHashSignatureType); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, sth.Timestamp); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, sth.TreeSize); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.BigEndian, sth.SHA256RootHash); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// SerializeSTHSignatureInput serializes the passed in sth into the correct
+// format for signing.
+func SerializeSTHSignatureInput(sth SignedTreeHead) ([]byte, error) {
+	switch sth.Version {
+	case V1:
+		return serializeV1STHSignatureInput(sth)
+	default:
+		return nil, fmt.Errorf("unsupported STH version %d", sth.Version)
+	}
+}
+
+// SCTListSerializedLength determines the length of the required buffer should a SCT List need to be serialized
+func SCTListSerializedLength(scts []SignedCertificateTimestamp) (int, error) {
+	if len(scts) == 0 {
+		return 0, fmt.Errorf("SCT List empty")
+	}
+
+	sctListLen := 0
+	for i, sct := range scts {
+		n, err := sct.SerializedLength()
+		if err != nil {
+			return 0, fmt.Errorf("unable to determine length of SCT in position %d: %v", i, err)
+		}
+		if n > MaxSCTInListLength {
+			return 0, fmt.Errorf("SCT in position %d too large: %d", i, n)
+		}
+		sctListLen += 2 + n
+	}
+
+	return sctListLen, nil
+}
+
+// SerializeSCTList serializes the passed-in slice of SignedCertificateTimestamp into a
+// byte slice as a SignedCertificateTimestampList (see RFC6962 Section 3.3)
+func SerializeSCTList(scts []SignedCertificateTimestamp) ([]byte, error) {
+	size, err := SCTListSerializedLength(scts)
+	if err != nil {
+		return nil, err
+	}
+	fullSize := 2 + size // 2 bytes for length + size of SCT list
+	if fullSize > MaxSCTListLength {
+		return nil, fmt.Errorf("SCT List too large to serialize: %d", fullSize)
+	}
+	buf := new(bytes.Buffer)
+	buf.Grow(fullSize)
+	if err = writeUint(buf, uint64(size), 2); err != nil {
+		return nil, err
+	}
+	for _, sct := range scts {
+		serialized, err := SerializeSCT(sct)
+		if err != nil {
+			return nil, err
+		}
+		if err = writeVarBytes(buf, serialized, 2); err != nil {
+			return nil, err
+		}
+	}
+	return asn1.Marshal(buf.Bytes()) // transform to Octet String
+}

--- a/vendor/github.com/google/certificate-transparency/go/signatures.go
+++ b/vendor/github.com/google/certificate-transparency/go/signatures.go
@@ -1,0 +1,131 @@
+package ct
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+)
+
+var allowVerificationWithNonCompliantKeys = flag.Bool("allow_verification_with_non_compliant_keys", false,
+	"Allow a SignatureVerifier to use keys which are technically non-compliant with RFC6962.")
+
+// PublicKeyFromPEM parses a PEM formatted block and returns the public key contained within and any remaining unread bytes, or an error.
+func PublicKeyFromPEM(b []byte) (crypto.PublicKey, SHA256Hash, []byte, error) {
+	p, rest := pem.Decode(b)
+	if p == nil {
+		return nil, [sha256.Size]byte{}, rest, fmt.Errorf("no PEM block found in %s", string(b))
+	}
+	k, err := x509.ParsePKIXPublicKey(p.Bytes)
+	return k, sha256.Sum256(p.Bytes), rest, err
+}
+
+// SignatureVerifier can verify signatures on SCTs and STHs
+type SignatureVerifier struct {
+	pubKey crypto.PublicKey
+}
+
+// NewSignatureVerifier creates a new SignatureVerifier using the passed in PublicKey.
+func NewSignatureVerifier(pk crypto.PublicKey) (*SignatureVerifier, error) {
+	switch pkType := pk.(type) {
+	case *rsa.PublicKey:
+		if pkType.N.BitLen() < 2048 {
+			e := fmt.Errorf("public key is RSA with < 2048 bits (size:%d)", pkType.N.BitLen())
+			if !(*allowVerificationWithNonCompliantKeys) {
+				return nil, e
+			}
+			log.Printf("WARNING: %v", e)
+		}
+	case *ecdsa.PublicKey:
+		params := *(pkType.Params())
+		if params != *elliptic.P256().Params() {
+			e := fmt.Errorf("public is ECDSA, but not on the P256 curve")
+			if !(*allowVerificationWithNonCompliantKeys) {
+				return nil, e
+			}
+			log.Printf("WARNING: %v", e)
+
+		}
+	default:
+		return nil, fmt.Errorf("Unsupported public key type %v", pkType)
+	}
+
+	return &SignatureVerifier{
+		pubKey: pk,
+	}, nil
+}
+
+// verifySignature verifies that the passed in signature over data was created by our PublicKey.
+// Currently, only SHA256 is supported as a HashAlgorithm, and only ECDSA and RSA signatures are supported.
+func (s SignatureVerifier) verifySignature(data []byte, sig DigitallySigned) error {
+	if sig.HashAlgorithm != SHA256 {
+		return fmt.Errorf("unsupported HashAlgorithm in signature: %v", sig.HashAlgorithm)
+	}
+
+	hasherType := crypto.SHA256
+	hasher := hasherType.New()
+	if _, err := hasher.Write(data); err != nil {
+		return fmt.Errorf("failed to write to hasher: %v", err)
+	}
+	hash := hasher.Sum([]byte{})
+
+	switch sig.SignatureAlgorithm {
+	case RSA:
+		rsaKey, ok := s.pubKey.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("cannot verify RSA signature with %T key", s.pubKey)
+		}
+		if err := rsa.VerifyPKCS1v15(rsaKey, hasherType, hash, sig.Signature); err != nil {
+			return fmt.Errorf("failed to verify rsa signature: %v", err)
+		}
+	case ECDSA:
+		ecdsaKey, ok := s.pubKey.(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("cannot verify ECDSA signature with %T key", s.pubKey)
+		}
+		var ecdsaSig struct {
+			R, S *big.Int
+		}
+		rest, err := asn1.Unmarshal(sig.Signature, &ecdsaSig)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal ECDSA signature: %v", err)
+		}
+		if len(rest) != 0 {
+			log.Printf("Garbage following signature %v", rest)
+		}
+
+		if !ecdsa.Verify(ecdsaKey, hash, ecdsaSig.R, ecdsaSig.S) {
+			return errors.New("failed to verify ecdsa signature")
+		}
+	default:
+		return fmt.Errorf("unsupported signature type %v", sig.SignatureAlgorithm)
+	}
+	return nil
+}
+
+// VerifySCTSignature verifies that the SCT's signature is valid for the given LogEntry
+func (s SignatureVerifier) VerifySCTSignature(sct SignedCertificateTimestamp, entry LogEntry) error {
+	sctData, err := SerializeSCTSignatureInput(sct, entry)
+	if err != nil {
+		return err
+	}
+	return s.verifySignature(sctData, sct.Signature)
+}
+
+// VerifySTHSignature verifies that the STH's signature is valid.
+func (s SignatureVerifier) VerifySTHSignature(sth SignedTreeHead) error {
+	sthData, err := SerializeSTHSignatureInput(sth)
+	if err != nil {
+		return err
+	}
+	return s.verifySignature(sthData, sth.TreeHeadSignature)
+}

--- a/vendor/github.com/google/certificate-transparency/go/types.go
+++ b/vendor/github.com/google/certificate-transparency/go/types.go
@@ -1,0 +1,363 @@
+package ct
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/certificate-transparency/go/x509"
+)
+
+const (
+	issuerKeyHashLength = 32
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// The following structures represent those outlined in the RFC6962 document:
+///////////////////////////////////////////////////////////////////////////////
+
+// LogEntryType represents the LogEntryType enum from section 3.1 of the RFC:
+//   enum { x509_entry(0), precert_entry(1), (65535) } LogEntryType;
+type LogEntryType uint16
+
+func (e LogEntryType) String() string {
+	switch e {
+	case X509LogEntryType:
+		return "X509LogEntryType"
+	case PrecertLogEntryType:
+		return "PrecertLogEntryType"
+	}
+	panic(fmt.Sprintf("No string defined for LogEntryType constant value %d", e))
+}
+
+// LogEntryType constants, see section 3.1 of RFC6962.
+const (
+	X509LogEntryType    LogEntryType = 0
+	PrecertLogEntryType LogEntryType = 1
+)
+
+// MerkleLeafType represents the MerkleLeafType enum from section 3.4 of the
+// RFC: enum { timestamped_entry(0), (255) } MerkleLeafType;
+type MerkleLeafType uint8
+
+func (m MerkleLeafType) String() string {
+	switch m {
+	case TimestampedEntryLeafType:
+		return "TimestampedEntryLeafType"
+	default:
+		return fmt.Sprintf("UnknownLeafType(%d)", m)
+	}
+}
+
+// MerkleLeafType constants, see section 3.4 of the RFC.
+const (
+	TimestampedEntryLeafType MerkleLeafType = 0 // Entry type for an SCT
+)
+
+// Version represents the Version enum from section 3.2 of the RFC:
+// enum { v1(0), (255) } Version;
+type Version uint8
+
+func (v Version) String() string {
+	switch v {
+	case V1:
+		return "V1"
+	default:
+		return fmt.Sprintf("UnknownVersion(%d)", v)
+	}
+}
+
+// CT Version constants, see section 3.2 of the RFC.
+const (
+	V1 Version = 0
+)
+
+// SignatureType differentiates STH signatures from SCT signatures, see RFC
+// section 3.2
+type SignatureType uint8
+
+func (st SignatureType) String() string {
+	switch st {
+	case CertificateTimestampSignatureType:
+		return "CertificateTimestamp"
+	case TreeHashSignatureType:
+		return "TreeHash"
+	default:
+		return fmt.Sprintf("UnknownSignatureType(%d)", st)
+	}
+}
+
+// SignatureType constants, see RFC section 3.2
+const (
+	CertificateTimestampSignatureType SignatureType = 0
+	TreeHashSignatureType             SignatureType = 1
+)
+
+// ASN1Cert type for holding the raw DER bytes of an ASN.1 Certificate
+// (section 3.1)
+type ASN1Cert []byte
+
+// PreCert represents a Precertificate (section 3.2)
+type PreCert struct {
+	IssuerKeyHash  [issuerKeyHashLength]byte
+	TBSCertificate []byte
+}
+
+// CTExtensions is a representation of the raw bytes of any CtExtension
+// structure (see section 3.2)
+type CTExtensions []byte
+
+// MerkleTreeNode represents an internal node in the CT tree
+type MerkleTreeNode []byte
+
+// ConsistencyProof represents a CT consistency proof (see sections 2.1.2 and
+// 4.4)
+type ConsistencyProof []MerkleTreeNode
+
+// AuditPath represents a CT inclusion proof (see sections 2.1.1 and 4.5)
+type AuditPath []MerkleTreeNode
+
+// LeafInput represents a serialized MerkleTreeLeaf structure
+type LeafInput []byte
+
+// HashAlgorithm from the DigitallySigned struct
+type HashAlgorithm byte
+
+// HashAlgorithm constants
+const (
+	None   HashAlgorithm = 0
+	MD5    HashAlgorithm = 1
+	SHA1   HashAlgorithm = 2
+	SHA224 HashAlgorithm = 3
+	SHA256 HashAlgorithm = 4
+	SHA384 HashAlgorithm = 5
+	SHA512 HashAlgorithm = 6
+)
+
+func (h HashAlgorithm) String() string {
+	switch h {
+	case None:
+		return "None"
+	case MD5:
+		return "MD5"
+	case SHA1:
+		return "SHA1"
+	case SHA224:
+		return "SHA224"
+	case SHA256:
+		return "SHA256"
+	case SHA384:
+		return "SHA384"
+	case SHA512:
+		return "SHA512"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", h)
+	}
+}
+
+// SignatureAlgorithm from the the DigitallySigned struct
+type SignatureAlgorithm byte
+
+// SignatureAlgorithm constants
+const (
+	Anonymous SignatureAlgorithm = 0
+	RSA       SignatureAlgorithm = 1
+	DSA       SignatureAlgorithm = 2
+	ECDSA     SignatureAlgorithm = 3
+)
+
+func (s SignatureAlgorithm) String() string {
+	switch s {
+	case Anonymous:
+		return "Anonymous"
+	case RSA:
+		return "RSA"
+	case DSA:
+		return "DSA"
+	case ECDSA:
+		return "ECDSA"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", s)
+	}
+}
+
+// DigitallySigned represents an RFC5246 DigitallySigned structure
+type DigitallySigned struct {
+	HashAlgorithm      HashAlgorithm
+	SignatureAlgorithm SignatureAlgorithm
+	Signature          []byte
+}
+
+// FromBase64String populates the DigitallySigned structure from the base64 data passed in.
+// Returns an error if the base64 data is invalid.
+func (d *DigitallySigned) FromBase64String(b64 string) error {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return fmt.Errorf("failed to unbase64 DigitallySigned: %v", err)
+	}
+	ds, err := UnmarshalDigitallySigned(bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal DigitallySigned: %v", err)
+	}
+	*d = *ds
+	return nil
+}
+
+// Base64String returns the base64 representation of the DigitallySigned struct.
+func (d DigitallySigned) Base64String() (string, error) {
+	b, err := MarshalDigitallySigned(d)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (d DigitallySigned) MarshalJSON() ([]byte, error) {
+	b64, err := d.Base64String()
+	if err != nil {
+		return []byte{}, err
+	}
+	return []byte(`"` + b64 + `"`), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *DigitallySigned) UnmarshalJSON(b []byte) error {
+	var content string
+	if err := json.Unmarshal(b, &content); err != nil {
+		return fmt.Errorf("failed to unmarshal DigitallySigned: %v", err)
+	}
+	return d.FromBase64String(content)
+}
+
+// LogEntry represents the contents of an entry in a CT log, see section 3.1.
+type LogEntry struct {
+	Index    int64
+	Leaf     MerkleTreeLeaf
+	X509Cert *x509.Certificate
+	Precert  *Precertificate
+	Chain    []ASN1Cert
+}
+
+// SHA256Hash represents the output from the SHA256 hash function.
+type SHA256Hash [sha256.Size]byte
+
+// FromBase64String populates the SHA256 struct with the contents of the base64 data passed in.
+func (s *SHA256Hash) FromBase64String(b64 string) error {
+	bs, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return fmt.Errorf("failed to unbase64 LogID: %v", err)
+	}
+	if len(bs) != sha256.Size {
+		return fmt.Errorf("invalid SHA256 length, expected 32 but got %d", len(bs))
+	}
+	copy(s[:], bs)
+	return nil
+}
+
+// Base64String returns the base64 representation of this SHA256Hash.
+func (s SHA256Hash) Base64String() string {
+	return base64.StdEncoding.EncodeToString(s[:])
+}
+
+// MarshalJSON implements the json.Marshaller interface for SHA256Hash.
+func (s SHA256Hash) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.Base64String() + `"`), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (s *SHA256Hash) UnmarshalJSON(b []byte) error {
+	var content string
+	if err := json.Unmarshal(b, &content); err != nil {
+		return fmt.Errorf("failed to unmarshal SHA256Hash: %v", err)
+	}
+	return s.FromBase64String(content)
+}
+
+// SignedTreeHead represents the structure returned by the get-sth CT method
+// after base64 decoding. See sections 3.5 and 4.3 in the RFC)
+type SignedTreeHead struct {
+	Version           Version         `json:"sth_version"`         // The version of the protocol to which the STH conforms
+	TreeSize          uint64          `json:"tree_size"`           // The number of entries in the new tree
+	Timestamp         uint64          `json:"timestamp"`           // The time at which the STH was created
+	SHA256RootHash    SHA256Hash      `json:"sha256_root_hash"`    // The root hash of the log's Merkle tree
+	TreeHeadSignature DigitallySigned `json:"tree_head_signature"` // The Log's signature for this STH (see RFC section 3.5)
+	LogID             SHA256Hash      `json:"log_id"`              // The SHA256 hash of the log's public key
+}
+
+// SignedCertificateTimestamp represents the structure returned by the
+// add-chain and add-pre-chain methods after base64 decoding. (see RFC sections
+// 3.2 ,4.1 and 4.2)
+type SignedCertificateTimestamp struct {
+	SCTVersion Version    // The version of the protocol to which the SCT conforms
+	LogID      SHA256Hash // the SHA-256 hash of the log's public key, calculated over
+	// the DER encoding of the key represented as SubjectPublicKeyInfo.
+	Timestamp  uint64          // Timestamp (in ms since unix epoc) at which the SCT was issued
+	Extensions CTExtensions    // For future extensions to the protocol
+	Signature  DigitallySigned // The Log's signature for this SCT
+}
+
+func (s SignedCertificateTimestamp) String() string {
+	return fmt.Sprintf("{Version:%d LogId:%s Timestamp:%d Extensions:'%s' Signature:%v}", s.SCTVersion,
+		base64.StdEncoding.EncodeToString(s.LogID[:]),
+		s.Timestamp,
+		s.Extensions,
+		s.Signature)
+}
+
+// TimestampedEntry is part of the MerkleTreeLeaf structure.
+// See RFC section 3.4
+type TimestampedEntry struct {
+	Timestamp    uint64
+	EntryType    LogEntryType
+	X509Entry    ASN1Cert
+	PrecertEntry PreCert
+	Extensions   CTExtensions
+}
+
+// MerkleTreeLeaf represents the deserialized sructure of the hash input for the
+// leaves of a log's Merkle tree. See RFC section 3.4
+type MerkleTreeLeaf struct {
+	Version          Version          // the version of the protocol to which the MerkleTreeLeaf corresponds
+	LeafType         MerkleLeafType   // The type of the leaf input, currently only TimestampedEntry can exist
+	TimestampedEntry TimestampedEntry // The entry data itself
+}
+
+// Precertificate represents the parsed CT Precertificate structure.
+type Precertificate struct {
+	// Raw DER bytes of the precert
+	Raw []byte
+	// SHA256 hash of the issuing key
+	IssuerKeyHash [issuerKeyHashLength]byte
+	// Parsed TBSCertificate structure (held in an x509.Certificate for ease of
+	// access.
+	TBSCertificate x509.Certificate
+}
+
+// X509Certificate returns the X.509 Certificate contained within the
+// MerkleTreeLeaf.
+// Returns a pointer to an x509.Certificate or a non-nil error.
+func (m *MerkleTreeLeaf) X509Certificate() (*x509.Certificate, error) {
+	return x509.ParseCertificate(m.TimestampedEntry.X509Entry)
+}
+
+type sctError int
+
+// Preallocate errors for performance
+var (
+	ErrInvalidVersion  error = sctError(1)
+	ErrNotEnoughBuffer error = sctError(2)
+)
+
+func (e sctError) Error() string {
+	switch e {
+	case ErrInvalidVersion:
+		return "invalid SCT version detected"
+	case ErrNotEnoughBuffer:
+		return "provided buffer was too small"
+	default:
+		return "unknown error"
+	}
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/cert_pool.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/cert_pool.go
@@ -1,0 +1,116 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"encoding/pem"
+)
+
+// CertPool is a set of certificates.
+type CertPool struct {
+	bySubjectKeyId map[string][]int
+	byName         map[string][]int
+	certs          []*Certificate
+}
+
+// NewCertPool returns a new, empty CertPool.
+func NewCertPool() *CertPool {
+	return &CertPool{
+		make(map[string][]int),
+		make(map[string][]int),
+		nil,
+	}
+}
+
+// findVerifiedParents attempts to find certificates in s which have signed the
+// given certificate. If any candidates were rejected then errCert will be set
+// to one of them, arbitrarily, and err will contain the reason that it was
+// rejected.
+func (s *CertPool) findVerifiedParents(cert *Certificate) (parents []int, errCert *Certificate, err error) {
+	if s == nil {
+		return
+	}
+	var candidates []int
+
+	if len(cert.AuthorityKeyId) > 0 {
+		candidates = s.bySubjectKeyId[string(cert.AuthorityKeyId)]
+	}
+	if len(candidates) == 0 {
+		candidates = s.byName[string(cert.RawIssuer)]
+	}
+
+	for _, c := range candidates {
+		if err = cert.CheckSignatureFrom(s.certs[c]); err == nil {
+			parents = append(parents, c)
+		} else {
+			errCert = s.certs[c]
+		}
+	}
+
+	return
+}
+
+// AddCert adds a certificate to a pool.
+func (s *CertPool) AddCert(cert *Certificate) {
+	if cert == nil {
+		panic("adding nil Certificate to CertPool")
+	}
+
+	// Check that the certificate isn't being added twice.
+	for _, c := range s.certs {
+		if c.Equal(cert) {
+			return
+		}
+	}
+
+	n := len(s.certs)
+	s.certs = append(s.certs, cert)
+
+	if len(cert.SubjectKeyId) > 0 {
+		keyId := string(cert.SubjectKeyId)
+		s.bySubjectKeyId[keyId] = append(s.bySubjectKeyId[keyId], n)
+	}
+	name := string(cert.RawSubject)
+	s.byName[name] = append(s.byName[name], n)
+}
+
+// AppendCertsFromPEM attempts to parse a series of PEM encoded certificates.
+// It appends any certificates found to s and returns true if any certificates
+// were successfully parsed.
+//
+// On many Linux systems, /etc/ssl/cert.pem will contain the system wide set
+// of root CAs in a format suitable for this function.
+func (s *CertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
+	for len(pemCerts) > 0 {
+		var block *pem.Block
+		block, pemCerts = pem.Decode(pemCerts)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+
+		cert, err := ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+
+		s.AddCert(cert)
+		ok = true
+	}
+
+	return
+}
+
+// Subjects returns a list of the DER-encoded subjects of
+// all of the certificates in the pool.
+func (s *CertPool) Subjects() (res [][]byte) {
+	res = make([][]byte, len(s.certs))
+	for i, c := range s.certs {
+		res[i] = c.RawSubject
+	}
+	return
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/pem_decrypt.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/pem_decrypt.go
@@ -1,0 +1,233 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+// RFC 1423 describes the encryption of PEM blocks. The algorithm used to
+// generate a key from the password was derived by looking at the OpenSSL
+// implementation.
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"io"
+	"strings"
+)
+
+type PEMCipher int
+
+// Possible values for the EncryptPEMBlock encryption algorithm.
+const (
+	_ PEMCipher = iota
+	PEMCipherDES
+	PEMCipher3DES
+	PEMCipherAES128
+	PEMCipherAES192
+	PEMCipherAES256
+)
+
+// rfc1423Algo holds a method for enciphering a PEM block.
+type rfc1423Algo struct {
+	cipher     PEMCipher
+	name       string
+	cipherFunc func(key []byte) (cipher.Block, error)
+	keySize    int
+	blockSize  int
+}
+
+// rfc1423Algos holds a slice of the possible ways to encrypt a PEM
+// block.  The ivSize numbers were taken from the OpenSSL source.
+var rfc1423Algos = []rfc1423Algo{{
+	cipher:     PEMCipherDES,
+	name:       "DES-CBC",
+	cipherFunc: des.NewCipher,
+	keySize:    8,
+	blockSize:  des.BlockSize,
+}, {
+	cipher:     PEMCipher3DES,
+	name:       "DES-EDE3-CBC",
+	cipherFunc: des.NewTripleDESCipher,
+	keySize:    24,
+	blockSize:  des.BlockSize,
+}, {
+	cipher:     PEMCipherAES128,
+	name:       "AES-128-CBC",
+	cipherFunc: aes.NewCipher,
+	keySize:    16,
+	blockSize:  aes.BlockSize,
+}, {
+	cipher:     PEMCipherAES192,
+	name:       "AES-192-CBC",
+	cipherFunc: aes.NewCipher,
+	keySize:    24,
+	blockSize:  aes.BlockSize,
+}, {
+	cipher:     PEMCipherAES256,
+	name:       "AES-256-CBC",
+	cipherFunc: aes.NewCipher,
+	keySize:    32,
+	blockSize:  aes.BlockSize,
+},
+}
+
+// deriveKey uses a key derivation function to stretch the password into a key
+// with the number of bits our cipher requires. This algorithm was derived from
+// the OpenSSL source.
+func (c rfc1423Algo) deriveKey(password, salt []byte) []byte {
+	hash := md5.New()
+	out := make([]byte, c.keySize)
+	var digest []byte
+
+	for i := 0; i < len(out); i += len(digest) {
+		hash.Reset()
+		hash.Write(digest)
+		hash.Write(password)
+		hash.Write(salt)
+		digest = hash.Sum(digest[:0])
+		copy(out[i:], digest)
+	}
+	return out
+}
+
+// IsEncryptedPEMBlock returns if the PEM block is password encrypted.
+func IsEncryptedPEMBlock(b *pem.Block) bool {
+	_, ok := b.Headers["DEK-Info"]
+	return ok
+}
+
+// IncorrectPasswordError is returned when an incorrect password is detected.
+var IncorrectPasswordError = errors.New("x509: decryption password incorrect")
+
+// DecryptPEMBlock takes a password encrypted PEM block and the password used to
+// encrypt it and returns a slice of decrypted DER encoded bytes. It inspects
+// the DEK-Info header to determine the algorithm used for decryption. If no
+// DEK-Info header is present, an error is returned. If an incorrect password
+// is detected an IncorrectPasswordError is returned.
+func DecryptPEMBlock(b *pem.Block, password []byte) ([]byte, error) {
+	dek, ok := b.Headers["DEK-Info"]
+	if !ok {
+		return nil, errors.New("x509: no DEK-Info header in block")
+	}
+
+	idx := strings.Index(dek, ",")
+	if idx == -1 {
+		return nil, errors.New("x509: malformed DEK-Info header")
+	}
+
+	mode, hexIV := dek[:idx], dek[idx+1:]
+	ciph := cipherByName(mode)
+	if ciph == nil {
+		return nil, errors.New("x509: unknown encryption mode")
+	}
+	iv, err := hex.DecodeString(hexIV)
+	if err != nil {
+		return nil, err
+	}
+	if len(iv) != ciph.blockSize {
+		return nil, errors.New("x509: incorrect IV size")
+	}
+
+	// Based on the OpenSSL implementation. The salt is the first 8 bytes
+	// of the initialization vector.
+	key := ciph.deriveKey(password, iv[:8])
+	block, err := ciph.cipherFunc(key)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, len(b.Bytes))
+	dec := cipher.NewCBCDecrypter(block, iv)
+	dec.CryptBlocks(data, b.Bytes)
+
+	// Blocks are padded using a scheme where the last n bytes of padding are all
+	// equal to n. It can pad from 1 to blocksize bytes inclusive. See RFC 1423.
+	// For example:
+	//	[x y z 2 2]
+	//	[x y 7 7 7 7 7 7 7]
+	// If we detect a bad padding, we assume it is an invalid password.
+	dlen := len(data)
+	if dlen == 0 || dlen%ciph.blockSize != 0 {
+		return nil, errors.New("x509: invalid padding")
+	}
+	last := int(data[dlen-1])
+	if dlen < last {
+		return nil, IncorrectPasswordError
+	}
+	if last == 0 || last > ciph.blockSize {
+		return nil, IncorrectPasswordError
+	}
+	for _, val := range data[dlen-last:] {
+		if int(val) != last {
+			return nil, IncorrectPasswordError
+		}
+	}
+	return data[:dlen-last], nil
+}
+
+// EncryptPEMBlock returns a PEM block of the specified type holding the
+// given DER-encoded data encrypted with the specified algorithm and
+// password.
+func EncryptPEMBlock(rand io.Reader, blockType string, data, password []byte, alg PEMCipher) (*pem.Block, error) {
+	ciph := cipherByKey(alg)
+	if ciph == nil {
+		return nil, errors.New("x509: unknown encryption mode")
+	}
+	iv := make([]byte, ciph.blockSize)
+	if _, err := io.ReadFull(rand, iv); err != nil {
+		return nil, errors.New("x509: cannot generate IV: " + err.Error())
+	}
+	// The salt is the first 8 bytes of the initialization vector,
+	// matching the key derivation in DecryptPEMBlock.
+	key := ciph.deriveKey(password, iv[:8])
+	block, err := ciph.cipherFunc(key)
+	if err != nil {
+		return nil, err
+	}
+	enc := cipher.NewCBCEncrypter(block, iv)
+	pad := ciph.blockSize - len(data)%ciph.blockSize
+	encrypted := make([]byte, len(data), len(data)+pad)
+	// We could save this copy by encrypting all the whole blocks in
+	// the data separately, but it doesn't seem worth the additional
+	// code.
+	copy(encrypted, data)
+	// See RFC 1423, section 1.1
+	for i := 0; i < pad; i++ {
+		encrypted = append(encrypted, byte(pad))
+	}
+	enc.CryptBlocks(encrypted, encrypted)
+
+	return &pem.Block{
+		Type: blockType,
+		Headers: map[string]string{
+			"Proc-Type": "4,ENCRYPTED",
+			"DEK-Info":  ciph.name + "," + hex.EncodeToString(iv),
+		},
+		Bytes: encrypted,
+	}, nil
+}
+
+func cipherByName(name string) *rfc1423Algo {
+	for i := range rfc1423Algos {
+		alg := &rfc1423Algos[i]
+		if alg.name == name {
+			return alg
+		}
+	}
+	return nil
+}
+
+func cipherByKey(key PEMCipher) *rfc1423Algo {
+	for i := range rfc1423Algos {
+		alg := &rfc1423Algos[i]
+		if alg.cipher == key {
+			return alg
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/pkcs1.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/pkcs1.go
@@ -1,0 +1,124 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"crypto/rsa"
+	// START CT CHANGES
+	"github.com/google/certificate-transparency/go/asn1"
+	// END CT CHANGES
+	"errors"
+	"math/big"
+)
+
+// pkcs1PrivateKey is a structure which mirrors the PKCS#1 ASN.1 for an RSA private key.
+type pkcs1PrivateKey struct {
+	Version int
+	N       *big.Int
+	E       int
+	D       *big.Int
+	P       *big.Int
+	Q       *big.Int
+	// We ignore these values, if present, because rsa will calculate them.
+	Dp   *big.Int `asn1:"optional"`
+	Dq   *big.Int `asn1:"optional"`
+	Qinv *big.Int `asn1:"optional"`
+
+	AdditionalPrimes []pkcs1AdditionalRSAPrime `asn1:"optional,omitempty"`
+}
+
+type pkcs1AdditionalRSAPrime struct {
+	Prime *big.Int
+
+	// We ignore these values because rsa will calculate them.
+	Exp   *big.Int
+	Coeff *big.Int
+}
+
+// ParsePKCS1PrivateKey returns an RSA private key from its ASN.1 PKCS#1 DER encoded form.
+func ParsePKCS1PrivateKey(der []byte) (key *rsa.PrivateKey, err error) {
+	var priv pkcs1PrivateKey
+	rest, err := asn1.Unmarshal(der, &priv)
+	if len(rest) > 0 {
+		err = asn1.SyntaxError{Msg: "trailing data"}
+		return
+	}
+	if err != nil {
+		return
+	}
+
+	if priv.Version > 1 {
+		return nil, errors.New("x509: unsupported private key version")
+	}
+
+	if priv.N.Sign() <= 0 || priv.D.Sign() <= 0 || priv.P.Sign() <= 0 || priv.Q.Sign() <= 0 {
+		return nil, errors.New("x509: private key contains zero or negative value")
+	}
+
+	key = new(rsa.PrivateKey)
+	key.PublicKey = rsa.PublicKey{
+		E: priv.E,
+		N: priv.N,
+	}
+
+	key.D = priv.D
+	key.Primes = make([]*big.Int, 2+len(priv.AdditionalPrimes))
+	key.Primes[0] = priv.P
+	key.Primes[1] = priv.Q
+	for i, a := range priv.AdditionalPrimes {
+		if a.Prime.Sign() <= 0 {
+			return nil, errors.New("x509: private key contains zero or negative prime")
+		}
+		key.Primes[i+2] = a.Prime
+		// We ignore the other two values because rsa will calculate
+		// them as needed.
+	}
+
+	err = key.Validate()
+	if err != nil {
+		return nil, err
+	}
+	key.Precompute()
+
+	return
+}
+
+// MarshalPKCS1PrivateKey converts a private key to ASN.1 DER encoded form.
+func MarshalPKCS1PrivateKey(key *rsa.PrivateKey) []byte {
+	key.Precompute()
+
+	version := 0
+	if len(key.Primes) > 2 {
+		version = 1
+	}
+
+	priv := pkcs1PrivateKey{
+		Version: version,
+		N:       key.N,
+		E:       key.PublicKey.E,
+		D:       key.D,
+		P:       key.Primes[0],
+		Q:       key.Primes[1],
+		Dp:      key.Precomputed.Dp,
+		Dq:      key.Precomputed.Dq,
+		Qinv:    key.Precomputed.Qinv,
+	}
+
+	priv.AdditionalPrimes = make([]pkcs1AdditionalRSAPrime, len(key.Precomputed.CRTValues))
+	for i, values := range key.Precomputed.CRTValues {
+		priv.AdditionalPrimes[i].Prime = key.Primes[2+i]
+		priv.AdditionalPrimes[i].Exp = values.Exp
+		priv.AdditionalPrimes[i].Coeff = values.Coeff
+	}
+
+	b, _ := asn1.Marshal(priv)
+	return b
+}
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKey struct {
+	N *big.Int
+	E int
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/pkcs8.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/pkcs8.go
@@ -1,0 +1,56 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	// START CT CHANGES
+	"github.com/google/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/x509/pkix"
+	// END CT CHANGES
+	"errors"
+	"fmt"
+)
+
+// pkcs8 reflects an ASN.1, PKCS#8 PrivateKey. See
+// ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-8/pkcs-8v1_2.asn
+// and RFC5208.
+type pkcs8 struct {
+	Version    int
+	Algo       pkix.AlgorithmIdentifier
+	PrivateKey []byte
+	// optional attributes omitted.
+}
+
+// ParsePKCS8PrivateKey parses an unencrypted, PKCS#8 private key. See
+// http://www.rsa.com/rsalabs/node.asp?id=2130 and RFC5208.
+func ParsePKCS8PrivateKey(der []byte) (key interface{}, err error) {
+	var privKey pkcs8
+	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
+		return nil, err
+	}
+	switch {
+	case privKey.Algo.Algorithm.Equal(oidPublicKeyRSA):
+		key, err = ParsePKCS1PrivateKey(privKey.PrivateKey)
+		if err != nil {
+			return nil, errors.New("x509: failed to parse RSA private key embedded in PKCS#8: " + err.Error())
+		}
+		return key, nil
+
+	case privKey.Algo.Algorithm.Equal(oidPublicKeyECDSA):
+		bytes := privKey.Algo.Parameters.FullBytes
+		namedCurveOID := new(asn1.ObjectIdentifier)
+		if _, err := asn1.Unmarshal(bytes, namedCurveOID); err != nil {
+			namedCurveOID = nil
+		}
+		key, err = parseECPrivateKey(namedCurveOID, privKey.PrivateKey)
+		if err != nil {
+			return nil, errors.New("x509: failed to parse EC private key embedded in PKCS#8: " + err.Error())
+		}
+		return key, nil
+
+	default:
+		return nil, fmt.Errorf("x509: PKCS#8 wrapping contained private key with unknown algorithm: %v", privKey.Algo.Algorithm)
+	}
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/pkix/pkix.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/pkix/pkix.go
@@ -1,0 +1,173 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pkix contains shared, low level structures used for ASN.1 parsing
+// and serialization of X.509 certificates, CRL and OCSP.
+package pkix
+
+import (
+	// START CT CHANGES
+	"github.com/google/certificate-transparency/go/asn1"
+	// END CT CHANGES
+	"math/big"
+	"time"
+)
+
+// AlgorithmIdentifier represents the ASN.1 structure of the same name. See RFC
+// 5280, section 4.1.1.2.
+type AlgorithmIdentifier struct {
+	Algorithm  asn1.ObjectIdentifier
+	Parameters asn1.RawValue `asn1:"optional"`
+}
+
+type RDNSequence []RelativeDistinguishedNameSET
+
+type RelativeDistinguishedNameSET []AttributeTypeAndValue
+
+// AttributeTypeAndValue mirrors the ASN.1 structure of the same name in
+// http://tools.ietf.org/html/rfc5280#section-4.1.2.4
+type AttributeTypeAndValue struct {
+	Type  asn1.ObjectIdentifier
+	Value interface{}
+}
+
+// Extension represents the ASN.1 structure of the same name. See RFC
+// 5280, section 4.2.
+type Extension struct {
+	Id       asn1.ObjectIdentifier
+	Critical bool `asn1:"optional"`
+	Value    []byte
+}
+
+// Name represents an X.509 distinguished name. This only includes the common
+// elements of a DN.  Additional elements in the name are ignored.
+type Name struct {
+	Country, Organization, OrganizationalUnit []string
+	Locality, Province                        []string
+	StreetAddress, PostalCode                 []string
+	SerialNumber, CommonName                  string
+
+	Names []AttributeTypeAndValue
+}
+
+func (n *Name) FillFromRDNSequence(rdns *RDNSequence) {
+	for _, rdn := range *rdns {
+		if len(rdn) == 0 {
+			continue
+		}
+		atv := rdn[0]
+		n.Names = append(n.Names, atv)
+		value, ok := atv.Value.(string)
+		if !ok {
+			continue
+		}
+
+		t := atv.Type
+		if len(t) == 4 && t[0] == 2 && t[1] == 5 && t[2] == 4 {
+			switch t[3] {
+			case 3:
+				n.CommonName = value
+			case 5:
+				n.SerialNumber = value
+			case 6:
+				n.Country = append(n.Country, value)
+			case 7:
+				n.Locality = append(n.Locality, value)
+			case 8:
+				n.Province = append(n.Province, value)
+			case 9:
+				n.StreetAddress = append(n.StreetAddress, value)
+			case 10:
+				n.Organization = append(n.Organization, value)
+			case 11:
+				n.OrganizationalUnit = append(n.OrganizationalUnit, value)
+			case 17:
+				n.PostalCode = append(n.PostalCode, value)
+			}
+		}
+	}
+}
+
+var (
+	oidCountry            = []int{2, 5, 4, 6}
+	oidOrganization       = []int{2, 5, 4, 10}
+	oidOrganizationalUnit = []int{2, 5, 4, 11}
+	oidCommonName         = []int{2, 5, 4, 3}
+	oidSerialNumber       = []int{2, 5, 4, 5}
+	oidLocality           = []int{2, 5, 4, 7}
+	oidProvince           = []int{2, 5, 4, 8}
+	oidStreetAddress      = []int{2, 5, 4, 9}
+	oidPostalCode         = []int{2, 5, 4, 17}
+)
+
+// appendRDNs appends a relativeDistinguishedNameSET to the given RDNSequence
+// and returns the new value. The relativeDistinguishedNameSET contains an
+// attributeTypeAndValue for each of the given values. See RFC 5280, A.1, and
+// search for AttributeTypeAndValue.
+func appendRDNs(in RDNSequence, values []string, oid asn1.ObjectIdentifier) RDNSequence {
+	if len(values) == 0 {
+		return in
+	}
+
+	s := make([]AttributeTypeAndValue, len(values))
+	for i, value := range values {
+		s[i].Type = oid
+		s[i].Value = value
+	}
+
+	return append(in, s)
+}
+
+func (n Name) ToRDNSequence() (ret RDNSequence) {
+	ret = appendRDNs(ret, n.Country, oidCountry)
+	ret = appendRDNs(ret, n.Organization, oidOrganization)
+	ret = appendRDNs(ret, n.OrganizationalUnit, oidOrganizationalUnit)
+	ret = appendRDNs(ret, n.Locality, oidLocality)
+	ret = appendRDNs(ret, n.Province, oidProvince)
+	ret = appendRDNs(ret, n.StreetAddress, oidStreetAddress)
+	ret = appendRDNs(ret, n.PostalCode, oidPostalCode)
+	if len(n.CommonName) > 0 {
+		ret = appendRDNs(ret, []string{n.CommonName}, oidCommonName)
+	}
+	if len(n.SerialNumber) > 0 {
+		ret = appendRDNs(ret, []string{n.SerialNumber}, oidSerialNumber)
+	}
+
+	return ret
+}
+
+// CertificateList represents the ASN.1 structure of the same name. See RFC
+// 5280, section 5.1. Use Certificate.CheckCRLSignature to verify the
+// signature.
+type CertificateList struct {
+	TBSCertList        TBSCertificateList
+	SignatureAlgorithm AlgorithmIdentifier
+	SignatureValue     asn1.BitString
+}
+
+// HasExpired reports whether now is past the expiry time of certList.
+func (certList *CertificateList) HasExpired(now time.Time) bool {
+	return now.After(certList.TBSCertList.NextUpdate)
+}
+
+// TBSCertificateList represents the ASN.1 structure of the same name. See RFC
+// 5280, section 5.1.
+type TBSCertificateList struct {
+	Raw                 asn1.RawContent
+	Version             int `asn1:"optional,default:2"`
+	Signature           AlgorithmIdentifier
+	Issuer              RDNSequence
+	ThisUpdate          time.Time
+	NextUpdate          time.Time
+	RevokedCertificates []RevokedCertificate `asn1:"optional"`
+	Extensions          []Extension          `asn1:"tag:0,optional,explicit"`
+}
+
+// RevokedCertificate represents the ASN.1 structure of the same name. See RFC
+// 5280, section 5.1.
+type RevokedCertificate struct {
+	SerialNumber   *big.Int
+	RevocationTime time.Time
+	Extensions     []Extension `asn1:"optional"`
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/root.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/root.go
@@ -1,0 +1,17 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import "sync"
+
+var (
+	once        sync.Once
+	systemRoots *CertPool
+)
+
+func systemRootsPool() *CertPool {
+	once.Do(initSystemRoots)
+	return systemRoots
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/root_darwin.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/root_darwin.go
@@ -1,0 +1,83 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin,cgo
+
+package x509
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1060
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+// FetchPEMRootsCTX509 fetches the system's list of trusted X.509 root certificates.
+//
+// On success it returns 0 and fills pemRoots with a CFDataRef that contains the extracted root
+// certificates of the system. On failure, the function returns -1.
+//
+// Note: The CFDataRef returned in pemRoots must be released (using CFRelease) after
+// we've consumed its content.
+int FetchPEMRootsCTX509(CFDataRef *pemRoots) {
+	if (pemRoots == NULL) {
+		return -1;
+	}
+
+	CFArrayRef certs = NULL;
+	OSStatus err = SecTrustCopyAnchorCertificates(&certs);
+	if (err != noErr) {
+		return -1;
+	}
+
+	CFMutableDataRef combinedData = CFDataCreateMutable(kCFAllocatorDefault, 0);
+	int i, ncerts = CFArrayGetCount(certs);
+	for (i = 0; i < ncerts; i++) {
+		CFDataRef data = NULL;
+		SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+		if (cert == NULL) {
+			continue;
+		}
+
+		// Note: SecKeychainItemExport is deprecated as of 10.7 in favor of SecItemExport.
+		// Once we support weak imports via cgo we should prefer that, and fall back to this
+		// for older systems.
+		err = SecKeychainItemExport(cert, kSecFormatX509Cert, kSecItemPemArmour, NULL, &data);
+		if (err != noErr) {
+			continue;
+		}
+
+		if (data != NULL) {
+			CFDataAppendBytes(combinedData, CFDataGetBytePtr(data), CFDataGetLength(data));
+			CFRelease(data);
+		}
+	}
+
+	CFRelease(certs);
+
+	*pemRoots = combinedData;
+	return 0;
+}
+*/
+import "C"
+import "unsafe"
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}
+
+func initSystemRoots() {
+	roots := NewCertPool()
+
+	var data C.CFDataRef = nil
+	err := C.FetchPEMRootsCTX509(&data)
+	if err == -1 {
+		return
+	}
+
+	defer C.CFRelease(C.CFTypeRef(data))
+	buf := C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(data)), C.int(C.CFDataGetLength(data)))
+	roots.AppendCertsFromPEM(buf)
+	systemRoots = roots
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/root_plan9.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/root_plan9.go
@@ -1,0 +1,33 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build plan9
+
+package x509
+
+import "io/ioutil"
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/sys/lib/tls/ca.pem",
+}
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}
+
+func initSystemRoots() {
+	roots := NewCertPool()
+	for _, file := range certFiles {
+		data, err := ioutil.ReadFile(file)
+		if err == nil {
+			roots.AppendCertsFromPEM(data)
+			systemRoots = roots
+			return
+		}
+	}
+
+	// All of the files failed to load. systemRoots will be nil which will
+	// trigger a specific error at verification time.
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/root_stub.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/root_stub.go
@@ -1,0 +1,14 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin,!cgo
+
+package x509
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}
+
+func initSystemRoots() {
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/root_unix.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/root_unix.go
@@ -1,0 +1,37 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build dragonfly freebsd linux openbsd netbsd
+
+package x509
+
+import "io/ioutil"
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",     // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",       // Fedora/RHEL
+	"/etc/ssl/ca-bundle.pem",                 // OpenSUSE
+	"/etc/ssl/cert.pem",                      // OpenBSD
+	"/usr/local/share/certs/ca-root-nss.crt", // FreeBSD/DragonFly
+}
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}
+
+func initSystemRoots() {
+	roots := NewCertPool()
+	for _, file := range certFiles {
+		data, err := ioutil.ReadFile(file)
+		if err == nil {
+			roots.AppendCertsFromPEM(data)
+			systemRoots = roots
+			return
+		}
+	}
+
+	// All of the files failed to load. systemRoots will be nil which will
+	// trigger a specific error at verification time.
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/root_windows.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/root_windows.go
@@ -1,0 +1,229 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+)
+
+// Creates a new *syscall.CertContext representing the leaf certificate in an in-memory
+// certificate store containing itself and all of the intermediate certificates specified
+// in the opts.Intermediates CertPool.
+//
+// A pointer to the in-memory store is available in the returned CertContext's Store field.
+// The store is automatically freed when the CertContext is freed using
+// syscall.CertFreeCertificateContext.
+func createStoreContext(leaf *Certificate, opts *VerifyOptions) (*syscall.CertContext, error) {
+	var storeCtx *syscall.CertContext
+
+	leafCtx, err := syscall.CertCreateCertificateContext(syscall.X509_ASN_ENCODING|syscall.PKCS_7_ASN_ENCODING, &leaf.Raw[0], uint32(len(leaf.Raw)))
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.CertFreeCertificateContext(leafCtx)
+
+	handle, err := syscall.CertOpenStore(syscall.CERT_STORE_PROV_MEMORY, 0, 0, syscall.CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.CertCloseStore(handle, 0)
+
+	err = syscall.CertAddCertificateContextToStore(handle, leafCtx, syscall.CERT_STORE_ADD_ALWAYS, &storeCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Intermediates != nil {
+		for _, intermediate := range opts.Intermediates.certs {
+			ctx, err := syscall.CertCreateCertificateContext(syscall.X509_ASN_ENCODING|syscall.PKCS_7_ASN_ENCODING, &intermediate.Raw[0], uint32(len(intermediate.Raw)))
+			if err != nil {
+				return nil, err
+			}
+
+			err = syscall.CertAddCertificateContextToStore(handle, ctx, syscall.CERT_STORE_ADD_ALWAYS, nil)
+			syscall.CertFreeCertificateContext(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return storeCtx, nil
+}
+
+// extractSimpleChain extracts the final certificate chain from a CertSimpleChain.
+func extractSimpleChain(simpleChain **syscall.CertSimpleChain, count int) (chain []*Certificate, err error) {
+	if simpleChain == nil || count == 0 {
+		return nil, errors.New("x509: invalid simple chain")
+	}
+
+	simpleChains := (*[1 << 20]*syscall.CertSimpleChain)(unsafe.Pointer(simpleChain))[:]
+	lastChain := simpleChains[count-1]
+	elements := (*[1 << 20]*syscall.CertChainElement)(unsafe.Pointer(lastChain.Elements))[:]
+	for i := 0; i < int(lastChain.NumElements); i++ {
+		// Copy the buf, since ParseCertificate does not create its own copy.
+		cert := elements[i].CertContext
+		encodedCert := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:]
+		buf := make([]byte, cert.Length)
+		copy(buf, encodedCert[:])
+		parsedCert, err := ParseCertificate(buf)
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, parsedCert)
+	}
+
+	return chain, nil
+}
+
+// checkChainTrustStatus checks the trust status of the certificate chain, translating
+// any errors it finds into Go errors in the process.
+func checkChainTrustStatus(c *Certificate, chainCtx *syscall.CertChainContext) error {
+	if chainCtx.TrustStatus.ErrorStatus != syscall.CERT_TRUST_NO_ERROR {
+		status := chainCtx.TrustStatus.ErrorStatus
+		switch status {
+		case syscall.CERT_TRUST_IS_NOT_TIME_VALID:
+			return CertificateInvalidError{c, Expired}
+		default:
+			return UnknownAuthorityError{c, nil, nil}
+		}
+	}
+	return nil
+}
+
+// checkChainSSLServerPolicy checks that the certificate chain in chainCtx is valid for
+// use as a certificate chain for a SSL/TLS server.
+func checkChainSSLServerPolicy(c *Certificate, chainCtx *syscall.CertChainContext, opts *VerifyOptions) error {
+	servernamep, err := syscall.UTF16PtrFromString(opts.DNSName)
+	if err != nil {
+		return err
+	}
+	sslPara := &syscall.SSLExtraCertChainPolicyPara{
+		AuthType:   syscall.AUTHTYPE_SERVER,
+		ServerName: servernamep,
+	}
+	sslPara.Size = uint32(unsafe.Sizeof(*sslPara))
+
+	para := &syscall.CertChainPolicyPara{
+		ExtraPolicyPara: uintptr(unsafe.Pointer(sslPara)),
+	}
+	para.Size = uint32(unsafe.Sizeof(*para))
+
+	status := syscall.CertChainPolicyStatus{}
+	err = syscall.CertVerifyCertificateChainPolicy(syscall.CERT_CHAIN_POLICY_SSL, chainCtx, para, &status)
+	if err != nil {
+		return err
+	}
+
+	// TODO(mkrautz): use the lChainIndex and lElementIndex fields
+	// of the CertChainPolicyStatus to provide proper context, instead
+	// using c.
+	if status.Error != 0 {
+		switch status.Error {
+		case syscall.CERT_E_EXPIRED:
+			return CertificateInvalidError{c, Expired}
+		case syscall.CERT_E_CN_NO_MATCH:
+			return HostnameError{c, opts.DNSName}
+		case syscall.CERT_E_UNTRUSTEDROOT:
+			return UnknownAuthorityError{c, nil, nil}
+		default:
+			return UnknownAuthorityError{c, nil, nil}
+		}
+	}
+
+	return nil
+}
+
+// systemVerify is like Verify, except that it uses CryptoAPI calls
+// to build certificate chains and verify them.
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	hasDNSName := opts != nil && len(opts.DNSName) > 0
+
+	storeCtx, err := createStoreContext(c, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.CertFreeCertificateContext(storeCtx)
+
+	para := new(syscall.CertChainPara)
+	para.Size = uint32(unsafe.Sizeof(*para))
+
+	// If there's a DNSName set in opts, assume we're verifying
+	// a certificate from a TLS server.
+	if hasDNSName {
+		oids := []*byte{
+			&syscall.OID_PKIX_KP_SERVER_AUTH[0],
+			// Both IE and Chrome allow certificates with
+			// Server Gated Crypto as well. Some certificates
+			// in the wild require them.
+			&syscall.OID_SERVER_GATED_CRYPTO[0],
+			&syscall.OID_SGC_NETSCAPE[0],
+		}
+		para.RequestedUsage.Type = syscall.USAGE_MATCH_TYPE_OR
+		para.RequestedUsage.Usage.Length = uint32(len(oids))
+		para.RequestedUsage.Usage.UsageIdentifiers = &oids[0]
+	} else {
+		para.RequestedUsage.Type = syscall.USAGE_MATCH_TYPE_AND
+		para.RequestedUsage.Usage.Length = 0
+		para.RequestedUsage.Usage.UsageIdentifiers = nil
+	}
+
+	var verifyTime *syscall.Filetime
+	if opts != nil && !opts.CurrentTime.IsZero() {
+		ft := syscall.NsecToFiletime(opts.CurrentTime.UnixNano())
+		verifyTime = &ft
+	}
+
+	// CertGetCertificateChain will traverse Windows's root stores
+	// in an attempt to build a verified certificate chain.  Once
+	// it has found a verified chain, it stops. MSDN docs on
+	// CERT_CHAIN_CONTEXT:
+	//
+	//   When a CERT_CHAIN_CONTEXT is built, the first simple chain
+	//   begins with an end certificate and ends with a self-signed
+	//   certificate. If that self-signed certificate is not a root
+	//   or otherwise trusted certificate, an attempt is made to
+	//   build a new chain. CTLs are used to create the new chain
+	//   beginning with the self-signed certificate from the original
+	//   chain as the end certificate of the new chain. This process
+	//   continues building additional simple chains until the first
+	//   self-signed certificate is a trusted certificate or until
+	//   an additional simple chain cannot be built.
+	//
+	// The result is that we'll only get a single trusted chain to
+	// return to our caller.
+	var chainCtx *syscall.CertChainContext
+	err = syscall.CertGetCertificateChain(syscall.Handle(0), storeCtx, verifyTime, storeCtx.Store, para, 0, 0, &chainCtx)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.CertFreeCertificateChain(chainCtx)
+
+	err = checkChainTrustStatus(c, chainCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasDNSName {
+		err = checkChainSSLServerPolicy(c, chainCtx, opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	chain, err := extractSimpleChain(chainCtx.Chains, int(chainCtx.ChainCount))
+	if err != nil {
+		return nil, err
+	}
+
+	chains = append(chains, chain)
+
+	return chains, nil
+}
+
+func initSystemRoots() {
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/sec1.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/sec1.go
@@ -1,0 +1,85 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	// START CT CHANGES
+	"github.com/google/certificate-transparency/go/asn1"
+	// START CT CHANGES
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+const ecPrivKeyVersion = 1
+
+// ecPrivateKey reflects an ASN.1 Elliptic Curve Private Key Structure.
+// References:
+//   RFC5915
+//   SEC1 - http://www.secg.org/download/aid-780/sec1-v2.pdf
+// Per RFC5915 the NamedCurveOID is marked as ASN.1 OPTIONAL, however in
+// most cases it is not.
+type ecPrivateKey struct {
+	Version       int
+	PrivateKey    []byte
+	NamedCurveOID asn1.ObjectIdentifier `asn1:"optional,explicit,tag:0"`
+	PublicKey     asn1.BitString        `asn1:"optional,explicit,tag:1"`
+}
+
+// ParseECPrivateKey parses an ASN.1 Elliptic Curve Private Key Structure.
+func ParseECPrivateKey(der []byte) (key *ecdsa.PrivateKey, err error) {
+	return parseECPrivateKey(nil, der)
+}
+
+// MarshalECPrivateKey marshals an EC private key into ASN.1, DER format.
+func MarshalECPrivateKey(key *ecdsa.PrivateKey) ([]byte, error) {
+	oid, ok := oidFromNamedCurve(key.Curve)
+	if !ok {
+		return nil, errors.New("x509: unknown elliptic curve")
+	}
+	return asn1.Marshal(ecPrivateKey{
+		Version:       1,
+		PrivateKey:    key.D.Bytes(),
+		NamedCurveOID: oid,
+		PublicKey:     asn1.BitString{Bytes: elliptic.Marshal(key.Curve, key.X, key.Y)},
+	})
+}
+
+// parseECPrivateKey parses an ASN.1 Elliptic Curve Private Key Structure.
+// The OID for the named curve may be provided from another source (such as
+// the PKCS8 container) - if it is provided then use this instead of the OID
+// that may exist in the EC private key structure.
+func parseECPrivateKey(namedCurveOID *asn1.ObjectIdentifier, der []byte) (key *ecdsa.PrivateKey, err error) {
+	var privKey ecPrivateKey
+	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
+		return nil, errors.New("x509: failed to parse EC private key: " + err.Error())
+	}
+	if privKey.Version != ecPrivKeyVersion {
+		return nil, fmt.Errorf("x509: unknown EC private key version %d", privKey.Version)
+	}
+
+	var curve elliptic.Curve
+	if namedCurveOID != nil {
+		curve = namedCurveFromOID(*namedCurveOID)
+	} else {
+		curve = namedCurveFromOID(privKey.NamedCurveOID)
+	}
+	if curve == nil {
+		return nil, errors.New("x509: unknown elliptic curve")
+	}
+
+	k := new(big.Int).SetBytes(privKey.PrivateKey)
+	if k.Cmp(curve.Params().N) >= 0 {
+		return nil, errors.New("x509: invalid elliptic curve private key value")
+	}
+	priv := new(ecdsa.PrivateKey)
+	priv.Curve = curve
+	priv.D = k
+	priv.X, priv.Y = curve.ScalarBaseMult(privKey.PrivateKey)
+
+	return priv, nil
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/verify.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/verify.go
@@ -1,0 +1,476 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+type InvalidReason int
+
+const (
+	// NotAuthorizedToSign results when a certificate is signed by another
+	// which isn't marked as a CA certificate.
+	NotAuthorizedToSign InvalidReason = iota
+	// Expired results when a certificate has expired, based on the time
+	// given in the VerifyOptions.
+	Expired
+	// CANotAuthorizedForThisName results when an intermediate or root
+	// certificate has a name constraint which doesn't include the name
+	// being checked.
+	CANotAuthorizedForThisName
+	// TooManyIntermediates results when a path length constraint is
+	// violated.
+	TooManyIntermediates
+	// IncompatibleUsage results when the certificate's key usage indicates
+	// that it may only be used for a different purpose.
+	IncompatibleUsage
+)
+
+// CertificateInvalidError results when an odd error occurs. Users of this
+// library probably want to handle all these errors uniformly.
+type CertificateInvalidError struct {
+	Cert   *Certificate
+	Reason InvalidReason
+}
+
+func (e CertificateInvalidError) Error() string {
+	switch e.Reason {
+	case NotAuthorizedToSign:
+		return "x509: certificate is not authorized to sign other certificates"
+	case Expired:
+		return "x509: certificate has expired or is not yet valid"
+	case CANotAuthorizedForThisName:
+		return "x509: a root or intermediate certificate is not authorized to sign in this domain"
+	case TooManyIntermediates:
+		return "x509: too many intermediates for path length constraint"
+	case IncompatibleUsage:
+		return "x509: certificate specifies an incompatible key usage"
+	}
+	return "x509: unknown error"
+}
+
+// HostnameError results when the set of authorized names doesn't match the
+// requested name.
+type HostnameError struct {
+	Certificate *Certificate
+	Host        string
+}
+
+func (h HostnameError) Error() string {
+	c := h.Certificate
+
+	var valid string
+	if ip := net.ParseIP(h.Host); ip != nil {
+		// Trying to validate an IP
+		if len(c.IPAddresses) == 0 {
+			return "x509: cannot validate certificate for " + h.Host + " because it doesn't contain any IP SANs"
+		}
+		for _, san := range c.IPAddresses {
+			if len(valid) > 0 {
+				valid += ", "
+			}
+			valid += san.String()
+		}
+	} else {
+		if len(c.DNSNames) > 0 {
+			valid = strings.Join(c.DNSNames, ", ")
+		} else {
+			valid = c.Subject.CommonName
+		}
+	}
+	return "x509: certificate is valid for " + valid + ", not " + h.Host
+}
+
+// UnknownAuthorityError results when the certificate issuer is unknown
+type UnknownAuthorityError struct {
+	cert *Certificate
+	// hintErr contains an error that may be helpful in determining why an
+	// authority wasn't found.
+	hintErr error
+	// hintCert contains a possible authority certificate that was rejected
+	// because of the error in hintErr.
+	hintCert *Certificate
+}
+
+func (e UnknownAuthorityError) Error() string {
+	s := "x509: certificate signed by unknown authority"
+	if e.hintErr != nil {
+		certName := e.hintCert.Subject.CommonName
+		if len(certName) == 0 {
+			if len(e.hintCert.Subject.Organization) > 0 {
+				certName = e.hintCert.Subject.Organization[0]
+			}
+			certName = "serial:" + e.hintCert.SerialNumber.String()
+		}
+		s += fmt.Sprintf(" (possibly because of %q while trying to verify candidate authority certificate %q)", e.hintErr, certName)
+	}
+	return s
+}
+
+// SystemRootsError results when we fail to load the system root certificates.
+type SystemRootsError struct {
+}
+
+func (e SystemRootsError) Error() string {
+	return "x509: failed to load system roots and no roots provided"
+}
+
+// VerifyOptions contains parameters for Certificate.Verify. It's a structure
+// because other PKIX verification APIs have ended up needing many options.
+type VerifyOptions struct {
+	DNSName           string
+	Intermediates     *CertPool
+	Roots             *CertPool // if nil, the system roots are used
+	CurrentTime       time.Time // if zero, the current time is used
+	DisableTimeChecks bool
+	// KeyUsage specifies which Extended Key Usage values are acceptable.
+	// An empty list means ExtKeyUsageServerAuth. Key usage is considered a
+	// constraint down the chain which mirrors Windows CryptoAPI behaviour,
+	// but not the spec. To accept any key usage, include ExtKeyUsageAny.
+	KeyUsages []ExtKeyUsage
+}
+
+const (
+	leafCertificate = iota
+	intermediateCertificate
+	rootCertificate
+)
+
+// isValid performs validity checks on the c.
+func (c *Certificate) isValid(certType int, currentChain []*Certificate, opts *VerifyOptions) error {
+	if !opts.DisableTimeChecks {
+		now := opts.CurrentTime
+		if now.IsZero() {
+			now = time.Now()
+		}
+		if now.Before(c.NotBefore) || now.After(c.NotAfter) {
+			return CertificateInvalidError{c, Expired}
+		}
+	}
+
+	if len(c.PermittedDNSDomains) > 0 {
+		ok := false
+		for _, domain := range c.PermittedDNSDomains {
+			if opts.DNSName == domain ||
+				(strings.HasSuffix(opts.DNSName, domain) &&
+					len(opts.DNSName) >= 1+len(domain) &&
+					opts.DNSName[len(opts.DNSName)-len(domain)-1] == '.') {
+				ok = true
+				break
+			}
+		}
+
+		if !ok {
+			return CertificateInvalidError{c, CANotAuthorizedForThisName}
+		}
+	}
+
+	// KeyUsage status flags are ignored. From Engineering Security, Peter
+	// Gutmann: A European government CA marked its signing certificates as
+	// being valid for encryption only, but no-one noticed. Another
+	// European CA marked its signature keys as not being valid for
+	// signatures. A different CA marked its own trusted root certificate
+	// as being invalid for certificate signing.  Another national CA
+	// distributed a certificate to be used to encrypt data for the
+	// country’s tax authority that was marked as only being usable for
+	// digital signatures but not for encryption. Yet another CA reversed
+	// the order of the bit flags in the keyUsage due to confusion over
+	// encoding endianness, essentially setting a random keyUsage in
+	// certificates that it issued. Another CA created a self-invalidating
+	// certificate by adding a certificate policy statement stipulating
+	// that the certificate had to be used strictly as specified in the
+	// keyUsage, and a keyUsage containing a flag indicating that the RSA
+	// encryption key could only be used for Diffie-Hellman key agreement.
+
+	if certType == intermediateCertificate && (!c.BasicConstraintsValid || !c.IsCA) {
+		return CertificateInvalidError{c, NotAuthorizedToSign}
+	}
+
+	if c.BasicConstraintsValid && c.MaxPathLen >= 0 {
+		numIntermediates := len(currentChain) - 1
+		if numIntermediates > c.MaxPathLen {
+			return CertificateInvalidError{c, TooManyIntermediates}
+		}
+	}
+
+	return nil
+}
+
+// Verify attempts to verify c by building one or more chains from c to a
+// certificate in opts.Roots, using certificates in opts.Intermediates if
+// needed. If successful, it returns one or more chains where the first
+// element of the chain is c and the last element is from opts.Roots.
+//
+// WARNING: this doesn't do any revocation checking.
+func (c *Certificate) Verify(opts VerifyOptions) (chains [][]*Certificate, err error) {
+	// Use Windows's own verification and chain building.
+	if opts.Roots == nil && runtime.GOOS == "windows" {
+		return c.systemVerify(&opts)
+	}
+
+	if opts.Roots == nil {
+		opts.Roots = systemRootsPool()
+		if opts.Roots == nil {
+			return nil, SystemRootsError{}
+		}
+	}
+
+	err = c.isValid(leafCertificate, nil, &opts)
+	if err != nil {
+		return
+	}
+
+	if len(opts.DNSName) > 0 {
+		err = c.VerifyHostname(opts.DNSName)
+		if err != nil {
+			return
+		}
+	}
+
+	candidateChains, err := c.buildChains(make(map[int][][]*Certificate), []*Certificate{c}, &opts)
+	if err != nil {
+		return
+	}
+
+	keyUsages := opts.KeyUsages
+	if len(keyUsages) == 0 {
+		keyUsages = []ExtKeyUsage{ExtKeyUsageServerAuth}
+	}
+
+	// If any key usage is acceptable then we're done.
+	for _, usage := range keyUsages {
+		if usage == ExtKeyUsageAny {
+			chains = candidateChains
+			return
+		}
+	}
+
+	for _, candidate := range candidateChains {
+		if checkChainForKeyUsage(candidate, keyUsages) {
+			chains = append(chains, candidate)
+		}
+	}
+
+	if len(chains) == 0 {
+		err = CertificateInvalidError{c, IncompatibleUsage}
+	}
+
+	return
+}
+
+func appendToFreshChain(chain []*Certificate, cert *Certificate) []*Certificate {
+	n := make([]*Certificate, len(chain)+1)
+	copy(n, chain)
+	n[len(chain)] = cert
+	return n
+}
+
+func (c *Certificate) buildChains(cache map[int][][]*Certificate, currentChain []*Certificate, opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	possibleRoots, failedRoot, rootErr := opts.Roots.findVerifiedParents(c)
+	for _, rootNum := range possibleRoots {
+		root := opts.Roots.certs[rootNum]
+		err = root.isValid(rootCertificate, currentChain, opts)
+		if err != nil {
+			continue
+		}
+		chains = append(chains, appendToFreshChain(currentChain, root))
+	}
+
+	possibleIntermediates, failedIntermediate, intermediateErr := opts.Intermediates.findVerifiedParents(c)
+nextIntermediate:
+	for _, intermediateNum := range possibleIntermediates {
+		intermediate := opts.Intermediates.certs[intermediateNum]
+		for _, cert := range currentChain {
+			if cert == intermediate {
+				continue nextIntermediate
+			}
+		}
+		err = intermediate.isValid(intermediateCertificate, currentChain, opts)
+		if err != nil {
+			continue
+		}
+		var childChains [][]*Certificate
+		childChains, ok := cache[intermediateNum]
+		if !ok {
+			childChains, err = intermediate.buildChains(cache, appendToFreshChain(currentChain, intermediate), opts)
+			cache[intermediateNum] = childChains
+		}
+		chains = append(chains, childChains...)
+	}
+
+	if len(chains) > 0 {
+		err = nil
+	}
+
+	if len(chains) == 0 && err == nil {
+		hintErr := rootErr
+		hintCert := failedRoot
+		if hintErr == nil {
+			hintErr = intermediateErr
+			hintCert = failedIntermediate
+		}
+		err = UnknownAuthorityError{c, hintErr, hintCert}
+	}
+
+	return
+}
+
+func matchHostnames(pattern, host string) bool {
+	if len(pattern) == 0 || len(host) == 0 {
+		return false
+	}
+
+	patternParts := strings.Split(pattern, ".")
+	hostParts := strings.Split(host, ".")
+
+	if len(patternParts) != len(hostParts) {
+		return false
+	}
+
+	for i, patternPart := range patternParts {
+		if patternPart == "*" {
+			continue
+		}
+		if patternPart != hostParts[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// toLowerCaseASCII returns a lower-case version of in. See RFC 6125 6.4.1. We use
+// an explicitly ASCII function to avoid any sharp corners resulting from
+// performing Unicode operations on DNS labels.
+func toLowerCaseASCII(in string) string {
+	// If the string is already lower-case then there's nothing to do.
+	isAlreadyLowerCase := true
+	for _, c := range in {
+		if c == utf8.RuneError {
+			// If we get a UTF-8 error then there might be
+			// upper-case ASCII bytes in the invalid sequence.
+			isAlreadyLowerCase = false
+			break
+		}
+		if 'A' <= c && c <= 'Z' {
+			isAlreadyLowerCase = false
+			break
+		}
+	}
+
+	if isAlreadyLowerCase {
+		return in
+	}
+
+	out := []byte(in)
+	for i, c := range out {
+		if 'A' <= c && c <= 'Z' {
+			out[i] += 'a' - 'A'
+		}
+	}
+	return string(out)
+}
+
+// VerifyHostname returns nil if c is a valid certificate for the named host.
+// Otherwise it returns an error describing the mismatch.
+func (c *Certificate) VerifyHostname(h string) error {
+	// IP addresses may be written in [ ].
+	candidateIP := h
+	if len(h) >= 3 && h[0] == '[' && h[len(h)-1] == ']' {
+		candidateIP = h[1 : len(h)-1]
+	}
+	if ip := net.ParseIP(candidateIP); ip != nil {
+		// We only match IP addresses against IP SANs.
+		// https://tools.ietf.org/html/rfc6125#appendix-B.2
+		for _, candidate := range c.IPAddresses {
+			if ip.Equal(candidate) {
+				return nil
+			}
+		}
+		return HostnameError{c, candidateIP}
+	}
+
+	lowered := toLowerCaseASCII(h)
+
+	if len(c.DNSNames) > 0 {
+		for _, match := range c.DNSNames {
+			if matchHostnames(toLowerCaseASCII(match), lowered) {
+				return nil
+			}
+		}
+		// If Subject Alt Name is given, we ignore the common name.
+	} else if matchHostnames(toLowerCaseASCII(c.Subject.CommonName), lowered) {
+		return nil
+	}
+
+	return HostnameError{c, h}
+}
+
+func checkChainForKeyUsage(chain []*Certificate, keyUsages []ExtKeyUsage) bool {
+	usages := make([]ExtKeyUsage, len(keyUsages))
+	copy(usages, keyUsages)
+
+	if len(chain) == 0 {
+		return false
+	}
+
+	usagesRemaining := len(usages)
+
+	// We walk down the list and cross out any usages that aren't supported
+	// by each certificate. If we cross out all the usages, then the chain
+	// is unacceptable.
+
+	for i := len(chain) - 1; i >= 0; i-- {
+		cert := chain[i]
+		if len(cert.ExtKeyUsage) == 0 && len(cert.UnknownExtKeyUsage) == 0 {
+			// The certificate doesn't have any extended key usage specified.
+			continue
+		}
+
+		for _, usage := range cert.ExtKeyUsage {
+			if usage == ExtKeyUsageAny {
+				// The certificate is explicitly good for any usage.
+				continue
+			}
+		}
+
+		const invalidUsage ExtKeyUsage = -1
+
+	NextRequestedUsage:
+		for i, requestedUsage := range usages {
+			if requestedUsage == invalidUsage {
+				continue
+			}
+
+			for _, usage := range cert.ExtKeyUsage {
+				if requestedUsage == usage {
+					continue NextRequestedUsage
+				} else if requestedUsage == ExtKeyUsageServerAuth &&
+					(usage == ExtKeyUsageNetscapeServerGatedCrypto ||
+						usage == ExtKeyUsageMicrosoftServerGatedCrypto) {
+					// In order to support COMODO
+					// certificate chains, we have to
+					// accept Netscape or Microsoft SGC
+					// usages as equal to ServerAuth.
+					continue NextRequestedUsage
+				}
+			}
+
+			usages[i] = invalidUsage
+			usagesRemaining--
+			if usagesRemaining == 0 {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/google/certificate-transparency/go/x509/x509.go
+++ b/vendor/github.com/google/certificate-transparency/go/x509/x509.go
@@ -1,0 +1,1622 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package x509 parses X.509-encoded keys and certificates.
+//
+// START CT CHANGES
+// This is a fork of the go library crypto/x509 package, it's more relaxed
+// about certificates that it'll accept, and exports the TBSCertificate
+// structure.
+// END CT CHANGES
+package x509
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha1"
+	// START CT CHANGES
+	"github.com/google/certificate-transparency/go/asn1"
+	"github.com/google/certificate-transparency/go/x509/pkix"
+	// END CT CHANGES
+	"encoding/pem"
+	"errors"
+	// START CT CHANGES
+	"fmt"
+	// END CT CHANGES
+	"io"
+	"math/big"
+	"net"
+	"time"
+)
+
+// pkixPublicKey reflects a PKIX public key structure. See SubjectPublicKeyInfo
+// in RFC 3280.
+type pkixPublicKey struct {
+	Algo      pkix.AlgorithmIdentifier
+	BitString asn1.BitString
+}
+
+// ParsePKIXPublicKey parses a DER encoded public key. These values are
+// typically found in PEM blocks with "BEGIN PUBLIC KEY".
+func ParsePKIXPublicKey(derBytes []byte) (pub interface{}, err error) {
+	var pki publicKeyInfo
+	if _, err = asn1.Unmarshal(derBytes, &pki); err != nil {
+		return
+	}
+	algo := getPublicKeyAlgorithmFromOID(pki.Algorithm.Algorithm)
+	if algo == UnknownPublicKeyAlgorithm {
+		return nil, errors.New("x509: unknown public key algorithm")
+	}
+	return parsePublicKey(algo, &pki)
+}
+
+func marshalPublicKey(pub interface{}) (publicKeyBytes []byte, publicKeyAlgorithm pkix.AlgorithmIdentifier, err error) {
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		publicKeyBytes, err = asn1.Marshal(rsaPublicKey{
+			N: pub.N,
+			E: pub.E,
+		})
+		publicKeyAlgorithm.Algorithm = oidPublicKeyRSA
+		// This is a NULL parameters value which is technically
+		// superfluous, but most other code includes it and, by
+		// doing this, we match their public key hashes.
+		publicKeyAlgorithm.Parameters = asn1.RawValue{
+			Tag: 5,
+		}
+	case *ecdsa.PublicKey:
+		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+		oid, ok := oidFromNamedCurve(pub.Curve)
+		if !ok {
+			return nil, pkix.AlgorithmIdentifier{}, errors.New("x509: unsupported elliptic curve")
+		}
+		publicKeyAlgorithm.Algorithm = oidPublicKeyECDSA
+		var paramBytes []byte
+		paramBytes, err = asn1.Marshal(oid)
+		if err != nil {
+			return
+		}
+		publicKeyAlgorithm.Parameters.FullBytes = paramBytes
+	default:
+		return nil, pkix.AlgorithmIdentifier{}, errors.New("x509: only RSA and ECDSA public keys supported")
+	}
+
+	return publicKeyBytes, publicKeyAlgorithm, nil
+}
+
+// MarshalPKIXPublicKey serialises a public key to DER-encoded PKIX format.
+func MarshalPKIXPublicKey(pub interface{}) ([]byte, error) {
+	var publicKeyBytes []byte
+	var publicKeyAlgorithm pkix.AlgorithmIdentifier
+	var err error
+
+	if publicKeyBytes, publicKeyAlgorithm, err = marshalPublicKey(pub); err != nil {
+		return nil, err
+	}
+
+	pkix := pkixPublicKey{
+		Algo: publicKeyAlgorithm,
+		BitString: asn1.BitString{
+			Bytes:     publicKeyBytes,
+			BitLength: 8 * len(publicKeyBytes),
+		},
+	}
+
+	ret, _ := asn1.Marshal(pkix)
+	return ret, nil
+}
+
+// These structures reflect the ASN.1 structure of X.509 certificates.:
+
+type certificate struct {
+	Raw                asn1.RawContent
+	TBSCertificate     tbsCertificate
+	SignatureAlgorithm pkix.AlgorithmIdentifier
+	SignatureValue     asn1.BitString
+}
+
+type tbsCertificate struct {
+	Raw                asn1.RawContent
+	Version            int `asn1:"optional,explicit,default:1,tag:0"`
+	SerialNumber       *big.Int
+	SignatureAlgorithm pkix.AlgorithmIdentifier
+	Issuer             asn1.RawValue
+	Validity           validity
+	Subject            asn1.RawValue
+	PublicKey          publicKeyInfo
+	UniqueId           asn1.BitString   `asn1:"optional,tag:1"`
+	SubjectUniqueId    asn1.BitString   `asn1:"optional,tag:2"`
+	Extensions         []pkix.Extension `asn1:"optional,explicit,tag:3"`
+}
+
+type dsaAlgorithmParameters struct {
+	P, Q, G *big.Int
+}
+
+type dsaSignature struct {
+	R, S *big.Int
+}
+
+type ecdsaSignature dsaSignature
+
+type validity struct {
+	NotBefore, NotAfter time.Time
+}
+
+type publicKeyInfo struct {
+	Raw       asn1.RawContent
+	Algorithm pkix.AlgorithmIdentifier
+	PublicKey asn1.BitString
+}
+
+// RFC 5280,  4.2.1.1
+type authKeyId struct {
+	Id []byte `asn1:"optional,tag:0"`
+}
+
+type SignatureAlgorithm int
+
+const (
+	UnknownSignatureAlgorithm SignatureAlgorithm = iota
+	MD2WithRSA
+	MD5WithRSA
+	SHA1WithRSA
+	SHA256WithRSA
+	SHA384WithRSA
+	SHA512WithRSA
+	DSAWithSHA1
+	DSAWithSHA256
+	ECDSAWithSHA1
+	ECDSAWithSHA256
+	ECDSAWithSHA384
+	ECDSAWithSHA512
+)
+
+type PublicKeyAlgorithm int
+
+const (
+	UnknownPublicKeyAlgorithm PublicKeyAlgorithm = iota
+	RSA
+	DSA
+	ECDSA
+)
+
+// OIDs for signature algorithms
+//
+// pkcs-1 OBJECT IDENTIFIER ::= {
+//    iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 1 }
+//
+//
+// RFC 3279 2.2.1 RSA Signature Algorithms
+//
+// md2WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 2 }
+//
+// md5WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 4 }
+//
+// sha-1WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 5 }
+//
+// dsaWithSha1 OBJECT IDENTIFIER ::= {
+//    iso(1) member-body(2) us(840) x9-57(10040) x9cm(4) 3 }
+//
+// RFC 3279 2.2.3 ECDSA Signature Algorithm
+//
+// ecdsa-with-SHA1 OBJECT IDENTIFIER ::= {
+// 	  iso(1) member-body(2) us(840) ansi-x962(10045)
+//    signatures(4) ecdsa-with-SHA1(1)}
+//
+//
+// RFC 4055 5 PKCS #1 Version 1.5
+//
+// sha256WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 11 }
+//
+// sha384WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 12 }
+//
+// sha512WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 13 }
+//
+//
+// RFC 5758 3.1 DSA Signature Algorithms
+//
+// dsaWithSha256 OBJECT IDENTIFIER ::= {
+//    joint-iso-ccitt(2) country(16) us(840) organization(1) gov(101)
+//    csor(3) algorithms(4) id-dsa-with-sha2(3) 2}
+//
+// RFC 5758 3.2 ECDSA Signature Algorithm
+//
+// ecdsa-with-SHA256 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 2 }
+//
+// ecdsa-with-SHA384 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 3 }
+//
+// ecdsa-with-SHA512 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 4 }
+
+var (
+	oidSignatureMD2WithRSA      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 2}
+	oidSignatureMD5WithRSA      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 4}
+	oidSignatureSHA1WithRSA     = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
+	oidSignatureSHA256WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
+	oidSignatureSHA384WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 12}
+	oidSignatureSHA512WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 13}
+	oidSignatureDSAWithSHA1     = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
+	oidSignatureDSAWithSHA256   = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 4, 3, 2}
+	oidSignatureECDSAWithSHA1   = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 1}
+	oidSignatureECDSAWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
+	oidSignatureECDSAWithSHA384 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 3}
+	oidSignatureECDSAWithSHA512 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 4}
+)
+
+func getSignatureAlgorithmFromOID(oid asn1.ObjectIdentifier) SignatureAlgorithm {
+	switch {
+	case oid.Equal(oidSignatureMD2WithRSA):
+		return MD2WithRSA
+	case oid.Equal(oidSignatureMD5WithRSA):
+		return MD5WithRSA
+	case oid.Equal(oidSignatureSHA1WithRSA):
+		return SHA1WithRSA
+	case oid.Equal(oidSignatureSHA256WithRSA):
+		return SHA256WithRSA
+	case oid.Equal(oidSignatureSHA384WithRSA):
+		return SHA384WithRSA
+	case oid.Equal(oidSignatureSHA512WithRSA):
+		return SHA512WithRSA
+	case oid.Equal(oidSignatureDSAWithSHA1):
+		return DSAWithSHA1
+	case oid.Equal(oidSignatureDSAWithSHA256):
+		return DSAWithSHA256
+	case oid.Equal(oidSignatureECDSAWithSHA1):
+		return ECDSAWithSHA1
+	case oid.Equal(oidSignatureECDSAWithSHA256):
+		return ECDSAWithSHA256
+	case oid.Equal(oidSignatureECDSAWithSHA384):
+		return ECDSAWithSHA384
+	case oid.Equal(oidSignatureECDSAWithSHA512):
+		return ECDSAWithSHA512
+	}
+	return UnknownSignatureAlgorithm
+}
+
+// RFC 3279, 2.3 Public Key Algorithms
+//
+// pkcs-1 OBJECT IDENTIFIER ::== { iso(1) member-body(2) us(840)
+//    rsadsi(113549) pkcs(1) 1 }
+//
+// rsaEncryption OBJECT IDENTIFIER ::== { pkcs1-1 1 }
+//
+// id-dsa OBJECT IDENTIFIER ::== { iso(1) member-body(2) us(840)
+//    x9-57(10040) x9cm(4) 1 }
+//
+// RFC 5480, 2.1.1 Unrestricted Algorithm Identifier and Parameters
+//
+// id-ecPublicKey OBJECT IDENTIFIER ::= {
+//       iso(1) member-body(2) us(840) ansi-X9-62(10045) keyType(2) 1 }
+var (
+	oidPublicKeyRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	oidPublicKeyDSA   = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 1}
+	oidPublicKeyECDSA = asn1.ObjectIdentifier{1, 2, 840, 10045, 2, 1}
+)
+
+func getPublicKeyAlgorithmFromOID(oid asn1.ObjectIdentifier) PublicKeyAlgorithm {
+	switch {
+	case oid.Equal(oidPublicKeyRSA):
+		return RSA
+	case oid.Equal(oidPublicKeyDSA):
+		return DSA
+	case oid.Equal(oidPublicKeyECDSA):
+		return ECDSA
+	}
+	return UnknownPublicKeyAlgorithm
+}
+
+// RFC 5480, 2.1.1.1. Named Curve
+//
+// secp224r1 OBJECT IDENTIFIER ::= {
+//   iso(1) identified-organization(3) certicom(132) curve(0) 33 }
+//
+// secp256r1 OBJECT IDENTIFIER ::= {
+//   iso(1) member-body(2) us(840) ansi-X9-62(10045) curves(3)
+//   prime(1) 7 }
+//
+// secp384r1 OBJECT IDENTIFIER ::= {
+//   iso(1) identified-organization(3) certicom(132) curve(0) 34 }
+//
+// secp521r1 OBJECT IDENTIFIER ::= {
+//   iso(1) identified-organization(3) certicom(132) curve(0) 35 }
+//
+// NB: secp256r1 is equivalent to prime256v1
+var (
+	oidNamedCurveP224 = asn1.ObjectIdentifier{1, 3, 132, 0, 33}
+	oidNamedCurveP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+	oidNamedCurveP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
+	oidNamedCurveP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
+)
+
+func namedCurveFromOID(oid asn1.ObjectIdentifier) elliptic.Curve {
+	switch {
+	case oid.Equal(oidNamedCurveP224):
+		return elliptic.P224()
+	case oid.Equal(oidNamedCurveP256):
+		return elliptic.P256()
+	case oid.Equal(oidNamedCurveP384):
+		return elliptic.P384()
+	case oid.Equal(oidNamedCurveP521):
+		return elliptic.P521()
+	}
+	return nil
+}
+
+func oidFromNamedCurve(curve elliptic.Curve) (asn1.ObjectIdentifier, bool) {
+	switch curve {
+	case elliptic.P224():
+		return oidNamedCurveP224, true
+	case elliptic.P256():
+		return oidNamedCurveP256, true
+	case elliptic.P384():
+		return oidNamedCurveP384, true
+	case elliptic.P521():
+		return oidNamedCurveP521, true
+	}
+
+	return nil, false
+}
+
+// KeyUsage represents the set of actions that are valid for a given key. It's
+// a bitmap of the KeyUsage* constants.
+type KeyUsage int
+
+const (
+	KeyUsageDigitalSignature KeyUsage = 1 << iota
+	KeyUsageContentCommitment
+	KeyUsageKeyEncipherment
+	KeyUsageDataEncipherment
+	KeyUsageKeyAgreement
+	KeyUsageCertSign
+	KeyUsageCRLSign
+	KeyUsageEncipherOnly
+	KeyUsageDecipherOnly
+)
+
+// RFC 5280, 4.2.1.12  Extended Key Usage
+//
+// anyExtendedKeyUsage OBJECT IDENTIFIER ::= { id-ce-extKeyUsage 0 }
+//
+// id-kp OBJECT IDENTIFIER ::= { id-pkix 3 }
+//
+// id-kp-serverAuth             OBJECT IDENTIFIER ::= { id-kp 1 }
+// id-kp-clientAuth             OBJECT IDENTIFIER ::= { id-kp 2 }
+// id-kp-codeSigning            OBJECT IDENTIFIER ::= { id-kp 3 }
+// id-kp-emailProtection        OBJECT IDENTIFIER ::= { id-kp 4 }
+// id-kp-timeStamping           OBJECT IDENTIFIER ::= { id-kp 8 }
+// id-kp-OCSPSigning            OBJECT IDENTIFIER ::= { id-kp 9 }
+var (
+	oidExtKeyUsageAny                        = asn1.ObjectIdentifier{2, 5, 29, 37, 0}
+	oidExtKeyUsageServerAuth                 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}
+	oidExtKeyUsageClientAuth                 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2}
+	oidExtKeyUsageCodeSigning                = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 3}
+	oidExtKeyUsageEmailProtection            = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 4}
+	oidExtKeyUsageIPSECEndSystem             = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 5}
+	oidExtKeyUsageIPSECTunnel                = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 6}
+	oidExtKeyUsageIPSECUser                  = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 7}
+	oidExtKeyUsageTimeStamping               = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
+	oidExtKeyUsageOCSPSigning                = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 9}
+	oidExtKeyUsageMicrosoftServerGatedCrypto = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 10, 3, 3}
+	oidExtKeyUsageNetscapeServerGatedCrypto  = asn1.ObjectIdentifier{2, 16, 840, 1, 113730, 4, 1}
+)
+
+// ExtKeyUsage represents an extended set of actions that are valid for a given key.
+// Each of the ExtKeyUsage* constants define a unique action.
+type ExtKeyUsage int
+
+const (
+	ExtKeyUsageAny ExtKeyUsage = iota
+	ExtKeyUsageServerAuth
+	ExtKeyUsageClientAuth
+	ExtKeyUsageCodeSigning
+	ExtKeyUsageEmailProtection
+	ExtKeyUsageIPSECEndSystem
+	ExtKeyUsageIPSECTunnel
+	ExtKeyUsageIPSECUser
+	ExtKeyUsageTimeStamping
+	ExtKeyUsageOCSPSigning
+	ExtKeyUsageMicrosoftServerGatedCrypto
+	ExtKeyUsageNetscapeServerGatedCrypto
+)
+
+// extKeyUsageOIDs contains the mapping between an ExtKeyUsage and its OID.
+var extKeyUsageOIDs = []struct {
+	extKeyUsage ExtKeyUsage
+	oid         asn1.ObjectIdentifier
+}{
+	{ExtKeyUsageAny, oidExtKeyUsageAny},
+	{ExtKeyUsageServerAuth, oidExtKeyUsageServerAuth},
+	{ExtKeyUsageClientAuth, oidExtKeyUsageClientAuth},
+	{ExtKeyUsageCodeSigning, oidExtKeyUsageCodeSigning},
+	{ExtKeyUsageEmailProtection, oidExtKeyUsageEmailProtection},
+	{ExtKeyUsageIPSECEndSystem, oidExtKeyUsageIPSECEndSystem},
+	{ExtKeyUsageIPSECTunnel, oidExtKeyUsageIPSECTunnel},
+	{ExtKeyUsageIPSECUser, oidExtKeyUsageIPSECUser},
+	{ExtKeyUsageTimeStamping, oidExtKeyUsageTimeStamping},
+	{ExtKeyUsageOCSPSigning, oidExtKeyUsageOCSPSigning},
+	{ExtKeyUsageMicrosoftServerGatedCrypto, oidExtKeyUsageMicrosoftServerGatedCrypto},
+	{ExtKeyUsageNetscapeServerGatedCrypto, oidExtKeyUsageNetscapeServerGatedCrypto},
+}
+
+func extKeyUsageFromOID(oid asn1.ObjectIdentifier) (eku ExtKeyUsage, ok bool) {
+	for _, pair := range extKeyUsageOIDs {
+		if oid.Equal(pair.oid) {
+			return pair.extKeyUsage, true
+		}
+	}
+	return
+}
+
+func oidFromExtKeyUsage(eku ExtKeyUsage) (oid asn1.ObjectIdentifier, ok bool) {
+	for _, pair := range extKeyUsageOIDs {
+		if eku == pair.extKeyUsage {
+			return pair.oid, true
+		}
+	}
+	return
+}
+
+// A Certificate represents an X.509 certificate.
+type Certificate struct {
+	Raw                     []byte // Complete ASN.1 DER content (certificate, signature algorithm and signature).
+	RawTBSCertificate       []byte // Certificate part of raw ASN.1 DER content.
+	RawSubjectPublicKeyInfo []byte // DER encoded SubjectPublicKeyInfo.
+	RawSubject              []byte // DER encoded Subject
+	RawIssuer               []byte // DER encoded Issuer
+
+	Signature          []byte
+	SignatureAlgorithm SignatureAlgorithm
+
+	PublicKeyAlgorithm PublicKeyAlgorithm
+	PublicKey          interface{}
+
+	Version             int
+	SerialNumber        *big.Int
+	Issuer              pkix.Name
+	Subject             pkix.Name
+	NotBefore, NotAfter time.Time // Validity bounds.
+	KeyUsage            KeyUsage
+
+	// Extensions contains raw X.509 extensions. When parsing certificates,
+	// this can be used to extract non-critical extensions that are not
+	// parsed by this package. When marshaling certificates, the Extensions
+	// field is ignored, see ExtraExtensions.
+	Extensions []pkix.Extension
+
+	// ExtraExtensions contains extensions to be copied, raw, into any
+	// marshaled certificates. Values override any extensions that would
+	// otherwise be produced based on the other fields. The ExtraExtensions
+	// field is not populated when parsing certificates, see Extensions.
+	ExtraExtensions []pkix.Extension
+
+	ExtKeyUsage        []ExtKeyUsage           // Sequence of extended key usages.
+	UnknownExtKeyUsage []asn1.ObjectIdentifier // Encountered extended key usages unknown to this package.
+
+	BasicConstraintsValid bool // if true then the next two fields are valid.
+	IsCA                  bool
+	MaxPathLen            int
+
+	SubjectKeyId   []byte
+	AuthorityKeyId []byte
+
+	// RFC 5280, 4.2.2.1 (Authority Information Access)
+	OCSPServer            []string
+	IssuingCertificateURL []string
+
+	// Subject Alternate Name values
+	DNSNames       []string
+	EmailAddresses []string
+	IPAddresses    []net.IP
+
+	// Name constraints
+	PermittedDNSDomainsCritical bool // if true then the name constraints are marked critical.
+	PermittedDNSDomains         []string
+
+	// CRL Distribution Points
+	CRLDistributionPoints []string
+
+	PolicyIdentifiers []asn1.ObjectIdentifier
+}
+
+// ErrUnsupportedAlgorithm results from attempting to perform an operation that
+// involves algorithms that are not currently implemented.
+var ErrUnsupportedAlgorithm = errors.New("x509: cannot verify signature: algorithm unimplemented")
+
+// ConstraintViolationError results when a requested usage is not permitted by
+// a certificate. For example: checking a signature when the public key isn't a
+// certificate signing key.
+type ConstraintViolationError struct{}
+
+func (ConstraintViolationError) Error() string {
+	return "x509: invalid signature: parent certificate cannot sign this kind of certificate"
+}
+
+func (c *Certificate) Equal(other *Certificate) bool {
+	return bytes.Equal(c.Raw, other.Raw)
+}
+
+// Entrust have a broken root certificate (CN=Entrust.net Certification
+// Authority (2048)) which isn't marked as a CA certificate and is thus invalid
+// according to PKIX.
+// We recognise this certificate by its SubjectPublicKeyInfo and exempt it
+// from the Basic Constraints requirement.
+// See http://www.entrust.net/knowledge-base/technote.cfm?tn=7869
+//
+// TODO(agl): remove this hack once their reissued root is sufficiently
+// widespread.
+var entrustBrokenSPKI = []byte{
+	0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09,
+	0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
+	0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00,
+	0x30, 0x82, 0x01, 0x0a, 0x02, 0x82, 0x01, 0x01,
+	0x00, 0x97, 0xa3, 0x2d, 0x3c, 0x9e, 0xde, 0x05,
+	0xda, 0x13, 0xc2, 0x11, 0x8d, 0x9d, 0x8e, 0xe3,
+	0x7f, 0xc7, 0x4b, 0x7e, 0x5a, 0x9f, 0xb3, 0xff,
+	0x62, 0xab, 0x73, 0xc8, 0x28, 0x6b, 0xba, 0x10,
+	0x64, 0x82, 0x87, 0x13, 0xcd, 0x57, 0x18, 0xff,
+	0x28, 0xce, 0xc0, 0xe6, 0x0e, 0x06, 0x91, 0x50,
+	0x29, 0x83, 0xd1, 0xf2, 0xc3, 0x2a, 0xdb, 0xd8,
+	0xdb, 0x4e, 0x04, 0xcc, 0x00, 0xeb, 0x8b, 0xb6,
+	0x96, 0xdc, 0xbc, 0xaa, 0xfa, 0x52, 0x77, 0x04,
+	0xc1, 0xdb, 0x19, 0xe4, 0xae, 0x9c, 0xfd, 0x3c,
+	0x8b, 0x03, 0xef, 0x4d, 0xbc, 0x1a, 0x03, 0x65,
+	0xf9, 0xc1, 0xb1, 0x3f, 0x72, 0x86, 0xf2, 0x38,
+	0xaa, 0x19, 0xae, 0x10, 0x88, 0x78, 0x28, 0xda,
+	0x75, 0xc3, 0x3d, 0x02, 0x82, 0x02, 0x9c, 0xb9,
+	0xc1, 0x65, 0x77, 0x76, 0x24, 0x4c, 0x98, 0xf7,
+	0x6d, 0x31, 0x38, 0xfb, 0xdb, 0xfe, 0xdb, 0x37,
+	0x02, 0x76, 0xa1, 0x18, 0x97, 0xa6, 0xcc, 0xde,
+	0x20, 0x09, 0x49, 0x36, 0x24, 0x69, 0x42, 0xf6,
+	0xe4, 0x37, 0x62, 0xf1, 0x59, 0x6d, 0xa9, 0x3c,
+	0xed, 0x34, 0x9c, 0xa3, 0x8e, 0xdb, 0xdc, 0x3a,
+	0xd7, 0xf7, 0x0a, 0x6f, 0xef, 0x2e, 0xd8, 0xd5,
+	0x93, 0x5a, 0x7a, 0xed, 0x08, 0x49, 0x68, 0xe2,
+	0x41, 0xe3, 0x5a, 0x90, 0xc1, 0x86, 0x55, 0xfc,
+	0x51, 0x43, 0x9d, 0xe0, 0xb2, 0xc4, 0x67, 0xb4,
+	0xcb, 0x32, 0x31, 0x25, 0xf0, 0x54, 0x9f, 0x4b,
+	0xd1, 0x6f, 0xdb, 0xd4, 0xdd, 0xfc, 0xaf, 0x5e,
+	0x6c, 0x78, 0x90, 0x95, 0xde, 0xca, 0x3a, 0x48,
+	0xb9, 0x79, 0x3c, 0x9b, 0x19, 0xd6, 0x75, 0x05,
+	0xa0, 0xf9, 0x88, 0xd7, 0xc1, 0xe8, 0xa5, 0x09,
+	0xe4, 0x1a, 0x15, 0xdc, 0x87, 0x23, 0xaa, 0xb2,
+	0x75, 0x8c, 0x63, 0x25, 0x87, 0xd8, 0xf8, 0x3d,
+	0xa6, 0xc2, 0xcc, 0x66, 0xff, 0xa5, 0x66, 0x68,
+	0x55, 0x02, 0x03, 0x01, 0x00, 0x01,
+}
+
+// CheckSignatureFrom verifies that the signature on c is a valid signature
+// from parent.
+func (c *Certificate) CheckSignatureFrom(parent *Certificate) (err error) {
+	// RFC 5280, 4.2.1.9:
+	// "If the basic constraints extension is not present in a version 3
+	// certificate, or the extension is present but the cA boolean is not
+	// asserted, then the certified public key MUST NOT be used to verify
+	// certificate signatures."
+	// (except for Entrust, see comment above entrustBrokenSPKI)
+	if (parent.Version == 3 && !parent.BasicConstraintsValid ||
+		parent.BasicConstraintsValid && !parent.IsCA) &&
+		!bytes.Equal(c.RawSubjectPublicKeyInfo, entrustBrokenSPKI) {
+		return ConstraintViolationError{}
+	}
+
+	if parent.KeyUsage != 0 && parent.KeyUsage&KeyUsageCertSign == 0 {
+		return ConstraintViolationError{}
+	}
+
+	if parent.PublicKeyAlgorithm == UnknownPublicKeyAlgorithm {
+		return ErrUnsupportedAlgorithm
+	}
+
+	// TODO(agl): don't ignore the path length constraint.
+
+	return parent.CheckSignature(c.SignatureAlgorithm, c.RawTBSCertificate, c.Signature)
+}
+
+// CheckSignature verifies that signature is a valid signature over signed from
+// c's public key.
+func (c *Certificate) CheckSignature(algo SignatureAlgorithm, signed, signature []byte) (err error) {
+	var hashType crypto.Hash
+
+	switch algo {
+	case SHA1WithRSA, DSAWithSHA1, ECDSAWithSHA1:
+		hashType = crypto.SHA1
+	case SHA256WithRSA, DSAWithSHA256, ECDSAWithSHA256:
+		hashType = crypto.SHA256
+	case SHA384WithRSA, ECDSAWithSHA384:
+		hashType = crypto.SHA384
+	case SHA512WithRSA, ECDSAWithSHA512:
+		hashType = crypto.SHA512
+	default:
+		return ErrUnsupportedAlgorithm
+	}
+
+	if !hashType.Available() {
+		return ErrUnsupportedAlgorithm
+	}
+	h := hashType.New()
+
+	h.Write(signed)
+	digest := h.Sum(nil)
+
+	switch pub := c.PublicKey.(type) {
+	case *rsa.PublicKey:
+		return rsa.VerifyPKCS1v15(pub, hashType, digest, signature)
+	case *dsa.PublicKey:
+		dsaSig := new(dsaSignature)
+		if _, err := asn1.Unmarshal(signature, dsaSig); err != nil {
+			return err
+		}
+		if dsaSig.R.Sign() <= 0 || dsaSig.S.Sign() <= 0 {
+			return errors.New("x509: DSA signature contained zero or negative values")
+		}
+		if !dsa.Verify(pub, digest, dsaSig.R, dsaSig.S) {
+			return errors.New("x509: DSA verification failure")
+		}
+		return
+	case *ecdsa.PublicKey:
+		ecdsaSig := new(ecdsaSignature)
+		if _, err := asn1.Unmarshal(signature, ecdsaSig); err != nil {
+			return err
+		}
+		if ecdsaSig.R.Sign() <= 0 || ecdsaSig.S.Sign() <= 0 {
+			return errors.New("x509: ECDSA signature contained zero or negative values")
+		}
+		if !ecdsa.Verify(pub, digest, ecdsaSig.R, ecdsaSig.S) {
+			return errors.New("x509: ECDSA verification failure")
+		}
+		return
+	}
+	return ErrUnsupportedAlgorithm
+}
+
+// CheckCRLSignature checks that the signature in crl is from c.
+func (c *Certificate) CheckCRLSignature(crl *pkix.CertificateList) (err error) {
+	algo := getSignatureAlgorithmFromOID(crl.SignatureAlgorithm.Algorithm)
+	return c.CheckSignature(algo, crl.TBSCertList.Raw, crl.SignatureValue.RightAlign())
+}
+
+// START CT CHANGES
+type UnhandledCriticalExtension struct {
+	ID asn1.ObjectIdentifier
+}
+
+func (h UnhandledCriticalExtension) Error() string {
+	return fmt.Sprintf("x509: unhandled critical extension (%v)", h.ID)
+}
+
+// END CT CHANGES
+
+type basicConstraints struct {
+	IsCA       bool `asn1:"optional"`
+	MaxPathLen int  `asn1:"optional,default:-1"`
+}
+
+// RFC 5280 4.2.1.4
+type policyInformation struct {
+	Policy asn1.ObjectIdentifier
+	// policyQualifiers omitted
+}
+
+// RFC 5280, 4.2.1.10
+type nameConstraints struct {
+	Permitted []generalSubtree `asn1:"optional,tag:0"`
+	Excluded  []generalSubtree `asn1:"optional,tag:1"`
+}
+
+type generalSubtree struct {
+	Name string `asn1:"tag:2,optional,ia5"`
+}
+
+// RFC 5280, 4.2.2.1
+type authorityInfoAccess struct {
+	Method   asn1.ObjectIdentifier
+	Location asn1.RawValue
+}
+
+// RFC 5280, 4.2.1.14
+type distributionPoint struct {
+	DistributionPoint distributionPointName `asn1:"optional,tag:0"`
+	Reason            asn1.BitString        `asn1:"optional,tag:1"`
+	CRLIssuer         asn1.RawValue         `asn1:"optional,tag:2"`
+}
+
+type distributionPointName struct {
+	FullName     asn1.RawValue    `asn1:"optional,tag:0"`
+	RelativeName pkix.RDNSequence `asn1:"optional,tag:1"`
+}
+
+func parsePublicKey(algo PublicKeyAlgorithm, keyData *publicKeyInfo) (interface{}, error) {
+	asn1Data := keyData.PublicKey.RightAlign()
+	switch algo {
+	case RSA:
+		p := new(rsaPublicKey)
+		_, err := asn1.Unmarshal(asn1Data, p)
+		if err != nil {
+			return nil, err
+		}
+
+		if p.N.Sign() <= 0 {
+			return nil, errors.New("x509: RSA modulus is not a positive number")
+		}
+		if p.E <= 0 {
+			return nil, errors.New("x509: RSA public exponent is not a positive number")
+		}
+
+		pub := &rsa.PublicKey{
+			E: p.E,
+			N: p.N,
+		}
+		return pub, nil
+	case DSA:
+		var p *big.Int
+		_, err := asn1.Unmarshal(asn1Data, &p)
+		if err != nil {
+			return nil, err
+		}
+		paramsData := keyData.Algorithm.Parameters.FullBytes
+		params := new(dsaAlgorithmParameters)
+		_, err = asn1.Unmarshal(paramsData, params)
+		if err != nil {
+			return nil, err
+		}
+		if p.Sign() <= 0 || params.P.Sign() <= 0 || params.Q.Sign() <= 0 || params.G.Sign() <= 0 {
+			return nil, errors.New("x509: zero or negative DSA parameter")
+		}
+		pub := &dsa.PublicKey{
+			Parameters: dsa.Parameters{
+				P: params.P,
+				Q: params.Q,
+				G: params.G,
+			},
+			Y: p,
+		}
+		return pub, nil
+	case ECDSA:
+		paramsData := keyData.Algorithm.Parameters.FullBytes
+		namedCurveOID := new(asn1.ObjectIdentifier)
+		_, err := asn1.Unmarshal(paramsData, namedCurveOID)
+		if err != nil {
+			return nil, err
+		}
+		namedCurve := namedCurveFromOID(*namedCurveOID)
+		if namedCurve == nil {
+			return nil, errors.New("x509: unsupported elliptic curve")
+		}
+		x, y := elliptic.Unmarshal(namedCurve, asn1Data)
+		if x == nil {
+			return nil, errors.New("x509: failed to unmarshal elliptic curve point")
+		}
+		pub := &ecdsa.PublicKey{
+			Curve: namedCurve,
+			X:     x,
+			Y:     y,
+		}
+		return pub, nil
+	default:
+		return nil, nil
+	}
+}
+
+// START CT CHANGES
+
+// NonFatalErrors is an error type which can hold a number of other errors.
+// It's used to collect a range of non-fatal errors which occur while parsing
+// a certificate, that way we can still match on certs which technically are
+// invalid.
+type NonFatalErrors struct {
+	Errors []error
+}
+
+// Adds an error to the list of errors contained by NonFatalErrors.
+func (e *NonFatalErrors) AddError(err error) {
+	e.Errors = append(e.Errors, err)
+}
+
+// Returns a string consisting of the values of Error() from all of the errors
+// contained in |e|
+func (e NonFatalErrors) Error() string {
+	r := "NonFatalErrors: "
+	for _, err := range e.Errors {
+		r += err.Error() + "; "
+	}
+	return r
+}
+
+// Returns true if |e| contains at least one error
+func (e *NonFatalErrors) HasError() bool {
+	return len(e.Errors) > 0
+}
+
+// END CT CHANGES
+
+func parseCertificate(in *certificate) (*Certificate, error) {
+	// START CT CHANGES
+	var nfe NonFatalErrors
+	// END CT CHANGES
+
+	out := new(Certificate)
+	out.Raw = in.Raw
+	out.RawTBSCertificate = in.TBSCertificate.Raw
+	out.RawSubjectPublicKeyInfo = in.TBSCertificate.PublicKey.Raw
+	out.RawSubject = in.TBSCertificate.Subject.FullBytes
+	out.RawIssuer = in.TBSCertificate.Issuer.FullBytes
+
+	out.Signature = in.SignatureValue.RightAlign()
+	out.SignatureAlgorithm =
+		getSignatureAlgorithmFromOID(in.TBSCertificate.SignatureAlgorithm.Algorithm)
+
+	out.PublicKeyAlgorithm =
+		getPublicKeyAlgorithmFromOID(in.TBSCertificate.PublicKey.Algorithm.Algorithm)
+	var err error
+	out.PublicKey, err = parsePublicKey(out.PublicKeyAlgorithm, &in.TBSCertificate.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if in.TBSCertificate.SerialNumber.Sign() < 0 {
+		// START CT CHANGES
+		nfe.AddError(errors.New("x509: negative serial number"))
+		// END CT CHANGES
+	}
+
+	out.Version = in.TBSCertificate.Version + 1
+	out.SerialNumber = in.TBSCertificate.SerialNumber
+
+	var issuer, subject pkix.RDNSequence
+	if _, err := asn1.Unmarshal(in.TBSCertificate.Subject.FullBytes, &subject); err != nil {
+		return nil, err
+	}
+	if _, err := asn1.Unmarshal(in.TBSCertificate.Issuer.FullBytes, &issuer); err != nil {
+		return nil, err
+	}
+
+	out.Issuer.FillFromRDNSequence(&issuer)
+	out.Subject.FillFromRDNSequence(&subject)
+
+	out.NotBefore = in.TBSCertificate.Validity.NotBefore
+	out.NotAfter = in.TBSCertificate.Validity.NotAfter
+
+	for _, e := range in.TBSCertificate.Extensions {
+		out.Extensions = append(out.Extensions, e)
+
+		if len(e.Id) == 4 && e.Id[0] == 2 && e.Id[1] == 5 && e.Id[2] == 29 {
+			switch e.Id[3] {
+			case 15:
+				// RFC 5280, 4.2.1.3
+				var usageBits asn1.BitString
+				_, err := asn1.Unmarshal(e.Value, &usageBits)
+
+				if err == nil {
+					var usage int
+					for i := 0; i < 9; i++ {
+						if usageBits.At(i) != 0 {
+							usage |= 1 << uint(i)
+						}
+					}
+					out.KeyUsage = KeyUsage(usage)
+					continue
+				}
+			case 19:
+				// RFC 5280, 4.2.1.9
+				var constraints basicConstraints
+				_, err := asn1.Unmarshal(e.Value, &constraints)
+
+				if err == nil {
+					out.BasicConstraintsValid = true
+					out.IsCA = constraints.IsCA
+					out.MaxPathLen = constraints.MaxPathLen
+					continue
+				}
+			case 17:
+				// RFC 5280, 4.2.1.6
+
+				// SubjectAltName ::= GeneralNames
+				//
+				// GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+				//
+				// GeneralName ::= CHOICE {
+				//      otherName                       [0]     OtherName,
+				//      rfc822Name                      [1]     IA5String,
+				//      dNSName                         [2]     IA5String,
+				//      x400Address                     [3]     ORAddress,
+				//      directoryName                   [4]     Name,
+				//      ediPartyName                    [5]     EDIPartyName,
+				//      uniformResourceIdentifier       [6]     IA5String,
+				//      iPAddress                       [7]     OCTET STRING,
+				//      registeredID                    [8]     OBJECT IDENTIFIER }
+				var seq asn1.RawValue
+				_, err := asn1.Unmarshal(e.Value, &seq)
+				if err != nil {
+					return nil, err
+				}
+				if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
+					return nil, asn1.StructuralError{Msg: "bad SAN sequence"}
+				}
+
+				parsedName := false
+
+				rest := seq.Bytes
+				for len(rest) > 0 {
+					var v asn1.RawValue
+					rest, err = asn1.Unmarshal(rest, &v)
+					if err != nil {
+						return nil, err
+					}
+					switch v.Tag {
+					case 1:
+						out.EmailAddresses = append(out.EmailAddresses, string(v.Bytes))
+						parsedName = true
+					case 2:
+						out.DNSNames = append(out.DNSNames, string(v.Bytes))
+						parsedName = true
+					case 7:
+						switch len(v.Bytes) {
+						case net.IPv4len, net.IPv6len:
+							out.IPAddresses = append(out.IPAddresses, v.Bytes)
+						default:
+							// START CT CHANGES
+							nfe.AddError(fmt.Errorf("x509: certificate contained IP address of length %d : %v", len(v.Bytes), v.Bytes))
+							// END CT CHANGES
+						}
+					}
+				}
+
+				if parsedName {
+					continue
+				}
+				// If we didn't parse any of the names then we
+				// fall through to the critical check below.
+
+			case 30:
+				// RFC 5280, 4.2.1.10
+
+				// NameConstraints ::= SEQUENCE {
+				//      permittedSubtrees       [0]     GeneralSubtrees OPTIONAL,
+				//      excludedSubtrees        [1]     GeneralSubtrees OPTIONAL }
+				//
+				// GeneralSubtrees ::= SEQUENCE SIZE (1..MAX) OF GeneralSubtree
+				//
+				// GeneralSubtree ::= SEQUENCE {
+				//      base                    GeneralName,
+				//      minimum         [0]     BaseDistance DEFAULT 0,
+				//      maximum         [1]     BaseDistance OPTIONAL }
+				//
+				// BaseDistance ::= INTEGER (0..MAX)
+
+				var constraints nameConstraints
+				_, err := asn1.Unmarshal(e.Value, &constraints)
+				if err != nil {
+					return nil, err
+				}
+
+				if len(constraints.Excluded) > 0 && e.Critical {
+					// START CT CHANGES
+					nfe.AddError(UnhandledCriticalExtension{e.Id})
+					// END CT CHANGES
+				}
+
+				for _, subtree := range constraints.Permitted {
+					if len(subtree.Name) == 0 {
+						if e.Critical {
+							// START CT CHANGES
+							nfe.AddError(UnhandledCriticalExtension{e.Id})
+							// END CT CHANGES
+						}
+						continue
+					}
+					out.PermittedDNSDomains = append(out.PermittedDNSDomains, subtree.Name)
+				}
+				continue
+
+			case 31:
+				// RFC 5280, 4.2.1.14
+
+				// CRLDistributionPoints ::= SEQUENCE SIZE (1..MAX) OF DistributionPoint
+				//
+				// DistributionPoint ::= SEQUENCE {
+				//     distributionPoint       [0]     DistributionPointName OPTIONAL,
+				//     reasons                 [1]     ReasonFlags OPTIONAL,
+				//     cRLIssuer               [2]     GeneralNames OPTIONAL }
+				//
+				// DistributionPointName ::= CHOICE {
+				//     fullName                [0]     GeneralNames,
+				//     nameRelativeToCRLIssuer [1]     RelativeDistinguishedName }
+
+				var cdp []distributionPoint
+				_, err := asn1.Unmarshal(e.Value, &cdp)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, dp := range cdp {
+					var n asn1.RawValue
+					_, err = asn1.Unmarshal(dp.DistributionPoint.FullName.Bytes, &n)
+					if err != nil {
+						return nil, err
+					}
+
+					if n.Tag == 6 {
+						out.CRLDistributionPoints = append(out.CRLDistributionPoints, string(n.Bytes))
+					}
+				}
+				continue
+
+			case 35:
+				// RFC 5280, 4.2.1.1
+				var a authKeyId
+				_, err = asn1.Unmarshal(e.Value, &a)
+				if err != nil {
+					return nil, err
+				}
+				out.AuthorityKeyId = a.Id
+				continue
+
+			case 37:
+				// RFC 5280, 4.2.1.12.  Extended Key Usage
+
+				// id-ce-extKeyUsage OBJECT IDENTIFIER ::= { id-ce 37 }
+				//
+				// ExtKeyUsageSyntax ::= SEQUENCE SIZE (1..MAX) OF KeyPurposeId
+				//
+				// KeyPurposeId ::= OBJECT IDENTIFIER
+
+				var keyUsage []asn1.ObjectIdentifier
+				_, err = asn1.Unmarshal(e.Value, &keyUsage)
+				if err != nil {
+					return nil, err
+				}
+
+				for _, u := range keyUsage {
+					if extKeyUsage, ok := extKeyUsageFromOID(u); ok {
+						out.ExtKeyUsage = append(out.ExtKeyUsage, extKeyUsage)
+					} else {
+						out.UnknownExtKeyUsage = append(out.UnknownExtKeyUsage, u)
+					}
+				}
+
+				continue
+
+			case 14:
+				// RFC 5280, 4.2.1.2
+				var keyid []byte
+				_, err = asn1.Unmarshal(e.Value, &keyid)
+				if err != nil {
+					return nil, err
+				}
+				out.SubjectKeyId = keyid
+				continue
+
+			case 32:
+				// RFC 5280 4.2.1.4: Certificate Policies
+				var policies []policyInformation
+				if _, err = asn1.Unmarshal(e.Value, &policies); err != nil {
+					return nil, err
+				}
+				out.PolicyIdentifiers = make([]asn1.ObjectIdentifier, len(policies))
+				for i, policy := range policies {
+					out.PolicyIdentifiers[i] = policy.Policy
+				}
+			}
+		} else if e.Id.Equal(oidExtensionAuthorityInfoAccess) {
+			// RFC 5280 4.2.2.1: Authority Information Access
+			var aia []authorityInfoAccess
+			if _, err = asn1.Unmarshal(e.Value, &aia); err != nil {
+				return nil, err
+			}
+
+			for _, v := range aia {
+				// GeneralName: uniformResourceIdentifier [6] IA5String
+				if v.Location.Tag != 6 {
+					continue
+				}
+				if v.Method.Equal(oidAuthorityInfoAccessOcsp) {
+					out.OCSPServer = append(out.OCSPServer, string(v.Location.Bytes))
+				} else if v.Method.Equal(oidAuthorityInfoAccessIssuers) {
+					out.IssuingCertificateURL = append(out.IssuingCertificateURL, string(v.Location.Bytes))
+				}
+			}
+		}
+
+		if e.Critical {
+			// START CT CHANGES
+			nfe.AddError(UnhandledCriticalExtension{e.Id})
+			// END CT CHANGES
+		}
+	}
+	// START CT CHANGES
+	if nfe.HasError() {
+		return out, nfe
+	}
+	// END CT CHANGES
+	return out, nil
+}
+
+// START CT CHANGES
+
+// ParseTBSCertificate parses a single TBSCertificate from the given ASN.1 DER data.
+// The parsed data is returned in a Certificate struct for ease of access.
+func ParseTBSCertificate(asn1Data []byte) (*Certificate, error) {
+	var tbsCert tbsCertificate
+	rest, err := asn1.Unmarshal(asn1Data, &tbsCert)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) > 0 {
+		return nil, asn1.SyntaxError{Msg: "trailing data"}
+	}
+	return parseCertificate(&certificate{
+		Raw:            tbsCert.Raw,
+		TBSCertificate: tbsCert})
+}
+
+// END CT CHANGES
+
+// ParseCertificate parses a single certificate from the given ASN.1 DER data.
+func ParseCertificate(asn1Data []byte) (*Certificate, error) {
+	var cert certificate
+	rest, err := asn1.Unmarshal(asn1Data, &cert)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) > 0 {
+		return nil, asn1.SyntaxError{Msg: "trailing data"}
+	}
+
+	return parseCertificate(&cert)
+}
+
+// ParseCertificates parses one or more certificates from the given ASN.1 DER
+// data. The certificates must be concatenated with no intermediate padding.
+func ParseCertificates(asn1Data []byte) ([]*Certificate, error) {
+	var v []*certificate
+
+	for len(asn1Data) > 0 {
+		cert := new(certificate)
+		var err error
+		asn1Data, err = asn1.Unmarshal(asn1Data, cert)
+		if err != nil {
+			return nil, err
+		}
+		v = append(v, cert)
+	}
+
+	ret := make([]*Certificate, len(v))
+	for i, ci := range v {
+		cert, err := parseCertificate(ci)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = cert
+	}
+
+	return ret, nil
+}
+
+func reverseBitsInAByte(in byte) byte {
+	b1 := in>>4 | in<<4
+	b2 := b1>>2&0x33 | b1<<2&0xcc
+	b3 := b2>>1&0x55 | b2<<1&0xaa
+	return b3
+}
+
+var (
+	oidExtensionSubjectKeyId          = []int{2, 5, 29, 14}
+	oidExtensionKeyUsage              = []int{2, 5, 29, 15}
+	oidExtensionExtendedKeyUsage      = []int{2, 5, 29, 37}
+	oidExtensionAuthorityKeyId        = []int{2, 5, 29, 35}
+	oidExtensionBasicConstraints      = []int{2, 5, 29, 19}
+	oidExtensionSubjectAltName        = []int{2, 5, 29, 17}
+	oidExtensionCertificatePolicies   = []int{2, 5, 29, 32}
+	oidExtensionNameConstraints       = []int{2, 5, 29, 30}
+	oidExtensionCRLDistributionPoints = []int{2, 5, 29, 31}
+	oidExtensionAuthorityInfoAccess   = []int{1, 3, 6, 1, 5, 5, 7, 1, 1}
+)
+
+var (
+	oidAuthorityInfoAccessOcsp    = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 48, 1}
+	oidAuthorityInfoAccessIssuers = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 48, 2}
+)
+
+// oidNotInExtensions returns whether an extension with the given oid exists in
+// extensions.
+func oidInExtensions(oid asn1.ObjectIdentifier, extensions []pkix.Extension) bool {
+	for _, e := range extensions {
+		if e.Id.Equal(oid) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildExtensions(template *Certificate) (ret []pkix.Extension, err error) {
+	ret = make([]pkix.Extension, 10 /* maximum number of elements. */)
+	n := 0
+
+	if template.KeyUsage != 0 &&
+		!oidInExtensions(oidExtensionKeyUsage, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionKeyUsage
+		ret[n].Critical = true
+
+		var a [2]byte
+		a[0] = reverseBitsInAByte(byte(template.KeyUsage))
+		a[1] = reverseBitsInAByte(byte(template.KeyUsage >> 8))
+
+		l := 1
+		if a[1] != 0 {
+			l = 2
+		}
+
+		ret[n].Value, err = asn1.Marshal(asn1.BitString{Bytes: a[0:l], BitLength: l * 8})
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if (len(template.ExtKeyUsage) > 0 || len(template.UnknownExtKeyUsage) > 0) &&
+		!oidInExtensions(oidExtensionExtendedKeyUsage, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionExtendedKeyUsage
+
+		var oids []asn1.ObjectIdentifier
+		for _, u := range template.ExtKeyUsage {
+			if oid, ok := oidFromExtKeyUsage(u); ok {
+				oids = append(oids, oid)
+			} else {
+				panic("internal error")
+			}
+		}
+
+		oids = append(oids, template.UnknownExtKeyUsage...)
+
+		ret[n].Value, err = asn1.Marshal(oids)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if template.BasicConstraintsValid && !oidInExtensions(oidExtensionBasicConstraints, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionBasicConstraints
+		ret[n].Value, err = asn1.Marshal(basicConstraints{template.IsCA, template.MaxPathLen})
+		ret[n].Critical = true
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.SubjectKeyId) > 0 && !oidInExtensions(oidExtensionSubjectKeyId, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionSubjectKeyId
+		ret[n].Value, err = asn1.Marshal(template.SubjectKeyId)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.AuthorityKeyId) > 0 && !oidInExtensions(oidExtensionAuthorityKeyId, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionAuthorityKeyId
+		ret[n].Value, err = asn1.Marshal(authKeyId{template.AuthorityKeyId})
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if (len(template.OCSPServer) > 0 || len(template.IssuingCertificateURL) > 0) &&
+		!oidInExtensions(oidExtensionAuthorityInfoAccess, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionAuthorityInfoAccess
+		var aiaValues []authorityInfoAccess
+		for _, name := range template.OCSPServer {
+			aiaValues = append(aiaValues, authorityInfoAccess{
+				Method:   oidAuthorityInfoAccessOcsp,
+				Location: asn1.RawValue{Tag: 6, Class: 2, Bytes: []byte(name)},
+			})
+		}
+		for _, name := range template.IssuingCertificateURL {
+			aiaValues = append(aiaValues, authorityInfoAccess{
+				Method:   oidAuthorityInfoAccessIssuers,
+				Location: asn1.RawValue{Tag: 6, Class: 2, Bytes: []byte(name)},
+			})
+		}
+		ret[n].Value, err = asn1.Marshal(aiaValues)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if (len(template.DNSNames) > 0 || len(template.EmailAddresses) > 0 || len(template.IPAddresses) > 0) &&
+		!oidInExtensions(oidExtensionSubjectAltName, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionSubjectAltName
+		var rawValues []asn1.RawValue
+		for _, name := range template.DNSNames {
+			rawValues = append(rawValues, asn1.RawValue{Tag: 2, Class: 2, Bytes: []byte(name)})
+		}
+		for _, email := range template.EmailAddresses {
+			rawValues = append(rawValues, asn1.RawValue{Tag: 1, Class: 2, Bytes: []byte(email)})
+		}
+		for _, rawIP := range template.IPAddresses {
+			// If possible, we always want to encode IPv4 addresses in 4 bytes.
+			ip := rawIP.To4()
+			if ip == nil {
+				ip = rawIP
+			}
+			rawValues = append(rawValues, asn1.RawValue{Tag: 7, Class: 2, Bytes: ip})
+		}
+		ret[n].Value, err = asn1.Marshal(rawValues)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.PolicyIdentifiers) > 0 &&
+		!oidInExtensions(oidExtensionCertificatePolicies, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionCertificatePolicies
+		policies := make([]policyInformation, len(template.PolicyIdentifiers))
+		for i, policy := range template.PolicyIdentifiers {
+			policies[i].Policy = policy
+		}
+		ret[n].Value, err = asn1.Marshal(policies)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.PermittedDNSDomains) > 0 &&
+		!oidInExtensions(oidExtensionNameConstraints, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionNameConstraints
+		ret[n].Critical = template.PermittedDNSDomainsCritical
+
+		var out nameConstraints
+		out.Permitted = make([]generalSubtree, len(template.PermittedDNSDomains))
+		for i, permitted := range template.PermittedDNSDomains {
+			out.Permitted[i] = generalSubtree{Name: permitted}
+		}
+		ret[n].Value, err = asn1.Marshal(out)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	if len(template.CRLDistributionPoints) > 0 &&
+		!oidInExtensions(oidExtensionCRLDistributionPoints, template.ExtraExtensions) {
+		ret[n].Id = oidExtensionCRLDistributionPoints
+
+		var crlDp []distributionPoint
+		for _, name := range template.CRLDistributionPoints {
+			rawFullName, _ := asn1.Marshal(asn1.RawValue{Tag: 6, Class: 2, Bytes: []byte(name)})
+
+			dp := distributionPoint{
+				DistributionPoint: distributionPointName{
+					FullName: asn1.RawValue{Tag: 0, Class: 2, Bytes: rawFullName},
+				},
+			}
+			crlDp = append(crlDp, dp)
+		}
+
+		ret[n].Value, err = asn1.Marshal(crlDp)
+		if err != nil {
+			return
+		}
+		n++
+	}
+
+	// Adding another extension here? Remember to update the maximum number
+	// of elements in the make() at the top of the function.
+
+	return append(ret[:n], template.ExtraExtensions...), nil
+}
+
+func subjectBytes(cert *Certificate) ([]byte, error) {
+	if len(cert.RawSubject) > 0 {
+		return cert.RawSubject, nil
+	}
+
+	return asn1.Marshal(cert.Subject.ToRDNSequence())
+}
+
+// CreateCertificate creates a new certificate based on a template. The
+// following members of template are used: SerialNumber, Subject, NotBefore,
+// NotAfter, KeyUsage, ExtKeyUsage, UnknownExtKeyUsage, BasicConstraintsValid,
+// IsCA, MaxPathLen, SubjectKeyId, DNSNames, PermittedDNSDomainsCritical,
+// PermittedDNSDomains.
+//
+// The certificate is signed by parent. If parent is equal to template then the
+// certificate is self-signed. The parameter pub is the public key of the
+// signee and priv is the private key of the signer.
+//
+// The returned slice is the certificate in DER encoding.
+//
+// The only supported key types are RSA and ECDSA (*rsa.PublicKey or
+// *ecdsa.PublicKey for pub, *rsa.PrivateKey or *ecdsa.PublicKey for priv).
+func CreateCertificate(rand io.Reader, template, parent *Certificate, pub interface{}, priv interface{}) (cert []byte, err error) {
+	var publicKeyBytes []byte
+	var publicKeyAlgorithm pkix.AlgorithmIdentifier
+
+	if publicKeyBytes, publicKeyAlgorithm, err = marshalPublicKey(pub); err != nil {
+		return nil, err
+	}
+
+	var signatureAlgorithm pkix.AlgorithmIdentifier
+	var hashFunc crypto.Hash
+
+	switch priv := priv.(type) {
+	case *rsa.PrivateKey:
+		signatureAlgorithm.Algorithm = oidSignatureSHA1WithRSA
+		hashFunc = crypto.SHA1
+	case *ecdsa.PrivateKey:
+		switch priv.Curve {
+		case elliptic.P224(), elliptic.P256():
+			hashFunc = crypto.SHA256
+			signatureAlgorithm.Algorithm = oidSignatureECDSAWithSHA256
+		case elliptic.P384():
+			hashFunc = crypto.SHA384
+			signatureAlgorithm.Algorithm = oidSignatureECDSAWithSHA384
+		case elliptic.P521():
+			hashFunc = crypto.SHA512
+			signatureAlgorithm.Algorithm = oidSignatureECDSAWithSHA512
+		default:
+			return nil, errors.New("x509: unknown elliptic curve")
+		}
+	default:
+		return nil, errors.New("x509: only RSA and ECDSA private keys supported")
+	}
+
+	if err != nil {
+		return
+	}
+
+	if len(parent.SubjectKeyId) > 0 {
+		template.AuthorityKeyId = parent.SubjectKeyId
+	}
+
+	extensions, err := buildExtensions(template)
+	if err != nil {
+		return
+	}
+
+	asn1Issuer, err := subjectBytes(parent)
+	if err != nil {
+		return
+	}
+
+	asn1Subject, err := subjectBytes(template)
+	if err != nil {
+		return
+	}
+
+	encodedPublicKey := asn1.BitString{BitLength: len(publicKeyBytes) * 8, Bytes: publicKeyBytes}
+	c := tbsCertificate{
+		Version:            2,
+		SerialNumber:       template.SerialNumber,
+		SignatureAlgorithm: signatureAlgorithm,
+		Issuer:             asn1.RawValue{FullBytes: asn1Issuer},
+		Validity:           validity{template.NotBefore.UTC(), template.NotAfter.UTC()},
+		Subject:            asn1.RawValue{FullBytes: asn1Subject},
+		PublicKey:          publicKeyInfo{nil, publicKeyAlgorithm, encodedPublicKey},
+		Extensions:         extensions,
+	}
+
+	tbsCertContents, err := asn1.Marshal(c)
+	if err != nil {
+		return
+	}
+
+	c.Raw = tbsCertContents
+
+	h := hashFunc.New()
+	h.Write(tbsCertContents)
+	digest := h.Sum(nil)
+
+	var signature []byte
+
+	switch priv := priv.(type) {
+	case *rsa.PrivateKey:
+		signature, err = rsa.SignPKCS1v15(rand, priv, hashFunc, digest)
+	case *ecdsa.PrivateKey:
+		var r, s *big.Int
+		if r, s, err = ecdsa.Sign(rand, priv, digest); err == nil {
+			signature, err = asn1.Marshal(ecdsaSignature{r, s})
+		}
+	default:
+		panic("internal error")
+	}
+
+	if err != nil {
+		return
+	}
+
+	cert, err = asn1.Marshal(certificate{
+		nil,
+		c,
+		signatureAlgorithm,
+		asn1.BitString{Bytes: signature, BitLength: len(signature) * 8},
+	})
+	return
+}
+
+// pemCRLPrefix is the magic string that indicates that we have a PEM encoded
+// CRL.
+var pemCRLPrefix = []byte("-----BEGIN X509 CRL")
+
+// pemType is the type of a PEM encoded CRL.
+var pemType = "X509 CRL"
+
+// ParseCRL parses a CRL from the given bytes. It's often the case that PEM
+// encoded CRLs will appear where they should be DER encoded, so this function
+// will transparently handle PEM encoding as long as there isn't any leading
+// garbage.
+func ParseCRL(crlBytes []byte) (certList *pkix.CertificateList, err error) {
+	if bytes.HasPrefix(crlBytes, pemCRLPrefix) {
+		block, _ := pem.Decode(crlBytes)
+		if block != nil && block.Type == pemType {
+			crlBytes = block.Bytes
+		}
+	}
+	return ParseDERCRL(crlBytes)
+}
+
+// ParseDERCRL parses a DER encoded CRL from the given bytes.
+func ParseDERCRL(derBytes []byte) (certList *pkix.CertificateList, err error) {
+	certList = new(pkix.CertificateList)
+	_, err = asn1.Unmarshal(derBytes, certList)
+	if err != nil {
+		certList = nil
+	}
+	return
+}
+
+// CreateCRL returns a DER encoded CRL, signed by this Certificate, that
+// contains the given list of revoked certificates.
+//
+// The only supported key type is RSA (*rsa.PrivateKey for priv).
+func (c *Certificate) CreateCRL(rand io.Reader, priv interface{}, revokedCerts []pkix.RevokedCertificate, now, expiry time.Time) (crlBytes []byte, err error) {
+	rsaPriv, ok := priv.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("x509: non-RSA private keys not supported")
+	}
+	tbsCertList := pkix.TBSCertificateList{
+		Version: 2,
+		Signature: pkix.AlgorithmIdentifier{
+			Algorithm: oidSignatureSHA1WithRSA,
+		},
+		Issuer:              c.Subject.ToRDNSequence(),
+		ThisUpdate:          now.UTC(),
+		NextUpdate:          expiry.UTC(),
+		RevokedCertificates: revokedCerts,
+	}
+
+	tbsCertListContents, err := asn1.Marshal(tbsCertList)
+	if err != nil {
+		return
+	}
+
+	h := sha1.New()
+	h.Write(tbsCertListContents)
+	digest := h.Sum(nil)
+
+	signature, err := rsa.SignPKCS1v15(rand, rsaPriv, crypto.SHA1, digest)
+	if err != nil {
+		return
+	}
+
+	return asn1.Marshal(pkix.CertificateList{
+		TBSCertList: tbsCertList,
+		SignatureAlgorithm: pkix.AlgorithmIdentifier{
+			Algorithm: oidSignatureSHA1WithRSA,
+		},
+		SignatureValue: asn1.BitString{Bytes: signature, BitLength: len(signature) * 8},
+	})
+}

--- a/vendor/github.com/google/certificate-transparency/proto/ct.proto
+++ b/vendor/github.com/google/certificate-transparency/proto/ct.proto
@@ -1,0 +1,320 @@
+syntax = "proto2";
+
+package ct;
+
+
+////////////////////////////////////////////////////////////////////////////////
+// These protocol buffers should be kept aligned with the I-D.                //
+////////////////////////////////////////////////////////////////////////////////
+
+// RFC 5246
+message DigitallySigned {
+  enum HashAlgorithm {
+    NONE = 0;
+    MD5 = 1;
+    SHA1 = 2;
+    SHA224 = 3;
+    SHA256 = 4;
+    SHA384 = 5;
+    SHA512 = 6;
+  }
+
+  enum SignatureAlgorithm {
+    ANONYMOUS = 0;
+    RSA = 1;
+    DSA = 2;
+    ECDSA = 3;
+  }
+
+  // 1 byte
+  optional HashAlgorithm hash_algorithm = 1 [ default = NONE ];
+  // 1 byte
+  optional SignatureAlgorithm sig_algorithm = 2 [ default = ANONYMOUS ];
+  // 0..2^16-1 bytes
+  optional bytes signature = 3;
+}
+
+enum LogEntryType {
+  X509_ENTRY = 0;
+  PRECERT_ENTRY = 1;
+  PRECERT_ENTRY_V2 = 2;
+  // Not part of the I-D, and outside the valid range.
+  X_JSON_ENTRY = 32768;  // Experimental, don't rely on this!
+  UNKNOWN_ENTRY_TYPE = 65536;
+}
+
+message X509ChainEntry {
+  // For V1 this entry just includes the certificate in the leaf_certificate
+  // field
+  // <1..2^24-1>
+  optional bytes leaf_certificate = 1;
+  // For V2 it includes the cert and key hash using CertInfo. The
+  // leaf_certificate field is not used
+  optional CertInfo cert_info = 3;
+  // <0..2^24-1>
+  // A chain from the leaf to a trusted root
+  // (excluding leaf and possibly root).
+  repeated bytes certificate_chain = 2;
+}
+
+// opaque TBSCertificate<1..2^16-1>;
+// struct {
+//   opaque issuer_key_hash[32];
+//   TBSCertificate tbs_certificate;
+// } PreCert;
+// Retained for V1 API compatibility. May be removed in a future release.
+message PreCert {
+  optional bytes issuer_key_hash = 1;
+  optional bytes tbs_certificate = 2;
+}
+
+// In V2 this is used for both certificates and precertificates in SCTs. It
+// replaces PreCert and has the same structure. The older message remains for
+// compatibility with existing code that depends on this proto.
+message CertInfo {
+  optional bytes issuer_key_hash = 1;
+  optional bytes tbs_certificate = 2;
+}
+
+message PrecertChainEntry {
+  // <1..2^24-1>
+  optional bytes pre_certificate = 1;
+  // <0..2^24-1>
+  // The chain certifying the precertificate, as submitted by the CA.
+  repeated bytes precertificate_chain = 2;
+
+  // PreCert input to the SCT. Can be computed from the above.
+  // Store it alongside the entry data so that the signers don't have to
+  // parse certificates to recompute it.
+  optional PreCert pre_cert = 3;
+  // As above for V2 messages. Only one of these fields will be set in a
+  // valid message
+  optional CertInfo cert_info = 4;
+}
+
+message XJSONEntry {
+  optional string json = 1;
+}
+
+// TODO(alcutter): Consider using extensions here instead.
+message LogEntry {
+  optional LogEntryType type = 1 [ default = UNKNOWN_ENTRY_TYPE ];
+
+  optional X509ChainEntry x509_entry = 2;
+
+  optional PrecertChainEntry precert_entry = 3;
+
+  optional XJSONEntry x_json_entry = 4;
+}
+
+enum SignatureType {
+  CERTIFICATE_TIMESTAMP = 0;
+  // TODO(ekasper): called tree_hash in I-D.
+  TREE_HEAD = 1;
+}
+
+enum Version {
+  V1 = 0;
+  V2 = 1;
+  // Not part of the I-D, and outside the valid range.
+  UNKNOWN_VERSION = 256;
+}
+
+message LogID {
+  // 32 bytes
+  optional bytes key_id = 1;
+}
+
+message SctExtension {
+  // Valid range is 0-65534
+  optional uint32 sct_extension_type = 1;
+  // Data is opaque and type specific. <0..2^16-1> bytes
+  optional bytes sct_extension_data = 2;
+}
+
+// TODO(ekasper): implement support for id.
+message SignedCertificateTimestamp {
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional LogID id = 2;
+  // UTC time in milliseconds, since January 1, 1970, 00:00.
+  optional uint64 timestamp = 3;
+  optional DigitallySigned signature = 4;
+  // V1 extensions
+  optional bytes extensions = 5;
+  // V2 extensions <0..2^16-1>. Must be ordered by type (lowest first)
+  repeated SctExtension sct_extension = 6;
+}
+
+message SignedCertificateTimestampList {
+  // One or more SCTs, <1..2^16-1> bytes each
+  repeated bytes sct_list = 1;
+}
+
+enum MerkleLeafType {
+  TIMESTAMPED_ENTRY = 0;
+  UNKNOWN_LEAF_TYPE = 256;
+}
+
+message SignedEntry {
+  // For V1 signed entries either the x509 or precert field will be set
+  optional bytes x509 = 1;
+  optional PreCert precert = 2;
+  optional bytes json = 3;
+  // For V2 all entries use the CertInfo field and the above fields are
+  // not set
+  optional CertInfo cert_info = 4;
+}
+
+message TimestampedEntry {
+  optional uint64 timestamp = 1;
+  optional LogEntryType entry_type = 2;
+  optional SignedEntry signed_entry = 3;
+  // V1 extensions
+  optional bytes extensions = 4;
+  // V2 extensions <0..2^16-1>. Must be ordered by type (lowest first)
+  repeated SctExtension sct_extension = 5;
+}
+
+// Stuff that's hashed into a Merkle leaf.
+message MerkleTreeLeaf {
+  // The version of the corresponding SCT.
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional MerkleLeafType type = 2 [ default = UNKNOWN_LEAF_TYPE ];
+  optional TimestampedEntry timestamped_entry = 3;
+}
+
+// TODO(benl): No longer needed?
+//
+// Used by cpp/client/ct: it assembles the one from the I-D JSON
+// protocol.
+//
+// Used by cpp/server/blob-server: it uses one to call a variant of
+// LogLookup::AuditProof.
+message MerkleAuditProof {
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional LogID id = 2;
+  optional int64 tree_size = 3;
+  optional uint64 timestamp = 4;
+  optional int64 leaf_index = 5;
+  repeated bytes path_node = 6;
+  optional DigitallySigned tree_head_signature = 7;
+}
+
+message ShortMerkleAuditProof {
+  required int64 leaf_index = 1;
+  repeated bytes path_node = 2;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Finally, stuff that's not in the I-D but that we use internally            //
+// for logging entries and tree head state.                                   //
+////////////////////////////////////////////////////////////////////////////////
+
+// TODO(alcutter): Come up with a better name :/
+message LoggedEntryPB {
+  optional int64 sequence_number = 1;
+  optional bytes merkle_leaf_hash = 2;
+  message Contents {
+    optional SignedCertificateTimestamp sct = 1;
+    optional LogEntry entry = 2;
+  }
+  required Contents contents = 3;
+}
+
+message SthExtension {
+  // Valid range is 0-65534
+  optional uint32 sth_extension_type = 1;
+  // Data is opaque and type specific <0..2^16-1> bytes
+  optional bytes sth_extension_data = 2;
+}
+
+message SignedTreeHead {
+  // The version of the tree head signature.
+  // (Note that each leaf has its own version, so a V2 tree
+  // can contain V1 leaves, too.
+  optional Version version = 1 [ default = UNKNOWN_VERSION ];
+  optional LogID id = 2;
+  optional uint64 timestamp = 3;
+  optional int64 tree_size = 4;
+  optional bytes sha256_root_hash = 5;
+  optional DigitallySigned signature = 6;
+  // Only supported in V2. <0..2^16-1>
+  repeated SthExtension sth_extension = 7;
+}
+
+// Stuff the SSL client spits out from a connection.
+message SSLClientCTData {
+  optional LogEntry reconstructed_entry = 1;
+  optional bytes certificate_sha256_hash = 2;
+
+  message SCTInfo {
+    // There is an entry + sct -> leaf hash mapping.
+    optional SignedCertificateTimestamp sct = 1;
+    optional bytes merkle_leaf_hash = 2;
+  }
+  repeated SCTInfo attached_sct_info = 3;
+}
+
+message ClusterNodeState {
+  optional string node_id = 1;
+  optional int64 contiguous_tree_size = 2 [deprecated = true];
+  optional SignedTreeHead newest_sth = 3;
+  optional SignedTreeHead current_serving_sth = 4;
+
+  // The following host_name/log_port pair are used to allow a log node to
+  // contact other nodes in the cluster, primarily for the purposes of
+  // replication.
+  // hostname/ip which can be used to contact [just] this log node
+  optional string hostname = 5;
+  // port on which this log node is listening.
+  optional int32 log_port = 6;
+}
+
+message ClusterControl {
+  optional bool accept_new_entries = 1 [ default = true ];
+}
+
+message ClusterConfig {
+  /////////////////////////////////
+  // This section of the config affects the selection of the cluster's current
+  // serving STH.
+  // The cluster will always attempt to determine the newest (and
+  // largest) possible STH which meets the constraints defined below from the
+  // set of STHs available at the individual cluster nodes.
+  // (Note that nodes with newer/larger STHs can, of course, serve
+  // earlier/smaller STHs.)
+
+
+  // The minimum number of nodes which must be able to serve a given STH.
+  // This setting allows you to configure the level of cluster resiliency
+  // against data (in the form of node/node database) loss.
+  // i.e.: Once an STH has been created, it must have been replicated to
+  // at least this many nodes before being considered as a candidate for
+  // the overall cluster serving STH.
+  optional int32 minimum_serving_nodes = 1;
+
+  // The minimum fraction of nodes which must be able to serve a given STH.
+  // This setting allows you to configure the serving capacity redundancy of
+  // your cluster.
+  // e.g. you determine you need 3 nodes to serve your expected peak traffic
+  // levels, but want to be over-provisioned by 25% to ensure the cluster will
+  // continue to be able to handle the traffic in the case of a single node
+  // failure, you might set this to 0.75 to ensure that any cluster-wide
+  // serving STH candidate must be servable from at least 3 of your 4 nodes.
+  optional double minimum_serving_fraction = 2;
+  /////////////////////////////////
+
+  // When the number of entries in the EtcedConsistentStore exceeds this value,
+  // the log server will reject all calls to add-[pre-]chain to protect itself
+  // and etcd.
+  optional double etcd_reject_add_pending_threshold = 3 [default = 30000];
+}
+
+message SequenceMapping {
+  message Mapping {
+    optional bytes entry_hash = 1;
+    optional int64 sequence_number = 2;
+  }
+
+  repeated Mapping mapping = 1;
+}

--- a/vendor/golang.org/x/crypto/pkcs12/bmp-string.go
+++ b/vendor/golang.org/x/crypto/pkcs12/bmp-string.go
@@ -1,0 +1,50 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"errors"
+	"unicode/utf16"
+)
+
+// bmpString returns s encoded in UCS-2 with a zero terminator.
+func bmpString(s string) ([]byte, error) {
+	// References:
+	// https://tools.ietf.org/html/rfc7292#appendix-B.1
+	// http://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane
+	//  - non-BMP characters are encoded in UTF 16 by using a surrogate pair of 16-bit codes
+	//	  EncodeRune returns 0xfffd if the rune does not need special encoding
+	//  - the above RFC provides the info that BMPStrings are NULL terminated.
+
+	ret := make([]byte, 0, 2*len(s)+2)
+
+	for _, r := range s {
+		if t, _ := utf16.EncodeRune(r); t != 0xfffd {
+			return nil, errors.New("pkcs12: string contains characters that cannot be encoded in UCS-2")
+		}
+		ret = append(ret, byte(r/256), byte(r%256))
+	}
+
+	return append(ret, 0, 0), nil
+}
+
+func decodeBMPString(bmpString []byte) (string, error) {
+	if len(bmpString)%2 != 0 {
+		return "", errors.New("pkcs12: odd-length BMP string")
+	}
+
+	// strip terminator if present
+	if l := len(bmpString); l >= 2 && bmpString[l-1] == 0 && bmpString[l-2] == 0 {
+		bmpString = bmpString[:l-2]
+	}
+
+	s := make([]uint16, 0, len(bmpString)/2)
+	for len(bmpString) > 0 {
+		s = append(s, uint16(bmpString[0])<<8+uint16(bmpString[1]))
+		bmpString = bmpString[2:]
+	}
+
+	return string(utf16.Decode(s)), nil
+}

--- a/vendor/golang.org/x/crypto/pkcs12/crypto.go
+++ b/vendor/golang.org/x/crypto/pkcs12/crypto.go
@@ -1,0 +1,131 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+
+	"golang.org/x/crypto/pkcs12/internal/rc2"
+)
+
+var (
+	oidPBEWithSHAAnd3KeyTripleDESCBC = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 3})
+	oidPBEWithSHAAnd40BitRC2CBC      = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 1, 6})
+)
+
+// pbeCipher is an abstraction of a PKCS#12 cipher.
+type pbeCipher interface {
+	// create returns a cipher.Block given a key.
+	create(key []byte) (cipher.Block, error)
+	// deriveKey returns a key derived from the given password and salt.
+	deriveKey(salt, password []byte, iterations int) []byte
+	// deriveKey returns an IV derived from the given password and salt.
+	deriveIV(salt, password []byte, iterations int) []byte
+}
+
+type shaWithTripleDESCBC struct{}
+
+func (shaWithTripleDESCBC) create(key []byte) (cipher.Block, error) {
+	return des.NewTripleDESCipher(key)
+}
+
+func (shaWithTripleDESCBC) deriveKey(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 1, 24)
+}
+
+func (shaWithTripleDESCBC) deriveIV(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 2, 8)
+}
+
+type shaWith40BitRC2CBC struct{}
+
+func (shaWith40BitRC2CBC) create(key []byte) (cipher.Block, error) {
+	return rc2.New(key, len(key)*8)
+}
+
+func (shaWith40BitRC2CBC) deriveKey(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 1, 5)
+}
+
+func (shaWith40BitRC2CBC) deriveIV(salt, password []byte, iterations int) []byte {
+	return pbkdf(sha1Sum, 20, 64, salt, password, iterations, 2, 8)
+}
+
+type pbeParams struct {
+	Salt       []byte
+	Iterations int
+}
+
+func pbDecrypterFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher.BlockMode, int, error) {
+	var cipherType pbeCipher
+
+	switch {
+	case algorithm.Algorithm.Equal(oidPBEWithSHAAnd3KeyTripleDESCBC):
+		cipherType = shaWithTripleDESCBC{}
+	case algorithm.Algorithm.Equal(oidPBEWithSHAAnd40BitRC2CBC):
+		cipherType = shaWith40BitRC2CBC{}
+	default:
+		return nil, 0, NotImplementedError("algorithm " + algorithm.Algorithm.String() + " is not supported")
+	}
+
+	var params pbeParams
+	if err := unmarshal(algorithm.Parameters.FullBytes, &params); err != nil {
+		return nil, 0, err
+	}
+
+	key := cipherType.deriveKey(params.Salt, password, params.Iterations)
+	iv := cipherType.deriveIV(params.Salt, password, params.Iterations)
+
+	block, err := cipherType.create(key)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return cipher.NewCBCDecrypter(block, iv), block.BlockSize(), nil
+}
+
+func pbDecrypt(info decryptable, password []byte) (decrypted []byte, err error) {
+	cbc, blockSize, err := pbDecrypterFor(info.Algorithm(), password)
+	if err != nil {
+		return nil, err
+	}
+
+	encrypted := info.Data()
+	if len(encrypted) == 0 {
+		return nil, errors.New("pkcs12: empty encrypted data")
+	}
+	if len(encrypted)%blockSize != 0 {
+		return nil, errors.New("pkcs12: input is not a multiple of the block size")
+	}
+	decrypted = make([]byte, len(encrypted))
+	cbc.CryptBlocks(decrypted, encrypted)
+
+	psLen := int(decrypted[len(decrypted)-1])
+	if psLen == 0 || psLen > blockSize {
+		return nil, ErrDecryption
+	}
+
+	if len(decrypted) < psLen {
+		return nil, ErrDecryption
+	}
+	ps := decrypted[len(decrypted)-psLen:]
+	decrypted = decrypted[:len(decrypted)-psLen]
+	if bytes.Compare(ps, bytes.Repeat([]byte{byte(psLen)}, psLen)) != 0 {
+		return nil, ErrDecryption
+	}
+
+	return
+}
+
+// decryptable abstracts a object that contains ciphertext.
+type decryptable interface {
+	Algorithm() pkix.AlgorithmIdentifier
+	Data() []byte
+}

--- a/vendor/golang.org/x/crypto/pkcs12/errors.go
+++ b/vendor/golang.org/x/crypto/pkcs12/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import "errors"
+
+var (
+	// ErrDecryption represents a failure to decrypt the input.
+	ErrDecryption = errors.New("pkcs12: decryption error, incorrect padding")
+
+	// ErrIncorrectPassword is returned when an incorrect password is detected.
+	// Usually, P12/PFX data is signed to be able to verify the password.
+	ErrIncorrectPassword = errors.New("pkcs12: decryption password incorrect")
+)
+
+// NotImplementedError indicates that the input is not currently supported.
+type NotImplementedError string
+
+func (e NotImplementedError) Error() string {
+	return "pkcs12: " + string(e)
+}

--- a/vendor/golang.org/x/crypto/pkcs12/internal/rc2/rc2.go
+++ b/vendor/golang.org/x/crypto/pkcs12/internal/rc2/rc2.go
@@ -1,0 +1,274 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package rc2 implements the RC2 cipher
+/*
+https://www.ietf.org/rfc/rfc2268.txt
+http://people.csail.mit.edu/rivest/pubs/KRRR98.pdf
+
+This code is licensed under the MIT license.
+*/
+package rc2
+
+import (
+	"crypto/cipher"
+	"encoding/binary"
+)
+
+// The rc2 block size in bytes
+const BlockSize = 8
+
+type rc2Cipher struct {
+	k [64]uint16
+}
+
+// New returns a new rc2 cipher with the given key and effective key length t1
+func New(key []byte, t1 int) (cipher.Block, error) {
+	// TODO(dgryski): error checking for key length
+	return &rc2Cipher{
+		k: expandKey(key, t1),
+	}, nil
+}
+
+func (*rc2Cipher) BlockSize() int { return BlockSize }
+
+var piTable = [256]byte{
+	0xd9, 0x78, 0xf9, 0xc4, 0x19, 0xdd, 0xb5, 0xed, 0x28, 0xe9, 0xfd, 0x79, 0x4a, 0xa0, 0xd8, 0x9d,
+	0xc6, 0x7e, 0x37, 0x83, 0x2b, 0x76, 0x53, 0x8e, 0x62, 0x4c, 0x64, 0x88, 0x44, 0x8b, 0xfb, 0xa2,
+	0x17, 0x9a, 0x59, 0xf5, 0x87, 0xb3, 0x4f, 0x13, 0x61, 0x45, 0x6d, 0x8d, 0x09, 0x81, 0x7d, 0x32,
+	0xbd, 0x8f, 0x40, 0xeb, 0x86, 0xb7, 0x7b, 0x0b, 0xf0, 0x95, 0x21, 0x22, 0x5c, 0x6b, 0x4e, 0x82,
+	0x54, 0xd6, 0x65, 0x93, 0xce, 0x60, 0xb2, 0x1c, 0x73, 0x56, 0xc0, 0x14, 0xa7, 0x8c, 0xf1, 0xdc,
+	0x12, 0x75, 0xca, 0x1f, 0x3b, 0xbe, 0xe4, 0xd1, 0x42, 0x3d, 0xd4, 0x30, 0xa3, 0x3c, 0xb6, 0x26,
+	0x6f, 0xbf, 0x0e, 0xda, 0x46, 0x69, 0x07, 0x57, 0x27, 0xf2, 0x1d, 0x9b, 0xbc, 0x94, 0x43, 0x03,
+	0xf8, 0x11, 0xc7, 0xf6, 0x90, 0xef, 0x3e, 0xe7, 0x06, 0xc3, 0xd5, 0x2f, 0xc8, 0x66, 0x1e, 0xd7,
+	0x08, 0xe8, 0xea, 0xde, 0x80, 0x52, 0xee, 0xf7, 0x84, 0xaa, 0x72, 0xac, 0x35, 0x4d, 0x6a, 0x2a,
+	0x96, 0x1a, 0xd2, 0x71, 0x5a, 0x15, 0x49, 0x74, 0x4b, 0x9f, 0xd0, 0x5e, 0x04, 0x18, 0xa4, 0xec,
+	0xc2, 0xe0, 0x41, 0x6e, 0x0f, 0x51, 0xcb, 0xcc, 0x24, 0x91, 0xaf, 0x50, 0xa1, 0xf4, 0x70, 0x39,
+	0x99, 0x7c, 0x3a, 0x85, 0x23, 0xb8, 0xb4, 0x7a, 0xfc, 0x02, 0x36, 0x5b, 0x25, 0x55, 0x97, 0x31,
+	0x2d, 0x5d, 0xfa, 0x98, 0xe3, 0x8a, 0x92, 0xae, 0x05, 0xdf, 0x29, 0x10, 0x67, 0x6c, 0xba, 0xc9,
+	0xd3, 0x00, 0xe6, 0xcf, 0xe1, 0x9e, 0xa8, 0x2c, 0x63, 0x16, 0x01, 0x3f, 0x58, 0xe2, 0x89, 0xa9,
+	0x0d, 0x38, 0x34, 0x1b, 0xab, 0x33, 0xff, 0xb0, 0xbb, 0x48, 0x0c, 0x5f, 0xb9, 0xb1, 0xcd, 0x2e,
+	0xc5, 0xf3, 0xdb, 0x47, 0xe5, 0xa5, 0x9c, 0x77, 0x0a, 0xa6, 0x20, 0x68, 0xfe, 0x7f, 0xc1, 0xad,
+}
+
+func expandKey(key []byte, t1 int) [64]uint16 {
+
+	l := make([]byte, 128)
+	copy(l, key)
+
+	var t = len(key)
+	var t8 = (t1 + 7) / 8
+	var tm = byte(255 % uint(1<<(8+uint(t1)-8*uint(t8))))
+
+	for i := len(key); i < 128; i++ {
+		l[i] = piTable[l[i-1]+l[uint8(i-t)]]
+	}
+
+	l[128-t8] = piTable[l[128-t8]&tm]
+
+	for i := 127 - t8; i >= 0; i-- {
+		l[i] = piTable[l[i+1]^l[i+t8]]
+	}
+
+	var k [64]uint16
+
+	for i := range k {
+		k[i] = uint16(l[2*i]) + uint16(l[2*i+1])*256
+	}
+
+	return k
+}
+
+func rotl16(x uint16, b uint) uint16 {
+	return (x >> (16 - b)) | (x << b)
+}
+
+func (c *rc2Cipher) Encrypt(dst, src []byte) {
+
+	r0 := binary.LittleEndian.Uint16(src[0:])
+	r1 := binary.LittleEndian.Uint16(src[2:])
+	r2 := binary.LittleEndian.Uint16(src[4:])
+	r3 := binary.LittleEndian.Uint16(src[6:])
+
+	var j int
+
+	for j <= 16 {
+		// mix r0
+		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
+		r0 = rotl16(r0, 1)
+		j++
+
+		// mix r1
+		r1 = r1 + c.k[j] + (r0 & r3) + ((^r0) & r2)
+		r1 = rotl16(r1, 2)
+		j++
+
+		// mix r2
+		r2 = r2 + c.k[j] + (r1 & r0) + ((^r1) & r3)
+		r2 = rotl16(r2, 3)
+		j++
+
+		// mix r3
+		r3 = r3 + c.k[j] + (r2 & r1) + ((^r2) & r0)
+		r3 = rotl16(r3, 5)
+		j++
+
+	}
+
+	r0 = r0 + c.k[r3&63]
+	r1 = r1 + c.k[r0&63]
+	r2 = r2 + c.k[r1&63]
+	r3 = r3 + c.k[r2&63]
+
+	for j <= 40 {
+
+		// mix r0
+		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
+		r0 = rotl16(r0, 1)
+		j++
+
+		// mix r1
+		r1 = r1 + c.k[j] + (r0 & r3) + ((^r0) & r2)
+		r1 = rotl16(r1, 2)
+		j++
+
+		// mix r2
+		r2 = r2 + c.k[j] + (r1 & r0) + ((^r1) & r3)
+		r2 = rotl16(r2, 3)
+		j++
+
+		// mix r3
+		r3 = r3 + c.k[j] + (r2 & r1) + ((^r2) & r0)
+		r3 = rotl16(r3, 5)
+		j++
+
+	}
+
+	r0 = r0 + c.k[r3&63]
+	r1 = r1 + c.k[r0&63]
+	r2 = r2 + c.k[r1&63]
+	r3 = r3 + c.k[r2&63]
+
+	for j <= 60 {
+
+		// mix r0
+		r0 = r0 + c.k[j] + (r3 & r2) + ((^r3) & r1)
+		r0 = rotl16(r0, 1)
+		j++
+
+		// mix r1
+		r1 = r1 + c.k[j] + (r0 & r3) + ((^r0) & r2)
+		r1 = rotl16(r1, 2)
+		j++
+
+		// mix r2
+		r2 = r2 + c.k[j] + (r1 & r0) + ((^r1) & r3)
+		r2 = rotl16(r2, 3)
+		j++
+
+		// mix r3
+		r3 = r3 + c.k[j] + (r2 & r1) + ((^r2) & r0)
+		r3 = rotl16(r3, 5)
+		j++
+	}
+
+	binary.LittleEndian.PutUint16(dst[0:], r0)
+	binary.LittleEndian.PutUint16(dst[2:], r1)
+	binary.LittleEndian.PutUint16(dst[4:], r2)
+	binary.LittleEndian.PutUint16(dst[6:], r3)
+}
+
+func (c *rc2Cipher) Decrypt(dst, src []byte) {
+
+	r0 := binary.LittleEndian.Uint16(src[0:])
+	r1 := binary.LittleEndian.Uint16(src[2:])
+	r2 := binary.LittleEndian.Uint16(src[4:])
+	r3 := binary.LittleEndian.Uint16(src[6:])
+
+	j := 63
+
+	for j >= 44 {
+		// unmix r3
+		r3 = rotl16(r3, 16-5)
+		r3 = r3 - c.k[j] - (r2 & r1) - ((^r2) & r0)
+		j--
+
+		// unmix r2
+		r2 = rotl16(r2, 16-3)
+		r2 = r2 - c.k[j] - (r1 & r0) - ((^r1) & r3)
+		j--
+
+		// unmix r1
+		r1 = rotl16(r1, 16-2)
+		r1 = r1 - c.k[j] - (r0 & r3) - ((^r0) & r2)
+		j--
+
+		// unmix r0
+		r0 = rotl16(r0, 16-1)
+		r0 = r0 - c.k[j] - (r3 & r2) - ((^r3) & r1)
+		j--
+	}
+
+	r3 = r3 - c.k[r2&63]
+	r2 = r2 - c.k[r1&63]
+	r1 = r1 - c.k[r0&63]
+	r0 = r0 - c.k[r3&63]
+
+	for j >= 20 {
+		// unmix r3
+		r3 = rotl16(r3, 16-5)
+		r3 = r3 - c.k[j] - (r2 & r1) - ((^r2) & r0)
+		j--
+
+		// unmix r2
+		r2 = rotl16(r2, 16-3)
+		r2 = r2 - c.k[j] - (r1 & r0) - ((^r1) & r3)
+		j--
+
+		// unmix r1
+		r1 = rotl16(r1, 16-2)
+		r1 = r1 - c.k[j] - (r0 & r3) - ((^r0) & r2)
+		j--
+
+		// unmix r0
+		r0 = rotl16(r0, 16-1)
+		r0 = r0 - c.k[j] - (r3 & r2) - ((^r3) & r1)
+		j--
+
+	}
+
+	r3 = r3 - c.k[r2&63]
+	r2 = r2 - c.k[r1&63]
+	r1 = r1 - c.k[r0&63]
+	r0 = r0 - c.k[r3&63]
+
+	for j >= 0 {
+
+		// unmix r3
+		r3 = rotl16(r3, 16-5)
+		r3 = r3 - c.k[j] - (r2 & r1) - ((^r2) & r0)
+		j--
+
+		// unmix r2
+		r2 = rotl16(r2, 16-3)
+		r2 = r2 - c.k[j] - (r1 & r0) - ((^r1) & r3)
+		j--
+
+		// unmix r1
+		r1 = rotl16(r1, 16-2)
+		r1 = r1 - c.k[j] - (r0 & r3) - ((^r0) & r2)
+		j--
+
+		// unmix r0
+		r0 = rotl16(r0, 16-1)
+		r0 = r0 - c.k[j] - (r3 & r2) - ((^r3) & r1)
+		j--
+
+	}
+
+	binary.LittleEndian.PutUint16(dst[0:], r0)
+	binary.LittleEndian.PutUint16(dst[2:], r1)
+	binary.LittleEndian.PutUint16(dst[4:], r2)
+	binary.LittleEndian.PutUint16(dst[6:], r3)
+}

--- a/vendor/golang.org/x/crypto/pkcs12/mac.go
+++ b/vendor/golang.org/x/crypto/pkcs12/mac.go
@@ -1,0 +1,45 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+)
+
+type macData struct {
+	Mac        digestInfo
+	MacSalt    []byte
+	Iterations int `asn1:"optional,default:1"`
+}
+
+// from PKCS#7:
+type digestInfo struct {
+	Algorithm pkix.AlgorithmIdentifier
+	Digest    []byte
+}
+
+var (
+	oidSHA1 = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
+)
+
+func verifyMac(macData *macData, message, password []byte) error {
+	if !macData.Mac.Algorithm.Algorithm.Equal(oidSHA1) {
+		return NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
+	}
+
+	key := pbkdf(sha1Sum, 20, 64, macData.MacSalt, password, macData.Iterations, 3, 20)
+
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	if !hmac.Equal(macData.Mac.Digest, expectedMAC) {
+		return ErrIncorrectPassword
+	}
+	return nil
+}

--- a/vendor/golang.org/x/crypto/pkcs12/pbkdf.go
+++ b/vendor/golang.org/x/crypto/pkcs12/pbkdf.go
@@ -1,0 +1,170 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"math/big"
+)
+
+var (
+	one = big.NewInt(1)
+)
+
+// sha1Sum returns the SHA-1 hash of in.
+func sha1Sum(in []byte) []byte {
+	sum := sha1.Sum(in)
+	return sum[:]
+}
+
+// fillWithRepeats returns v*ceiling(len(pattern) / v) bytes consisting of
+// repeats of pattern.
+func fillWithRepeats(pattern []byte, v int) []byte {
+	if len(pattern) == 0 {
+		return nil
+	}
+	outputLen := v * ((len(pattern) + v - 1) / v)
+	return bytes.Repeat(pattern, (outputLen+len(pattern)-1)/len(pattern))[:outputLen]
+}
+
+func pbkdf(hash func([]byte) []byte, u, v int, salt, password []byte, r int, ID byte, size int) (key []byte) {
+	// implementation of https://tools.ietf.org/html/rfc7292#appendix-B.2 , RFC text verbatim in comments
+
+	//    Let H be a hash function built around a compression function f:
+
+	//       Z_2^u x Z_2^v -> Z_2^u
+
+	//    (that is, H has a chaining variable and output of length u bits, and
+	//    the message input to the compression function of H is v bits).  The
+	//    values for u and v are as follows:
+
+	//            HASH FUNCTION     VALUE u        VALUE v
+	//              MD2, MD5          128            512
+	//                SHA-1           160            512
+	//               SHA-224          224            512
+	//               SHA-256          256            512
+	//               SHA-384          384            1024
+	//               SHA-512          512            1024
+	//             SHA-512/224        224            1024
+	//             SHA-512/256        256            1024
+
+	//    Furthermore, let r be the iteration count.
+
+	//    We assume here that u and v are both multiples of 8, as are the
+	//    lengths of the password and salt strings (which we denote by p and s,
+	//    respectively) and the number n of pseudorandom bits required.  In
+	//    addition, u and v are of course non-zero.
+
+	//    For information on security considerations for MD5 [19], see [25] and
+	//    [1], and on those for MD2, see [18].
+
+	//    The following procedure can be used to produce pseudorandom bits for
+	//    a particular "purpose" that is identified by a byte called "ID".
+	//    This standard specifies 3 different values for the ID byte:
+
+	//    1.  If ID=1, then the pseudorandom bits being produced are to be used
+	//        as key material for performing encryption or decryption.
+
+	//    2.  If ID=2, then the pseudorandom bits being produced are to be used
+	//        as an IV (Initial Value) for encryption or decryption.
+
+	//    3.  If ID=3, then the pseudorandom bits being produced are to be used
+	//        as an integrity key for MACing.
+
+	//    1.  Construct a string, D (the "diversifier"), by concatenating v/8
+	//        copies of ID.
+	var D []byte
+	for i := 0; i < v; i++ {
+		D = append(D, ID)
+	}
+
+	//    2.  Concatenate copies of the salt together to create a string S of
+	//        length v(ceiling(s/v)) bits (the final copy of the salt may be
+	//        truncated to create S).  Note that if the salt is the empty
+	//        string, then so is S.
+
+	S := fillWithRepeats(salt, v)
+
+	//    3.  Concatenate copies of the password together to create a string P
+	//        of length v(ceiling(p/v)) bits (the final copy of the password
+	//        may be truncated to create P).  Note that if the password is the
+	//        empty string, then so is P.
+
+	P := fillWithRepeats(password, v)
+
+	//    4.  Set I=S||P to be the concatenation of S and P.
+	I := append(S, P...)
+
+	//    5.  Set c=ceiling(n/u).
+	c := (size + u - 1) / u
+
+	//    6.  For i=1, 2, ..., c, do the following:
+	A := make([]byte, c*20)
+	var IjBuf []byte
+	for i := 0; i < c; i++ {
+		//        A.  Set A2=H^r(D||I). (i.e., the r-th hash of D||1,
+		//            H(H(H(... H(D||I))))
+		Ai := hash(append(D, I...))
+		for j := 1; j < r; j++ {
+			Ai = hash(Ai)
+		}
+		copy(A[i*20:], Ai[:])
+
+		if i < c-1 { // skip on last iteration
+			// B.  Concatenate copies of Ai to create a string B of length v
+			//     bits (the final copy of Ai may be truncated to create B).
+			var B []byte
+			for len(B) < v {
+				B = append(B, Ai[:]...)
+			}
+			B = B[:v]
+
+			// C.  Treating I as a concatenation I_0, I_1, ..., I_(k-1) of v-bit
+			//     blocks, where k=ceiling(s/v)+ceiling(p/v), modify I by
+			//     setting I_j=(I_j+B+1) mod 2^v for each j.
+			{
+				Bbi := new(big.Int).SetBytes(B)
+				Ij := new(big.Int)
+
+				for j := 0; j < len(I)/v; j++ {
+					Ij.SetBytes(I[j*v : (j+1)*v])
+					Ij.Add(Ij, Bbi)
+					Ij.Add(Ij, one)
+					Ijb := Ij.Bytes()
+					// We expect Ijb to be exactly v bytes,
+					// if it is longer or shorter we must
+					// adjust it accordingly.
+					if len(Ijb) > v {
+						Ijb = Ijb[len(Ijb)-v:]
+					}
+					if len(Ijb) < v {
+						if IjBuf == nil {
+							IjBuf = make([]byte, v)
+						}
+						bytesShort := v - len(Ijb)
+						for i := 0; i < bytesShort; i++ {
+							IjBuf[i] = 0
+						}
+						copy(IjBuf[bytesShort:], Ijb)
+						Ijb = IjBuf
+					}
+					copy(I[j*v:(j+1)*v], Ijb)
+				}
+			}
+		}
+	}
+	//    7.  Concatenate A_1, A_2, ..., A_c together to form a pseudorandom
+	//        bit string, A.
+
+	//    8.  Use the first n bits of A as the output of this entire process.
+	return A[:size]
+
+	//    If the above process is being used to generate a DES key, the process
+	//    should be used to create 64 random bits, and the key's parity bits
+	//    should be set after the 64 bits have been produced.  Similar concerns
+	//    hold for 2-key and 3-key triple-DES keys, for CDMF keys, and for any
+	//    similar keys with parity bits "built into them".
+}

--- a/vendor/golang.org/x/crypto/pkcs12/pkcs12.go
+++ b/vendor/golang.org/x/crypto/pkcs12/pkcs12.go
@@ -1,0 +1,342 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pkcs12 implements some of PKCS#12.
+//
+// This implementation is distilled from https://tools.ietf.org/html/rfc7292
+// and referenced documents. It is intended for decoding P12/PFX-stored
+// certificates and keys for use with the crypto/tls package.
+package pkcs12
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	oidDataContentType          = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 7, 1})
+	oidEncryptedDataContentType = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 7, 6})
+
+	oidFriendlyName     = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 20})
+	oidLocalKeyID       = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 21})
+	oidMicrosoftCSPName = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 311, 17, 1})
+)
+
+type pfxPdu struct {
+	Version  int
+	AuthSafe contentInfo
+	MacData  macData `asn1:"optional"`
+}
+
+type contentInfo struct {
+	ContentType asn1.ObjectIdentifier
+	Content     asn1.RawValue `asn1:"tag:0,explicit,optional"`
+}
+
+type encryptedData struct {
+	Version              int
+	EncryptedContentInfo encryptedContentInfo
+}
+
+type encryptedContentInfo struct {
+	ContentType                asn1.ObjectIdentifier
+	ContentEncryptionAlgorithm pkix.AlgorithmIdentifier
+	EncryptedContent           []byte `asn1:"tag:0,optional"`
+}
+
+func (i encryptedContentInfo) Algorithm() pkix.AlgorithmIdentifier {
+	return i.ContentEncryptionAlgorithm
+}
+
+func (i encryptedContentInfo) Data() []byte { return i.EncryptedContent }
+
+type safeBag struct {
+	Id         asn1.ObjectIdentifier
+	Value      asn1.RawValue     `asn1:"tag:0,explicit"`
+	Attributes []pkcs12Attribute `asn1:"set,optional"`
+}
+
+type pkcs12Attribute struct {
+	Id    asn1.ObjectIdentifier
+	Value asn1.RawValue `asn1:"set"`
+}
+
+type encryptedPrivateKeyInfo struct {
+	AlgorithmIdentifier pkix.AlgorithmIdentifier
+	EncryptedData       []byte
+}
+
+func (i encryptedPrivateKeyInfo) Algorithm() pkix.AlgorithmIdentifier {
+	return i.AlgorithmIdentifier
+}
+
+func (i encryptedPrivateKeyInfo) Data() []byte {
+	return i.EncryptedData
+}
+
+// PEM block types
+const (
+	certificateType = "CERTIFICATE"
+	privateKeyType  = "PRIVATE KEY"
+)
+
+// unmarshal calls asn1.Unmarshal, but also returns an error if there is any
+// trailing data after unmarshaling.
+func unmarshal(in []byte, out interface{}) error {
+	trailing, err := asn1.Unmarshal(in, out)
+	if err != nil {
+		return err
+	}
+	if len(trailing) != 0 {
+		return errors.New("pkcs12: trailing data found")
+	}
+	return nil
+}
+
+// ConvertToPEM converts all "safe bags" contained in pfxData to PEM blocks.
+func ToPEM(pfxData []byte, password string) ([]*pem.Block, error) {
+	encodedPassword, err := bmpString(password)
+	if err != nil {
+		return nil, ErrIncorrectPassword
+	}
+
+	bags, encodedPassword, err := getSafeContents(pfxData, encodedPassword)
+
+	blocks := make([]*pem.Block, 0, len(bags))
+	for _, bag := range bags {
+		block, err := convertBag(&bag, encodedPassword)
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, block)
+	}
+
+	return blocks, nil
+}
+
+func convertBag(bag *safeBag, password []byte) (*pem.Block, error) {
+	block := &pem.Block{
+		Headers: make(map[string]string),
+	}
+
+	for _, attribute := range bag.Attributes {
+		k, v, err := convertAttribute(&attribute)
+		if err != nil {
+			return nil, err
+		}
+		block.Headers[k] = v
+	}
+
+	switch {
+	case bag.Id.Equal(oidCertBag):
+		block.Type = certificateType
+		certsData, err := decodeCertBag(bag.Value.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		block.Bytes = certsData
+	case bag.Id.Equal(oidPKCS8ShroundedKeyBag):
+		block.Type = privateKeyType
+
+		key, err := decodePkcs8ShroudedKeyBag(bag.Value.Bytes, password)
+		if err != nil {
+			return nil, err
+		}
+
+		switch key := key.(type) {
+		case *rsa.PrivateKey:
+			block.Bytes = x509.MarshalPKCS1PrivateKey(key)
+		case *ecdsa.PrivateKey:
+			block.Bytes, err = x509.MarshalECPrivateKey(key)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, errors.New("found unknown private key type in PKCS#8 wrapping")
+		}
+	default:
+		return nil, errors.New("don't know how to convert a safe bag of type " + bag.Id.String())
+	}
+	return block, nil
+}
+
+func convertAttribute(attribute *pkcs12Attribute) (key, value string, err error) {
+	isString := false
+
+	switch {
+	case attribute.Id.Equal(oidFriendlyName):
+		key = "friendlyName"
+		isString = true
+	case attribute.Id.Equal(oidLocalKeyID):
+		key = "localKeyId"
+	case attribute.Id.Equal(oidMicrosoftCSPName):
+		// This key is chosen to match OpenSSL.
+		key = "Microsoft CSP Name"
+		isString = true
+	default:
+		return "", "", errors.New("pkcs12: unknown attribute with OID " + attribute.Id.String())
+	}
+
+	if isString {
+		if err := unmarshal(attribute.Value.Bytes, &attribute.Value); err != nil {
+			return "", "", err
+		}
+		if value, err = decodeBMPString(attribute.Value.Bytes); err != nil {
+			return "", "", err
+		}
+	} else {
+		var id []byte
+		if err := unmarshal(attribute.Value.Bytes, &id); err != nil {
+			return "", "", err
+		}
+		value = hex.EncodeToString(id)
+	}
+
+	return key, value, nil
+}
+
+// Decode extracts a certificate and private key from pfxData. This function
+// assumes that there is only one certificate and only one private key in the
+// pfxData.
+func Decode(pfxData []byte, password string) (privateKey interface{}, certificate *x509.Certificate, err error) {
+	encodedPassword, err := bmpString(password)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bags, encodedPassword, err := getSafeContents(pfxData, encodedPassword)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(bags) != 2 {
+		err = errors.New("pkcs12: expected exactly two safe bags in the PFX PDU")
+		return
+	}
+
+	for _, bag := range bags {
+		switch {
+		case bag.Id.Equal(oidCertBag):
+			if certificate != nil {
+				err = errors.New("pkcs12: expected exactly one certificate bag")
+			}
+
+			certsData, err := decodeCertBag(bag.Value.Bytes)
+			if err != nil {
+				return nil, nil, err
+			}
+			certs, err := x509.ParseCertificates(certsData)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(certs) != 1 {
+				err = errors.New("pkcs12: expected exactly one certificate in the certBag")
+				return nil, nil, err
+			}
+			certificate = certs[0]
+
+		case bag.Id.Equal(oidPKCS8ShroundedKeyBag):
+			if privateKey != nil {
+				err = errors.New("pkcs12: expected exactly one key bag")
+			}
+
+			if privateKey, err = decodePkcs8ShroudedKeyBag(bag.Value.Bytes, encodedPassword); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	if certificate == nil {
+		return nil, nil, errors.New("pkcs12: certificate missing")
+	}
+	if privateKey == nil {
+		return nil, nil, errors.New("pkcs12: private key missing")
+	}
+
+	return
+}
+
+func getSafeContents(p12Data, password []byte) (bags []safeBag, updatedPassword []byte, err error) {
+	pfx := new(pfxPdu)
+	if err := unmarshal(p12Data, pfx); err != nil {
+		return nil, nil, errors.New("pkcs12: error reading P12 data: " + err.Error())
+	}
+
+	if pfx.Version != 3 {
+		return nil, nil, NotImplementedError("can only decode v3 PFX PDU's")
+	}
+
+	if !pfx.AuthSafe.ContentType.Equal(oidDataContentType) {
+		return nil, nil, NotImplementedError("only password-protected PFX is implemented")
+	}
+
+	// unmarshal the explicit bytes in the content for type 'data'
+	if err := unmarshal(pfx.AuthSafe.Content.Bytes, &pfx.AuthSafe.Content); err != nil {
+		return nil, nil, err
+	}
+
+	if len(pfx.MacData.Mac.Algorithm.Algorithm) == 0 {
+		return nil, nil, errors.New("pkcs12: no MAC in data")
+	}
+
+	if err := verifyMac(&pfx.MacData, pfx.AuthSafe.Content.Bytes, password); err != nil {
+		if err == ErrIncorrectPassword && len(password) == 2 && password[0] == 0 && password[1] == 0 {
+			// some implementations use an empty byte array
+			// for the empty string password try one more
+			// time with empty-empty password
+			password = nil
+			err = verifyMac(&pfx.MacData, pfx.AuthSafe.Content.Bytes, password)
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var authenticatedSafe []contentInfo
+	if err := unmarshal(pfx.AuthSafe.Content.Bytes, &authenticatedSafe); err != nil {
+		return nil, nil, err
+	}
+
+	if len(authenticatedSafe) != 2 {
+		return nil, nil, NotImplementedError("expected exactly two items in the authenticated safe")
+	}
+
+	for _, ci := range authenticatedSafe {
+		var data []byte
+
+		switch {
+		case ci.ContentType.Equal(oidDataContentType):
+			if err := unmarshal(ci.Content.Bytes, &data); err != nil {
+				return nil, nil, err
+			}
+		case ci.ContentType.Equal(oidEncryptedDataContentType):
+			var encryptedData encryptedData
+			if err := unmarshal(ci.Content.Bytes, &encryptedData); err != nil {
+				return nil, nil, err
+			}
+			if encryptedData.Version != 0 {
+				return nil, nil, NotImplementedError("only version 0 of EncryptedData is supported")
+			}
+			if data, err = pbDecrypt(encryptedData.EncryptedContentInfo, password); err != nil {
+				return nil, nil, err
+			}
+		default:
+			return nil, nil, NotImplementedError("only data and encryptedData content types are supported in authenticated safe")
+		}
+
+		var safeContents []safeBag
+		if err := unmarshal(data, &safeContents); err != nil {
+			return nil, nil, err
+		}
+		bags = append(bags, safeContents...)
+	}
+
+	return bags, password, nil
+}

--- a/vendor/golang.org/x/crypto/pkcs12/safebags.go
+++ b/vendor/golang.org/x/crypto/pkcs12/safebags.go
@@ -1,0 +1,57 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pkcs12
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+)
+
+var (
+	// see https://tools.ietf.org/html/rfc7292#appendix-D
+	oidCertTypeX509Certificate = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 22, 1})
+	oidPKCS8ShroundedKeyBag    = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 2})
+	oidCertBag                 = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 3})
+)
+
+type certBag struct {
+	Id   asn1.ObjectIdentifier
+	Data []byte `asn1:"tag:0,explicit"`
+}
+
+func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{}, err error) {
+	pkinfo := new(encryptedPrivateKeyInfo)
+	if err = unmarshal(asn1Data, pkinfo); err != nil {
+		return nil, errors.New("pkcs12: error decoding PKCS#8 shrouded key bag: " + err.Error())
+	}
+
+	pkData, err := pbDecrypt(pkinfo, password)
+	if err != nil {
+		return nil, errors.New("pkcs12: error decrypting PKCS#8 shrouded key bag: " + err.Error())
+	}
+
+	ret := new(asn1.RawValue)
+	if err = unmarshal(pkData, ret); err != nil {
+		return nil, errors.New("pkcs12: error unmarshaling decrypted private key: " + err.Error())
+	}
+
+	if privateKey, err = x509.ParsePKCS8PrivateKey(pkData); err != nil {
+		return nil, errors.New("pkcs12: error parsing PKCS#8 private key: " + err.Error())
+	}
+
+	return privateKey, nil
+}
+
+func decodeCertBag(asn1Data []byte) (x509Certificates []byte, err error) {
+	bag := new(certBag)
+	if err := unmarshal(asn1Data, bag); err != nil {
+		return nil, errors.New("pkcs12: error decoding cert bag: " + err.Error())
+	}
+	if !bag.Id.Equal(oidCertTypeX509Certificate) {
+		return nil, NotImplementedError("only X509 certificates are supported")
+	}
+	return bag.Data, nil
+}


### PR DESCRIPTION
Rather than pin hard-coded certs for testing, just dynamically generate them to avoid expiry issues.  There was also possibly an issue with `TestValidateRoot` where the root data was being templated and replaced, but the signature didn't change, which could cause false-positive errors, so updated the test to re-sign after every manipulation.

This vendors CFSSL for easier cert chain generation.

cc @umayr @riyazdf 