### PR TITLE
pkcs8: add comment about padding during unmarshal

### DIFF
--- a/tuf/utils/pkcs8.go
+++ b/tuf/utils/pkcs8.go
@@ -226,6 +226,7 @@ func ParsePKCS8ToTufKey(der []byte, password []byte) (data.PrivateKey, error) {
 		mode := cipher.NewCBCDecrypter(block, iv)
 		mode.CryptBlocks(encryptedKey, encryptedKey)
 
+		// no need to explicitly remove padding, as ASN.1 unmarshalling will automatically discard it
 		key, err := parsePKCS8ToTufKey(encryptedKey)
 		if err != nil {
 			return nil, errors.New("pkcs8: incorrect password")


### PR DESCRIPTION
Adds [this comment](https://github.com/docker/notary/pull/1130#discussion_r129042988) to the source so we don't ever lose track of the rationale

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>