### PR TITLE
Notary client interface type

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -225,10 +225,10 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	require.Len(t, targets, 2)
 
 	// Also check that we can add/remove keys by rotating keys
-	oldTargetsKeys := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
+	oldTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
 	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false, nil))
 	require.NoError(t, repo.Publish())
-	newTargetsKeys := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
+	newTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
 
 	require.Len(t, oldTargetsKeys, 1)
 	require.Len(t, newTargetsKeys, 1)
@@ -292,10 +292,10 @@ func Test0Dot3RepoFormat(t *testing.T) {
 	require.Equal(t, data.RoleName("targets/releases"), delegations[0].Name)
 
 	// Also check that we can add/remove keys by rotating keys
-	oldTargetsKeys := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
+	oldTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
 	require.NoError(t, repo.RotateKey(data.CanonicalTargetsRole, false, nil))
 	require.NoError(t, repo.Publish())
-	newTargetsKeys := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
+	newTargetsKeys := repo.GetCryptoService().ListKeys(data.CanonicalTargetsRole)
 
 	require.Len(t, oldTargetsKeys, 1)
 	require.Len(t, newTargetsKeys, 1)

--- a/client/client.go
+++ b/client/client.go
@@ -347,13 +347,13 @@ func keyExistsInList(cert data.PublicKey, ids map[string]bool) error {
 
 // InitializeWithCertificate initializes the repository with root keys and their corresponding certificates
 func (r *NotaryRepository) InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey,
-	nRepo *NotaryRepository, serverManagedRoles ...data.RoleName) error {
+	serverManagedRoles ...data.RoleName) error {
 
 	// If we explicitly pass in certificate(s) but not key, then look keys up using certificate
 	if len(rootKeyIDs) == 0 && len(rootCerts) != 0 {
 		rootKeyIDs = []string{}
 		availableRootKeyIDs := make(map[string]bool)
-		for _, k := range nRepo.CryptoService().ListKeys(data.CanonicalRootRole) {
+		for _, k := range r.CryptoService().ListKeys(data.CanonicalRootRole) {
 			availableRootKeyIDs[k] = true
 		}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -195,7 +195,7 @@ func createRepoAndKey(t *testing.T, rootType, tempBaseDir, gun, url string) (*No
 		tempBaseDir, data.GUN(gun), url, http.DefaultTransport, rec.retriever, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
-	rootPubKey, err := testutils.CreateOrAddKey(repo.CryptoService, data.CanonicalRootRole, repo.gun, rootType)
+	rootPubKey, err := testutils.CreateOrAddKey(repo.CryptoService(), data.CanonicalRootRole, repo.gun, rootType)
 	require.NoError(t, err, "error generating root key: %s", err)
 
 	rec.requireCreated(t, []string{data.CanonicalRootRole.String()},
@@ -365,7 +365,7 @@ func TestInitRepositoryWithCerts(t *testing.T) {
 
 		//create extra key pairs if necessary
 		for i := 0; i < tc.extraKeys; i++ {
-			key, err := repo.CryptoService.Create(data.CanonicalRootRole, repo.gun, data.ECDSAKey)
+			key, err := repo.CryptoService().Create(data.CanonicalRootRole, repo.gun, data.ECDSAKey)
 			require.NoError(t, err, "error creating %v-th key: %v", i, err)
 			pubKeyIDs = append(pubKeyIDs, key.ID())
 		}
@@ -373,7 +373,7 @@ func TestInitRepositoryWithCerts(t *testing.T) {
 		// assign pubKeys if necessary
 		var pubKeys []data.PublicKey
 		for i := 0; i < tc.numberOfCerts; i++ {
-			pubKeys = append(pubKeys, repo.CryptoService.GetKey(pubKeyIDs[i]))
+			pubKeys = append(pubKeys, repo.CryptoService().GetKey(pubKeyIDs[i]))
 		}
 
 		if !strings.Contains(tc.name, "unmatched key pairs") {
@@ -413,8 +413,8 @@ func TestMatchKeyIDsWithPublicKeys(t *testing.T) {
 
 	// set up repo and keys
 	repo, _, keyID := createRepoAndKey(t, data.ECDSAKey, tempBaseDir, "docker.com/notary", ts.URL)
-	publicKey := repo.CryptoService.GetKey(keyID)
-	privateKey, _, err := repo.CryptoService.GetPrivateKey(keyID)
+	publicKey := repo.CryptoService().GetKey(keyID)
+	privateKey, _, err := repo.CryptoService().GetPrivateKey(keyID)
 	require.NoError(t, err, "private key should exist in keystore")
 
 	// 1. create a repository and obtain its root key id, use the key id to get the corresponding
@@ -443,7 +443,7 @@ func TestMatchKeyIDsWithPublicKeys(t *testing.T) {
 	require.NoError(t, err, "public key should be matched with its corresponding private key")
 
 	// 4. match a non matching key pair, expect error
-	pub2, err := repo.CryptoService.Create(data.CanonicalRootRole, "docker.com/notary", data.ECDSAKey)
+	pub2, err := repo.CryptoService().Create(data.CanonicalRootRole, "docker.com/notary", data.ECDSAKey)
 	require.NoError(t, err, "error generating root key: %s", err)
 	err = matchKeyIdsWithPubKeys(repo, []string{pub2.ID()}, []data.PublicKey{publicKey})
 	require.Error(t, err, "validating a non-matching key pair should fail but didn't")
@@ -701,7 +701,7 @@ func testInitRepoAttemptsExceeded(t *testing.T, rootType string) {
 	repo, err := NewFileCachedNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, retriever, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
-	rootPubKey, err := testutils.CreateOrAddKey(repo.CryptoService, data.CanonicalRootRole, repo.gun, rootType)
+	rootPubKey, err := testutils.CreateOrAddKey(repo.CryptoService(), data.CanonicalRootRole, repo.gun, rootType)
 	require.NoError(t, err, "error generating root key: %s", err)
 
 	retriever = passphrase.ConstantRetriever("incorrect password")
@@ -740,7 +740,7 @@ func testInitRepoPasswordInvalid(t *testing.T, rootType string) {
 	repo, err := NewFileCachedNotaryRepository(tempBaseDir, gun, ts.URL, http.DefaultTransport, retriever, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
-	rootPubKey, err := testutils.CreateOrAddKey(repo.CryptoService, data.CanonicalRootRole, repo.gun, rootType)
+	rootPubKey, err := testutils.CreateOrAddKey(repo.CryptoService(), data.CanonicalRootRole, repo.gun, rootType)
 	require.NoError(t, err, "error generating root key: %s", err)
 
 	// repo.CryptoService’s FileKeyStore caches the unlocked private key, so to test
@@ -1177,7 +1177,7 @@ func fakeServerData(t *testing.T, repo *NotaryRepository, mux *http.ServeMux,
 	timestampKey, ok := keys[data.CanonicalTimestampRole.String()]
 	require.True(t, ok)
 	// Add timestamp key via the server's cryptoservice so it can sign
-	repo.CryptoService.AddKey(data.CanonicalTimestampRole, repo.gun, timestampKey)
+	repo.CryptoService().AddKey(data.CanonicalTimestampRole, repo.gun, timestampKey)
 
 	savedTUFRepo := repo.tufRepo // in case this is overwritten
 
@@ -1390,7 +1390,7 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	currentTarget := addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt")
 
 	// setup delegated targets/level1 role
-	k, err := testutils.CreateOrAddKey(repo.CryptoService, "targets/level1", repo.gun, rootType)
+	k, err := testutils.CreateOrAddKey(repo.CryptoService(), "targets/level1", repo.gun, rootType)
 	require.NoError(t, err)
 	err = repo.tufRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
 	require.NoError(t, err)
@@ -1400,7 +1400,7 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 	otherTarget := addTarget(t, repo, "other", "../fixtures/root-ca.crt", "targets/level1")
 
 	// setup delegated targets/level2 role
-	k, err = testutils.CreateOrAddKey(repo.CryptoService, "targets/level2", repo.gun, rootType)
+	k, err = testutils.CreateOrAddKey(repo.CryptoService(), "targets/level2", repo.gun, rootType)
 	require.NoError(t, err)
 	err = repo.tufRepo.UpdateDelegationKeys("targets/level2", []data.PublicKey{k}, []string{}, 1)
 	require.NoError(t, err)
@@ -1432,7 +1432,7 @@ func testListTargetWithDelegates(t *testing.T, rootType string) {
 
 	// setup delegated targets/level1/level2 role separately, which can only modify paths prefixed with "level2"
 	// This is done separately due to target shadowing
-	k, err = testutils.CreateOrAddKey(repo.CryptoService, "targets/level1/level2", repo.gun, rootType)
+	k, err = testutils.CreateOrAddKey(repo.CryptoService(), "targets/level1/level2", repo.gun, rootType)
 	require.NoError(t, err)
 	err = repo.tufRepo.UpdateDelegationKeys("targets/level1/level2", []data.PublicKey{k}, []string{}, 1)
 	require.NoError(t, err)
@@ -1544,7 +1544,7 @@ func TestListTargetRestrictsDelegationPaths(t *testing.T) {
 	require.NoError(t, err, "error creating repository: %s", err)
 
 	// setup delegated targets/level1 role
-	k, err := repo.CryptoService.Create("targets/level1", repo.gun, data.ECDSAKey)
+	k, err := repo.CryptoService().Create("targets/level1", repo.gun, data.ECDSAKey)
 	require.NoError(t, err)
 	err = repo.tufRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
 	require.NoError(t, err)
@@ -1987,11 +1987,11 @@ func testPublishNoOneHasSnapshotKey(t *testing.T, rootType string) {
 	snapshotRole, ok := repo.tufRepo.Root.Signed.Roles[data.CanonicalSnapshotRole]
 	require.True(t, ok)
 	for _, keyID := range snapshotRole.KeyIDs {
-		repo.CryptoService.RemoveKey(keyID)
+		repo.CryptoService().RemoveKey(keyID)
 	}
 
 	// ensure that the cryptoservice no longer has any snapshot keys
-	require.Len(t, repo.CryptoService.ListKeys(data.CanonicalSnapshotRole), 0)
+	require.Len(t, repo.CryptoService().ListKeys(data.CanonicalSnapshotRole), 0)
 
 	// Publish something
 	addTarget(t, repo, "v1", "../fixtures/intermediate-ca.crt")
@@ -2139,7 +2139,7 @@ func TestPublishSnapshotLocalKeysCreatedFirst(t *testing.T) {
 	rootPubKey, err := cs.Create(data.CanonicalRootRole, gun, data.ECDSAKey)
 	require.NoError(t, err, "error generating root key: %s", err)
 
-	repo.CryptoService = cannotCreateKeys{CryptoService: cs}
+	repo.cryptoService = cannotCreateKeys{CryptoService: cs}
 
 	err = repo.Initialize([]string{rootPubKey.ID()}, data.CanonicalSnapshotRole)
 	require.Error(t, err)
@@ -2148,12 +2148,12 @@ func TestPublishSnapshotLocalKeysCreatedFirst(t *testing.T) {
 }
 
 func createKey(t *testing.T, repo *NotaryRepository, role data.RoleName, x509 bool) data.PublicKey {
-	key, err := repo.CryptoService.Create(role, repo.gun, data.ECDSAKey)
+	key, err := repo.CryptoService().Create(role, repo.gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating key")
 
 	if x509 {
 		start := time.Now().AddDate(0, 0, -1)
-		privKey, _, err := repo.CryptoService.GetPrivateKey(key.ID())
+		privKey, _, err := repo.CryptoService().GetPrivateKey(key.ID())
 		require.NoError(t, err)
 		cert, err := cryptoservice.GenerateCertificate(
 			privKey, data.GUN(role), start, start.AddDate(1, 0, 0),
@@ -2370,9 +2370,9 @@ func TestPublishTargetsDelegationNoTargetsKeyNeeded(t *testing.T) {
 	rec.clear()
 
 	// remove targets key - it is not even needed
-	targetsKeys := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
+	targetsKeys := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
 	require.Len(t, targetsKeys, 1)
-	require.NoError(t, repo.CryptoService.RemoveKey(targetsKeys[0]))
+	require.NoError(t, repo.CryptoService().RemoveKey(targetsKeys[0]))
 
 	requirePublishToRolesSucceeds(t, repo,
 		[]data.RoleName{"targets/a/b"}, []data.RoleName{"targets/a/b"})
@@ -2405,11 +2405,11 @@ func TestPublishTargetsDelegationSuccessNeedsToDownloadRoles(t *testing.T) {
 	defer os.RemoveAll(delgRepo.baseDir)
 
 	// create a key on the owner repo
-	aKey, err := ownerRepo.CryptoService.Create("targets/a", gun, data.ECDSAKey)
+	aKey, err := ownerRepo.CryptoService().Create("targets/a", gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating delegation key")
 
 	// create a key on the delegated repo
-	bKey, err := delgRepo.CryptoService.Create("targets/a/b", gun, data.ECDSAKey)
+	bKey, err := delgRepo.CryptoService().Create("targets/a/b", gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating delegation key")
 
 	// clear metadata and unencrypted private key cache
@@ -2470,11 +2470,11 @@ func TestPublishTargetsDelegationFromTwoRepos(t *testing.T) {
 	defer os.RemoveAll(repo2.baseDir)
 
 	// create keys for each repo
-	key1, err := repo1.CryptoService.Create("targets/a", repo1.gun, data.ECDSAKey)
+	key1, err := repo1.CryptoService().Create("targets/a", repo1.gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating delegation key")
 
 	// create a key on the delegated repo
-	key2, err := repo2.CryptoService.Create("targets/a", repo2.gun, data.ECDSAKey)
+	key2, err := repo2.CryptoService().Create("targets/a", repo2.gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating delegation key")
 
 	// delegation includes both keys
@@ -2544,7 +2544,7 @@ func TestPublishRemoveDelegationKeyFromDelegationRole(t *testing.T) {
 	defer os.RemoveAll(delgRepo.baseDir)
 
 	// create a key on the delegated repo
-	aKey, err := delgRepo.CryptoService.Create("targets/a", delgRepo.gun, data.ECDSAKey)
+	aKey, err := delgRepo.CryptoService().Create("targets/a", delgRepo.gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating delegation key")
 
 	// owner creates delegation, adds the delegated key to it, and publishes it
@@ -2559,7 +2559,7 @@ func TestPublishRemoveDelegationKeyFromDelegationRole(t *testing.T) {
 
 	// owner revokes delegation
 	// note there is no removekeyfromdelegation yet, so here's a hack to do so
-	newKey, err := ownerRepo.CryptoService.Create("targets/a", ownerRepo.gun, data.ECDSAKey)
+	newKey, err := ownerRepo.CryptoService().Create("targets/a", ownerRepo.gun, data.ECDSAKey)
 	require.NoError(t, err)
 	tdJSON, err := json.Marshal(&changelist.TUFDelegation{
 		NewThreshold: 1,
@@ -2608,7 +2608,7 @@ func TestPublishRemoveDelegation(t *testing.T) {
 	defer os.RemoveAll(delgRepo.baseDir)
 
 	// create a key on the delegated repo
-	aKey, err := delgRepo.CryptoService.Create("targets/a", delgRepo.gun, data.ECDSAKey)
+	aKey, err := delgRepo.CryptoService().Create("targets/a", delgRepo.gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating delegation key")
 
 	// owner creates delegation, adds the delegated key to it, and publishes it
@@ -2643,7 +2643,7 @@ func TestPublishSucceedsDespiteDelegationCorrupt(t *testing.T) {
 	repo, _ := initializeRepo(t, data.ECDSAKey, "docker.com/notary", ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 
-	delgKey, err := repo.CryptoService.Create("targets/a", repo.gun, data.ECDSAKey)
+	delgKey, err := repo.CryptoService().Create("targets/a", repo.gun, data.ECDSAKey)
 	require.NoError(t, err, "error creating delegation key")
 
 	require.NoError(t,
@@ -2666,7 +2666,7 @@ func TestRotateKeyInvalidRole(t *testing.T) {
 	defer os.RemoveAll(repo.baseDir)
 
 	// create a delegation
-	pubKey, err := repo.CryptoService.Create("targets/releases", data.GUN("docker.com/notary"), data.ECDSAKey)
+	pubKey, err := repo.CryptoService().Create("targets/releases", data.GUN("docker.com/notary"), data.ECDSAKey)
 	require.NoError(t, err)
 	require.NoError(t, repo.AddDelegation("targets/releases", []data.PublicKey{pubKey}, []string{""}))
 	require.NoError(t, repo.Publish())
@@ -2817,7 +2817,7 @@ func requireRotationSuccessful(t *testing.T, repo1 *NotaryRepository, keysToRota
 					canonicalID, err := utils.CanonicalKeyID(oldPubKey)
 					require.NoError(t, err)
 
-					_, _, err = repo.CryptoService.GetPrivateKey(canonicalID)
+					_, _, err = repo.CryptoService().GetPrivateKey(canonicalID)
 					switch roleName {
 					case data.CanonicalRootRole:
 						require.NoError(t, err)
@@ -2834,7 +2834,7 @@ func requireRotationSuccessful(t *testing.T, repo1 *NotaryRepository, keysToRota
 				canonicalID, err := utils.CanonicalKeyID(pubKey)
 				require.NoError(t, err)
 
-				key, _, err := repo.CryptoService.GetPrivateKey(canonicalID)
+				key, _, err := repo.CryptoService().GetPrivateKey(canonicalID)
 				if isRemoteKey {
 					require.Error(t, err)
 					require.Nil(t, key)
@@ -3130,9 +3130,9 @@ func TestRotateRootKeyProvided(t *testing.T) {
 	require.NoError(t, err)
 
 	// Key loaded from file (just generating it here)
-	rootPublicKey, err := authorRepo.CryptoService.Create(data.CanonicalRootRole, "", data.ECDSAKey)
+	rootPublicKey, err := authorRepo.CryptoService().Create(data.CanonicalRootRole, "", data.ECDSAKey)
 	require.NoError(t, err)
-	rootPrivateKey, _, err := authorRepo.CryptoService.GetPrivateKey(rootPublicKey.ID())
+	rootPrivateKey, _, err := authorRepo.CryptoService().GetPrivateKey(rootPublicKey.ID())
 	require.NoError(t, err)
 
 	// Fail to rotate to bad key
@@ -3312,9 +3312,9 @@ func TestAddDelegationChangefileValid(t *testing.T) {
 	repo, _ := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 
-	targetKeyIds := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
+	targetKeyIds := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
 	require.NotEmpty(t, targetKeyIds)
-	targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
+	targetPubKey := repo.CryptoService().GetKey(targetKeyIds[0])
 	require.NotNil(t, targetPubKey)
 
 	err := repo.AddDelegation(data.CanonicalRootRole, []data.PublicKey{targetPubKey}, []string{""})
@@ -3350,9 +3350,9 @@ func TestAddDelegationChangefileApplicable(t *testing.T) {
 	repo, _ := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
 
-	targetKeyIds := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
+	targetKeyIds := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
 	require.NotEmpty(t, targetKeyIds)
-	targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
+	targetPubKey := repo.CryptoService().GetKey(targetKeyIds[0])
 	require.NotNil(t, targetPubKey)
 
 	// this hierarchy has to be right to be applied
@@ -3382,9 +3382,9 @@ func TestAddDelegationChangefileApplicable(t *testing.T) {
 // to be propagated.
 func TestAddDelegationErrorWritingChanges(t *testing.T) {
 	testErrorWritingChangefiles(t, func(repo *NotaryRepository) error {
-		targetKeyIds := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)
+		targetKeyIds := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)
 		require.NotEmpty(t, targetKeyIds)
-		targetPubKey := repo.CryptoService.GetKey(targetKeyIds[0])
+		targetPubKey := repo.CryptoService().GetKey(targetKeyIds[0])
 		require.NotNil(t, targetPubKey)
 
 		return repo.AddDelegation("targets/a", []data.PublicKey{targetPubKey}, []string{""})
@@ -3401,7 +3401,7 @@ func TestRemoveDelegationChangefileValid(t *testing.T) {
 
 	repo, rootKeyID := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
-	rootPubKey := repo.CryptoService.GetKey(rootKeyID)
+	rootPubKey := repo.CryptoService().GetKey(rootKeyID)
 	require.NotNil(t, rootPubKey)
 
 	err := repo.RemoveDelegationKeys(data.CanonicalRootRole, []string{rootKeyID})
@@ -3432,7 +3432,7 @@ func TestRemoveDelegationChangefileApplicable(t *testing.T) {
 
 	repo, rootKeyID := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
-	rootPubKey := repo.CryptoService.GetKey(rootKeyID)
+	rootPubKey := repo.CryptoService().GetKey(rootKeyID)
 	require.NotNil(t, rootPubKey)
 
 	// add a delegation first so it can be removed
@@ -3468,7 +3468,7 @@ func TestClearAllPathsDelegationChangefileApplicable(t *testing.T) {
 
 	repo, rootKeyID := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
-	rootPubKey := repo.CryptoService.GetKey(rootKeyID)
+	rootPubKey := repo.CryptoService().GetKey(rootKeyID)
 	require.NotNil(t, rootPubKey)
 
 	// add a delegation first so it can be removed
@@ -3498,10 +3498,10 @@ func TestFullAddDelegationChangefileApplicable(t *testing.T) {
 
 	repo, rootKeyID := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
-	rootPubKey := repo.CryptoService.GetKey(rootKeyID)
+	rootPubKey := repo.CryptoService().GetKey(rootKeyID)
 	require.NotNil(t, rootPubKey)
 
-	key2, err := repo.CryptoService.Create("user", repo.gun, data.ECDSAKey)
+	key2, err := repo.CryptoService().Create("user", repo.gun, data.ECDSAKey)
 	require.NoError(t, err)
 
 	var delegationName data.RoleName = "targets/a"
@@ -3540,10 +3540,10 @@ func TestFullRemoveDelegationChangefileApplicable(t *testing.T) {
 
 	repo, rootKeyID := initializeRepo(t, data.ECDSAKey, gun, ts.URL, false)
 	defer os.RemoveAll(repo.baseDir)
-	rootPubKey := repo.CryptoService.GetKey(rootKeyID)
+	rootPubKey := repo.CryptoService().GetKey(rootKeyID)
 	require.NotNil(t, rootPubKey)
 
-	key2, err := repo.CryptoService.Create("user", repo.gun, data.ECDSAKey)
+	key2, err := repo.CryptoService().Create("user", repo.gun, data.ECDSAKey)
 	require.NoError(t, err)
 	key2CanonicalID, err := utils.CanonicalKeyID(key2)
 	require.NoError(t, err)
@@ -3966,7 +3966,7 @@ func TestGetAllTargetInfo(t *testing.T) {
 	targetsCurrentTarget := addTarget(t, repo, "current", "../fixtures/intermediate-ca.crt")
 
 	// setup delegated targets/level1 role with targets current and other
-	k, err := repo.CryptoService.Create("targets/level1", repo.gun, rootType)
+	k, err := repo.CryptoService().Create("targets/level1", repo.gun, rootType)
 	require.NoError(t, err)
 	key1 := k
 	err = repo.tufRepo.UpdateDelegationKeys("targets/level1", []data.PublicKey{k}, []string{}, 1)
@@ -3977,7 +3977,7 @@ func TestGetAllTargetInfo(t *testing.T) {
 	level1OtherTarget := addTarget(t, repo, "other", "../fixtures/root-ca.crt", "targets/level1")
 
 	// setup delegated targets/level2 role with targets current and level2
-	k, err = repo.CryptoService.Create("targets/level2", repo.gun, rootType)
+	k, err = repo.CryptoService().Create("targets/level2", repo.gun, rootType)
 	require.NoError(t, err)
 	key2 := k
 	err = repo.tufRepo.UpdateDelegationKeys("targets/level2", []data.PublicKey{k}, []string{}, 1)
@@ -4008,7 +4008,7 @@ func TestGetAllTargetInfo(t *testing.T) {
 
 	// setup delegated targets/level1/level2 role separately, which can only modify paths prefixed with "level2"
 	// add level2 to targets/level1/level2
-	k, err = repo.CryptoService.Create("targets/level1/level2", repo.gun, rootType)
+	k, err = repo.CryptoService().Create("targets/level1/level2", repo.gun, rootType)
 	require.NoError(t, err)
 	key3 := k
 	err = repo.tufRepo.UpdateDelegationKeys("targets/level1/level2", []data.PublicKey{k}, []string{}, 1)
@@ -4038,7 +4038,7 @@ func TestGetAllTargetInfo(t *testing.T) {
 		level2Level2       = expectation{role: "targets/level2", target: "level2"}
 		level1Level2Level2 = expectation{role: "targets/level1/level2", target: "level2"}
 	)
-	targetsKey := repo.CryptoService.ListKeys(data.CanonicalTargetsRole)[0]
+	targetsKey := repo.CryptoService().ListKeys(data.CanonicalTargetsRole)[0]
 	allExpected := map[expectation]TargetSignedStruct{
 		targetCurrent: {
 			Target: *targetsCurrentTarget,

--- a/client/interface.go
+++ b/client/interface.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"github.com/docker/notary/client/changelist"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+)
+
+// Repository represents the set of options that must be supported over a TUF repo.
+type Repository interface {
+	// General management operations
+	Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error
+	Publish() error
+
+	// Target Operations
+	AddTarget(target *Target, roles ...data.RoleName) error
+	RemoveTarget(targetName string, roles ...data.RoleName) error
+	ListTargets(roles ...data.RoleName) ([]*TargetWithRole, error)
+	GetTargetByName(name string, roles ...data.RoleName) (*TargetWithRole, error)
+	GetAllTargetMetadataByName(name string) ([]TargetSignedStruct, error)
+
+	// Changelist operations
+	GetChangelist() (changelist.Changelist, error)
+
+	// Role operations
+	ListRoles() ([]RoleWithSignatures, error)
+	GetDelegationRoles() ([]data.Role, error)
+	AddDelegation(name data.RoleName, delegationKeys []data.PublicKey, paths []string) error
+	AddDelegationRoleAndKeys(name data.RoleName, delegationKeys []data.PublicKey) error
+	AddDelegationPaths(name data.RoleName, paths []string) error
+	RemoveDelegationKeysAndPaths(name data.RoleName, keyIDs, paths []string) error
+	RemoveDelegationRole(name data.RoleName) error
+	RemoveDelegationPaths(name data.RoleName, paths []string) error
+	RemoveDelegationKeys(name data.RoleName, keyIDs []string) error
+	ClearDelegationPaths(name data.RoleName) error
+
+	// Witness and other re-signing operations
+	Witness(roles ...data.RoleName) ([]data.RoleName, error)
+
+	// Key Operations
+	RotateKey(role data.RoleName, serverManagesKey bool, keyList []string) error
+
+	CryptoService() signed.CryptoService
+	SetLegacyVersions(int)
+	GetGUN() data.GUN
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -41,7 +41,7 @@ type Repository interface {
 	// Key Operations
 	RotateKey(role data.RoleName, serverManagesKey bool, keyList []string) error
 
-	CryptoService() signed.CryptoService
+	GetCryptoService() signed.CryptoService
 	SetLegacyVersions(int)
 	GetGUN() data.GUN
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -10,6 +10,7 @@ import (
 type Repository interface {
 	// General management operations
 	Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error
+	InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error
 	Publish() error
 
 	// Target Operations

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -324,7 +324,7 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		err = nRepo.CryptoService.AddKey(rotateKeyRole, gun, privKey)
+		err = nRepo.CryptoService().AddKey(rotateKeyRole, gun, privKey)
 		if err != nil {
 			return fmt.Errorf("Error importing key: %v", err)
 		}

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -324,7 +324,7 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		err = nRepo.CryptoService().AddKey(rotateKeyRole, gun, privKey)
+		err = nRepo.GetCryptoService().AddKey(rotateKeyRole, gun, privKey)
 		if err != nil {
 			return fmt.Errorf("Error importing key: %v", err)
 		}

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -337,13 +337,13 @@ func setUpRepo(t *testing.T, tempBaseDir string, gun data.GUN, ret notary.PassRe
 		tempBaseDir, gun, ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
-	rootPubKey, err := repo.CryptoService().Create(data.CanonicalRootRole, "", data.ECDSAKey)
+	rootPubKey, err := repo.GetCryptoService().Create(data.CanonicalRootRole, "", data.ECDSAKey)
 	require.NoError(t, err, "error generating root key: %s", err)
 
 	err = repo.Initialize([]string{rootPubKey.ID()})
 	require.NoError(t, err)
 
-	return ts, repo.CryptoService().ListAllKeys()
+	return ts, repo.GetCryptoService().ListAllKeys()
 }
 
 // The command line uses NotaryRepository's RotateKey - this is just testing
@@ -383,7 +383,7 @@ func TestRotateKeyRemoteServerManagesKey(t *testing.T) {
 		require.NoError(t, err, "unable to get changelist: %v", err)
 		require.Len(t, cl.List(), 0, "expected the changes to have been published")
 
-		finalKeys := repo.CryptoService().ListAllKeys()
+		finalKeys := repo.GetCryptoService().ListAllKeys()
 		// no keys have been created, since a remote key was specified
 		if role == data.CanonicalSnapshotRole.String() {
 			require.Len(t, finalKeys, 2)
@@ -438,7 +438,7 @@ func TestRotateKeyBothKeys(t *testing.T) {
 	require.Len(t, cl.List(), 0)
 
 	// two new keys have been created, and the old keys should still be gone
-	newKeys := repo.CryptoService().ListAllKeys()
+	newKeys := repo.GetCryptoService().ListAllKeys()
 	// there should be 3 keys - snapshot, targets, and root
 	require.Len(t, newKeys, 3)
 
@@ -499,7 +499,7 @@ func TestRotateKeyRootIsInteractive(t *testing.T) {
 	require.NoError(t, err, "error creating repo: %s", err)
 
 	// There should still just be one root key (and one targets and one snapshot)
-	allKeys := repo.CryptoService().ListAllKeys()
+	allKeys := repo.GetCryptoService().ListAllKeys()
 	require.Len(t, allKeys, 3)
 }
 

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -337,13 +337,13 @@ func setUpRepo(t *testing.T, tempBaseDir string, gun data.GUN, ret notary.PassRe
 		tempBaseDir, gun, ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
-	rootPubKey, err := repo.CryptoService.Create(data.CanonicalRootRole, "", data.ECDSAKey)
+	rootPubKey, err := repo.CryptoService().Create(data.CanonicalRootRole, "", data.ECDSAKey)
 	require.NoError(t, err, "error generating root key: %s", err)
 
 	err = repo.Initialize([]string{rootPubKey.ID()})
 	require.NoError(t, err)
 
-	return ts, repo.CryptoService.ListAllKeys()
+	return ts, repo.CryptoService().ListAllKeys()
 }
 
 // The command line uses NotaryRepository's RotateKey - this is just testing
@@ -383,7 +383,7 @@ func TestRotateKeyRemoteServerManagesKey(t *testing.T) {
 		require.NoError(t, err, "unable to get changelist: %v", err)
 		require.Len(t, cl.List(), 0, "expected the changes to have been published")
 
-		finalKeys := repo.CryptoService.ListAllKeys()
+		finalKeys := repo.CryptoService().ListAllKeys()
 		// no keys have been created, since a remote key was specified
 		if role == data.CanonicalSnapshotRole.String() {
 			require.Len(t, finalKeys, 2)
@@ -438,7 +438,7 @@ func TestRotateKeyBothKeys(t *testing.T) {
 	require.Len(t, cl.List(), 0)
 
 	// two new keys have been created, and the old keys should still be gone
-	newKeys := repo.CryptoService.ListAllKeys()
+	newKeys := repo.CryptoService().ListAllKeys()
 	// there should be 3 keys - snapshot, targets, and root
 	require.Len(t, newKeys, 3)
 
@@ -499,7 +499,7 @@ func TestRotateKeyRootIsInteractive(t *testing.T) {
 	require.NoError(t, err, "error creating repo: %s", err)
 
 	// There should still just be one root key (and one targets and one snapshot)
-	allKeys := repo.CryptoService.ListAllKeys()
+	allKeys := repo.CryptoService().ListAllKeys()
 	require.Len(t, allKeys, 3)
 }
 

--- a/cmd/notary/repo_factory.go
+++ b/cmd/notary/repo_factory.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/spf13/viper"
+
+	"net/http"
+
+	"github.com/docker/notary"
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/tuf/data"
+)
+
+const remoteConfigField = "api"
+
+// RepoFactory takes a GUN and returns an initialized client.Repository, or an error.
+type RepoFactory func(gun data.GUN) (client.Repository, error)
+
+// ConfigureRepo takes in the configuration parameters and returns a repoFactory that can
+// initialize new client.Repository objects with the correct upstreams and password
+// retrieval mechanisms.
+func ConfigureRepo(v *viper.Viper, retriever notary.PassRetriever, onlineOperation bool) RepoFactory {
+	localRepo := func(gun data.GUN) (client.Repository, error) {
+		var rt http.RoundTripper
+		trustPin, err := getTrustPinning(v)
+		if err != nil {
+			return nil, err
+		}
+		if onlineOperation {
+			rt, err = getTransport(v, gun, admin)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return client.NewFileCachedNotaryRepository(
+			v.GetString("trust_dir"),
+			gun,
+			getRemoteTrustServer(v),
+			rt,
+			retriever,
+			trustPin,
+		)
+	}
+
+	return localRepo
+}

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -418,13 +418,13 @@ func importRootKey(cmd *cobra.Command, rootKey string, nRepo notaryclient.Reposi
 			return nil, err
 		}
 		// add root key to repo
-		err = nRepo.CryptoService().AddKey(data.CanonicalRootRole, "", privKey)
+		err = nRepo.GetCryptoService().AddKey(data.CanonicalRootRole, "", privKey)
 		if err != nil {
 			return nil, fmt.Errorf("Error importing key: %v", err)
 		}
 		rootKeyList = []string{privKey.ID()}
 	} else {
-		rootKeyList = nRepo.CryptoService().ListKeys(data.CanonicalRootRole)
+		rootKeyList = nRepo.GetCryptoService().ListKeys(data.CanonicalRootRole)
 	}
 
 	if len(rootKeyList) > 0 {

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -501,7 +501,7 @@ func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {
 		rootKeyIDs = []string{}
 	}
 
-	if err = nRepo.InitializeWithCertificate(rootKeyIDs, rootCerts, nRepo); err != nil {
+	if err = nRepo.InitializeWithCertificate(rootKeyIDs, rootCerts); err != nil {
 		return err
 	}
 

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -200,17 +200,12 @@ func (t *tufCommander) tufWitness(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
+
 	gun := data.GUN(args[0])
 	roles := data.NewRoleList(args[1:])
 
-	// no online operations are performed by add so the transport argument
-	// should be nil
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, false)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -296,15 +291,10 @@ func (t *tufCommander) tufAddByHash(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, false)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -357,15 +347,10 @@ func (t *tufCommander) tufAdd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, false)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -424,7 +409,7 @@ func (t *tufCommander) tufDeleteGUN(cmd *cobra.Command, args []string) error {
 
 // importRootKey imports the root key from path then adds the key to repo
 // returns key ids
-func importRootKey(cmd *cobra.Command, rootKey string, nRepo *notaryclient.NotaryRepository, retriever notary.PassRetriever) ([]string, error) {
+func importRootKey(cmd *cobra.Command, rootKey string, nRepo notaryclient.Repository, retriever notary.PassRetriever) ([]string, error) {
 	var rootKeyList []string
 
 	if rootKey != "" {
@@ -433,13 +418,13 @@ func importRootKey(cmd *cobra.Command, rootKey string, nRepo *notaryclient.Notar
 			return nil, err
 		}
 		// add root key to repo
-		err = nRepo.CryptoService.AddKey(data.CanonicalRootRole, "", privKey)
+		err = nRepo.CryptoService().AddKey(data.CanonicalRootRole, "", privKey)
 		if err != nil {
 			return nil, fmt.Errorf("Error importing key: %v", err)
 		}
 		rootKeyList = []string{privKey.ID()}
 	} else {
-		rootKeyList = nRepo.CryptoService.ListKeys(data.CanonicalRootRole)
+		rootKeyList = nRepo.CryptoService().ListKeys(data.CanonicalRootRole)
 	}
 
 	if len(rootKeyList) > 0 {
@@ -495,18 +480,8 @@ func (t *tufCommander) tufInit(cmd *cobra.Command, args []string) error {
 	}
 	gun := data.GUN(args[0])
 
-	rt, err := getTransport(config, gun, readWrite)
-	if err != nil {
-		return err
-	}
-
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, true)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -571,18 +546,8 @@ func (t *tufCommander) tufList(cmd *cobra.Command, args []string) error {
 	}
 	gun := data.GUN(args[0])
 
-	rt, err := getTransport(config, gun, readOnly)
-	if err != nil {
-		return err
-	}
-
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, true)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -610,18 +575,8 @@ func (t *tufCommander) tufLookup(cmd *cobra.Command, args []string) error {
 	gun := data.GUN(args[0])
 	targetName := args[1]
 
-	rt, err := getTransport(config, gun, readOnly)
-	if err != nil {
-		return err
-	}
-
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, true)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -647,13 +602,8 @@ func (t *tufCommander) tufStatus(cmd *cobra.Command, args []string) error {
 	}
 	gun := data.GUN(args[0])
 
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, false)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -704,13 +654,8 @@ func (t *tufCommander) tufReset(cmd *cobra.Command, args []string) error {
 	}
 	gun := data.GUN(args[0])
 
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, false)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -746,18 +691,8 @@ func (t *tufCommander) tufPublish(cmd *cobra.Command, args []string) error {
 
 	cmd.Println("Pushing changes to", gun)
 
-	rt, err := getTransport(config, gun, readWrite)
-	if err != nil {
-		return err
-	}
-
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, true)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -777,21 +712,14 @@ func (t *tufCommander) tufRemove(cmd *cobra.Command, args []string) error {
 	gun := data.GUN(args[0])
 	targetName := args[1]
 
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	// no online operation are performed by remove so the transport argument
-	// should be nil.
-	repo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, false)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
 
 	// If roles is empty, we default to removing from targets
-	if err = repo.RemoveTarget(targetName, data.NewRoleList(t.roles)...); err != nil {
+	if err = nRepo.RemoveTarget(targetName, data.NewRoleList(t.roles)...); err != nil {
 		return err
 	}
 
@@ -819,18 +747,8 @@ func (t *tufCommander) tufVerify(cmd *cobra.Command, args []string) error {
 	gun := data.GUN(args[0])
 	targetName := args[1]
 
-	rt, err := getTransport(config, gun, readOnly)
-	if err != nil {
-		return err
-	}
-
-	trustPin, err := getTrustPinning(config)
-	if err != nil {
-		return err
-	}
-
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
-		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, t.retriever, trustPin)
+	fact := ConfigureRepo(config, t.retriever, true)
+	nRepo, err := fact(gun)
 	if err != nil {
 		return err
 	}
@@ -1126,7 +1044,7 @@ func maybeAutoPublish(cmd *cobra.Command, doPublish bool, gun data.GUN, config *
 	return publishAndPrintToCLI(cmd, nRepo)
 }
 
-func publishAndPrintToCLI(cmd *cobra.Command, nRepo *notaryclient.NotaryRepository) error {
+func publishAndPrintToCLI(cmd *cobra.Command, nRepo notaryclient.Repository) error {
 	if err := nRepo.Publish(); err != nil {
 		return err
 	}

--- a/storage/filestore.go
+++ b/storage/filestore.go
@@ -63,7 +63,7 @@ func (f *FilesystemStore) moveKeyTo0Dot4Location(file string) {
 	fileDir = strings.TrimPrefix(fileDir, notary.RootKeysSubdir)
 	fileDir = strings.TrimPrefix(fileDir, notary.NonRootKeysSubdir)
 	if fileDir != "" {
-		block.Headers["gun"] = fileDir[1:]
+		block.Headers["gun"] = filepath.ToSlash(fileDir[1:])
 	}
 	if strings.Contains(keyID, "_") {
 		role := strings.Split(keyID, "_")[1]

--- a/utils/configuration_linux_test.go
+++ b/utils/configuration_linux_test.go
@@ -1,0 +1,44 @@
+// +build !windows
+
+package utils
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+
+	"github.com/docker/notary"
+	"github.com/stretchr/testify/require"
+)
+
+func testSetSignalTrap(t *testing.T) {
+	var signalsPassedOn map[string]struct{}
+
+	signalHandler := func(s os.Signal) {
+		signalsPassedOn := make(map[string]struct{})
+		signalsPassedOn[s.String()] = struct{}{}
+	}
+	c := SetupSignalTrap(signalHandler)
+
+	if len(notary.NotarySupportedSignals) == 0 { // currently, windows only
+		require.Nil(t, c)
+	} else {
+		require.NotNil(t, c)
+		defer signal.Stop(c)
+	}
+
+	for _, s := range notary.NotarySupportedSignals {
+		syscallSignal, ok := s.(syscall.Signal)
+		require.True(t, ok)
+		require.NoError(t, syscall.Kill(syscall.Getpid(), syscallSignal))
+		require.Len(t, signalsPassedOn, 0)
+		require.NotNil(t, signalsPassedOn[s.String()])
+	}
+}
+
+// TODO: undo this extra indirection, needed for mocking notary.NotarySupportedSignals being empty, when we have
+// a windows CI system running
+func TestSetSignalTrap(t *testing.T) {
+	testSetSignalTrap(t)
+}

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"reflect"
-	"syscall"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
@@ -548,42 +546,4 @@ func TestAdjustLogLevel(t *testing.T) {
 
 		require.Equal(t, expt.endLevel, logrus.GetLevel())
 	}
-}
-
-func testSetSignalTrap(t *testing.T) {
-	var signalsPassedOn map[string]struct{}
-
-	signalHandler := func(s os.Signal) {
-		signalsPassedOn := make(map[string]struct{})
-		signalsPassedOn[s.String()] = struct{}{}
-	}
-	c := SetupSignalTrap(signalHandler)
-
-	if len(notary.NotarySupportedSignals) == 0 { // currently, windows only
-		require.Nil(t, c)
-	} else {
-		require.NotNil(t, c)
-		defer signal.Stop(c)
-	}
-
-	for _, s := range notary.NotarySupportedSignals {
-		syscallSignal, ok := s.(syscall.Signal)
-		require.True(t, ok)
-		require.NoError(t, syscall.Kill(syscall.Getpid(), syscallSignal))
-		require.Len(t, signalsPassedOn, 0)
-		require.NotNil(t, signalsPassedOn[s.String()])
-	}
-}
-
-// TODO: undo this extra indirection, needed for mocking notary.NotarySupportedSignals being empty, when we have
-// a windows CI system running
-func TestSetSignalTrap(t *testing.T) {
-	testSetSignalTrap(t)
-}
-
-func TestSetSignalTrapMockWindows(t *testing.T) {
-	old := notary.NotarySupportedSignals
-	notary.NotarySupportedSignals = nil
-	testSetSignalTrap(t)
-	notary.NotarySupportedSignals = old
 }


### PR DESCRIPTION
- creates a `Repository` interface to standardize `client.NotaryRepository`
- fixes `InitializeWithCertificate` to not take a notary repository as an argument

Part of #1139, originally stolen from `endophage/client_interface` branch