### PR TITLE
Fixed potential race condition in cachedKeyService

### DIFF
--- a/signer/keydbstore/cachedcryptoservice.go
+++ b/signer/keydbstore/cachedcryptoservice.go
@@ -9,7 +9,7 @@ import (
 
 type cachedKeyService struct {
 	signed.CryptoService
-	lock       *sync.Mutex
+	lock       *sync.RWMutex
 	cachedKeys map[string]*cachedKey
 }
 
@@ -22,7 +22,7 @@ type cachedKey struct {
 func NewCachedKeyService(baseKeyService signed.CryptoService) signed.CryptoService {
 	return &cachedKeyService{
 		CryptoService: baseKeyService,
-		lock:          &sync.Mutex{},
+		lock:          &sync.RWMutex{},
 		cachedKeys:    make(map[string]*cachedKey),
 	}
 }
@@ -47,7 +47,9 @@ func (s *cachedKeyService) AddKey(role data.RoleName, gun data.GUN, privKey data
 
 // GetKey returns the PrivateKey given a KeyID
 func (s *cachedKeyService) GetPrivateKey(keyID string) (data.PrivateKey, data.RoleName, error) {
+	s.lock.RLock()
 	cachedKeyEntry, ok := s.cachedKeys[keyID]
+	s.lock.RUnlock()
 	if ok {
 		return cachedKeyEntry.key, cachedKeyEntry.role, nil
 	}


### PR DESCRIPTION
Changed `lock` to be of type `sync.RWMutex` in `cachedKeyService` in  notary/signer/keydbstore/cachedcryptoservice.go and introduced a read lock around read access to the map `cachedKeys` to avoid race conditions when the map is being read and written at the same time.

This fixes the issue https://github.com/docker/notary/issues/1194.