### PR TITLE
Remove `Notary` from Repository constructor functions

### DIFF
--- a/client/backwards_compatibility_test.go
+++ b/client/backwards_compatibility_test.go
@@ -22,7 +22,7 @@ import (
 
 // Once a fixture is read in, ensure that it's valid by making sure the expiry
 // times of all the metadata and certificates is > 10 years ahead
-func requireValidFixture(t *testing.T, notaryRepo *NotaryRepository) {
+func requireValidFixture(t *testing.T, notaryRepo *repository) {
 	tenYearsInFuture := time.Now().AddDate(10, 0, 0)
 	require.True(t, notaryRepo.tufRepo.Root.Signed.Expires.After(tenYearsInFuture))
 	require.True(t, notaryRepo.tufRepo.Snapshot.Signed.Expires.After(tenYearsInFuture))
@@ -90,7 +90,7 @@ func Test0Dot1Migration(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	_, err = NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	_, err = NewFileCachedRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -138,7 +138,7 @@ func Test0Dot3Migration(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	_, err = NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	_, err = NewFileCachedRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -197,9 +197,10 @@ func Test0Dot1RepoFormat(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	repo, err := NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	r, err := NewFileCachedRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
+	repo := r.(*repository)
 
 	// targets should have 1 target, and it should be readable offline
 	targets, err := repo.ListTargets()
@@ -260,9 +261,10 @@ func Test0Dot3RepoFormat(t *testing.T) {
 	ts := fullTestServer(t)
 	defer ts.Close()
 
-	repo, err := NewFileCachedNotaryRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
+	r, err := NewFileCachedRepository(tmpDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
+	repo := r.(*repository)
 
 	// targets should have 1 target, and it should be readable offline
 	targets, err := repo.ListTargets()
@@ -326,9 +328,10 @@ func TestDownloading0Dot1RepoFormat(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(repoDir)
 
-	repo, err := NewFileCachedNotaryRepository(repoDir, gun, ts.URL, http.DefaultTransport,
+	r, err := NewFileCachedRepository(repoDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
+	repo := r.(*repository)
 
 	err = repo.Update(true)
 	require.NoError(t, err, "error updating repo: %s", err)
@@ -351,9 +354,10 @@ func TestDownloading0Dot3RepoFormat(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(repoDir)
 
-	repo, err := NewFileCachedNotaryRepository(repoDir, gun, ts.URL, http.DefaultTransport,
+	r, err := NewFileCachedRepository(repoDir, gun, ts.URL, http.DefaultTransport,
 		passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
+	repo := r.(*repository)
 
 	err = repo.Update(true)
 	require.NoError(t, err, "error updating repo: %s", err)

--- a/client/client.go
+++ b/client/client.go
@@ -36,9 +36,8 @@ func init() {
 	data.SetDefaultExpiryTimes(data.NotaryDefaultExpiries)
 }
 
-// NotaryRepository stores all the information needed to operate on a notary
-// repository.
-type NotaryRepository struct {
+// repository stores all the information needed to operate on a notary repository.
+type repository struct {
 	baseDir        string
 	gun            data.GUN
 	baseURL        string
@@ -53,15 +52,14 @@ type NotaryRepository struct {
 	LegacyVersions int // number of versions back to fetch roots to sign with
 }
 
-// NewFileCachedNotaryRepository is a wrapper for NewNotaryRepository that initializes
+// NewFileCachedRepository is a wrapper for NewRepository that initializes
 // a file cache from the provided repository, local config information and a crypto service.
 // It also retrieves the remote store associated to the base directory under where all the
 // trust files will be stored and the specified GUN.
 //
 // In case of a nil RoundTripper, a default offline store is used instead.
-func NewFileCachedNotaryRepository(baseDir string, gun data.GUN, baseURL string, rt http.RoundTripper,
-	retriever notary.PassRetriever, trustPinning trustpinning.TrustPinConfig) (
-	*NotaryRepository, error) {
+func NewFileCachedRepository(baseDir string, gun data.GUN, baseURL string, rt http.RoundTripper,
+	retriever notary.PassRetriever, trustPinning trustpinning.TrustPinConfig) (Repository, error) {
 
 	cache, err := store.NewFileStore(
 		filepath.Join(baseDir, tufDir, filepath.FromSlash(gun.String()), "metadata"),
@@ -91,18 +89,17 @@ func NewFileCachedNotaryRepository(baseDir string, gun data.GUN, baseURL string,
 		return nil, err
 	}
 
-	return NewNotaryRepository(baseDir, gun, baseURL, remoteStore, cache, trustPinning, cryptoService, cl)
+	return NewRepository(baseDir, gun, baseURL, remoteStore, cache, trustPinning, cryptoService, cl)
 }
 
-// NewNotaryRepository is the base method that returns a new notary repository.
+// NewRepository is the base method that returns a new notary repository.
 // It takes the base directory under where all the trust files will be stored
 // (This is normally defaults to "~/.notary" or "~/.docker/trust" when enabling
 // docker content trust).
 // It expects an initialized cache. In case of a nil remote store, a default
 // offline store is used.
-func NewNotaryRepository(baseDir string, gun data.GUN, baseURL string, remoteStore store.RemoteStore, cache store.MetadataStore,
-	trustPinning trustpinning.TrustPinConfig, cryptoService signed.CryptoService, cl changelist.Changelist) (
-	*NotaryRepository, error) {
+func NewRepository(baseDir string, gun data.GUN, baseURL string, remoteStore store.RemoteStore, cache store.MetadataStore,
+	trustPinning trustpinning.TrustPinConfig, cryptoService signed.CryptoService, cl changelist.Changelist) (Repository, error) {
 
 	// Repo's remote store is either a valid remote store or an OfflineStore
 	if remoteStore == nil {
@@ -113,7 +110,7 @@ func NewNotaryRepository(baseDir string, gun data.GUN, baseURL string, remoteSto
 		return nil, fmt.Errorf("got an invalid cache (nil metadata store)")
 	}
 
-	nRepo := &NotaryRepository{
+	nRepo := &repository{
 		gun:            gun,
 		baseURL:        baseURL,
 		baseDir:        baseDir,
@@ -128,8 +125,8 @@ func NewNotaryRepository(baseDir string, gun data.GUN, baseURL string, remoteSto
 	return nRepo, nil
 }
 
-// GetGUN is a getter for the GUN object from a NotaryRepository
-func (r *NotaryRepository) GetGUN() data.GUN {
+// GetGUN is a getter for the GUN object from a Repository
+func (r *repository) GetGUN() data.GUN {
 	return r.gun
 }
 
@@ -183,12 +180,12 @@ func rootCertKey(gun data.GUN, privKey data.PrivateKey) (data.PublicKey, error) 
 }
 
 // GetCryptoService is the getter for the repository's CryptoService
-func (r *NotaryRepository) GetCryptoService() signed.CryptoService {
+func (r *repository) GetCryptoService() signed.CryptoService {
 	return r.cryptoService
 }
 
 // initialize initializes the notary repository with a set of rootkeys, root certificates and roles.
-func (r *NotaryRepository) initialize(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error {
+func (r *repository) initialize(rootKeyIDs []string, rootCerts []data.PublicKey, serverManagedRoles ...data.RoleName) error {
 
 	// currently we only support server managing timestamps and snapshots, and
 	// nothing else - timestamps are always managed by the server, and implicit
@@ -266,7 +263,7 @@ func (r *NotaryRepository) initialize(rootKeyIDs []string, rootCerts []data.Publ
 // createNewPublicKeyFromKeyIDs generates a set of public keys corresponding to the given list of
 // key IDs existing in the repository's CryptoService.
 // the public keys returned are ordered to correspond to the keyIDs
-func (r *NotaryRepository) createNewPublicKeyFromKeyIDs(keyIDs []string) ([]data.PublicKey, error) {
+func (r *repository) createNewPublicKeyFromKeyIDs(keyIDs []string) ([]data.PublicKey, error) {
 	publicKeys := []data.PublicKey{}
 
 	privKeys, err := getAllPrivKeys(keyIDs, r.GetCryptoService())
@@ -287,7 +284,7 @@ func (r *NotaryRepository) createNewPublicKeyFromKeyIDs(keyIDs []string) ([]data
 // publicKeysOfKeyIDs confirms that the public key and private keys (by Key IDs) forms valid, strictly ordered key pairs
 // (eg. keyIDs[0] must match pubKeys[0] and keyIDs[1] must match certs[1] and so on).
 // Or throw error when they mismatch.
-func (r *NotaryRepository) publicKeysOfKeyIDs(keyIDs []string, pubKeys []data.PublicKey) ([]data.PublicKey, error) {
+func (r *repository) publicKeysOfKeyIDs(keyIDs []string, pubKeys []data.PublicKey) ([]data.PublicKey, error) {
 	if len(keyIDs) != len(pubKeys) {
 		err := fmt.Errorf("require matching number of keyIDs and public keys but got %d IDs and %d public keys", len(keyIDs), len(pubKeys))
 		return nil, err
@@ -301,7 +298,7 @@ func (r *NotaryRepository) publicKeysOfKeyIDs(keyIDs []string, pubKeys []data.Pu
 
 // matchKeyIdsWithPubKeys validates that the private keys (represented by their IDs) and the public keys
 // forms matching key pairs
-func matchKeyIdsWithPubKeys(r *NotaryRepository, ids []string, pubKeys []data.PublicKey) error {
+func matchKeyIdsWithPubKeys(r *repository, ids []string, pubKeys []data.PublicKey) error {
 	for i := 0; i < len(ids); i++ {
 		privKey, _, err := r.GetCryptoService().GetPrivateKey(ids[i])
 		if err != nil {
@@ -322,7 +319,7 @@ func matchKeyIdsWithPubKeys(r *NotaryRepository, ids []string, pubKeys []data.Pu
 // timestamp key and possibly other serverManagedRoles), but the created repository
 // result is only stored on local disk, not published to the server. To do that,
 // use r.Publish() eventually.
-func (r *NotaryRepository) Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error {
+func (r *repository) Initialize(rootKeyIDs []string, serverManagedRoles ...data.RoleName) error {
 	return r.initialize(rootKeyIDs, nil, serverManagedRoles...)
 }
 
@@ -346,7 +343,7 @@ func keyExistsInList(cert data.PublicKey, ids map[string]bool) error {
 }
 
 // InitializeWithCertificate initializes the repository with root keys and their corresponding certificates
-func (r *NotaryRepository) InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey,
+func (r *repository) InitializeWithCertificate(rootKeyIDs []string, rootCerts []data.PublicKey,
 	serverManagedRoles ...data.RoleName) error {
 
 	// If we explicitly pass in certificate(s) but not key, then look keys up using certificate
@@ -368,7 +365,7 @@ func (r *NotaryRepository) InitializeWithCertificate(rootKeyIDs []string, rootCe
 	return r.initialize(rootKeyIDs, rootCerts, serverManagedRoles...)
 }
 
-func (r *NotaryRepository) initializeRoles(rootKeys []data.PublicKey, localRoles, remoteRoles []data.RoleName) (
+func (r *repository) initializeRoles(rootKeys []data.PublicKey, localRoles, remoteRoles []data.RoleName) (
 	root, targets, snapshot, timestamp data.BaseRole, err error) {
 	root = data.NewBaseRole(
 		data.CanonicalRootRole,
@@ -467,7 +464,7 @@ func addChange(cl changelist.Changelist, c changelist.Change, roles ...data.Role
 // AddTarget creates new changelist entries to add a target to the given roles
 // in the repository when the changelist gets applied at publish time.
 // If roles are unspecified, the default role is "targets"
-func (r *NotaryRepository) AddTarget(target *Target, roles ...data.RoleName) error {
+func (r *repository) AddTarget(target *Target, roles ...data.RoleName) error {
 	if len(target.Hashes) == 0 {
 		return fmt.Errorf("no hashes specified for target \"%s\"", target.Name)
 	}
@@ -488,7 +485,7 @@ func (r *NotaryRepository) AddTarget(target *Target, roles ...data.RoleName) err
 // RemoveTarget creates new changelist entries to remove a target from the given
 // roles in the repository when the changelist gets applied at publish time.
 // If roles are unspecified, the default role is "target".
-func (r *NotaryRepository) RemoveTarget(targetName string, roles ...data.RoleName) error {
+func (r *repository) RemoveTarget(targetName string, roles ...data.RoleName) error {
 	logrus.Debugf("Removing target \"%s\"", targetName)
 	template := changelist.NewTUFChange(changelist.ActionDelete, "",
 		changelist.TypeTargetsTarget, targetName, nil)
@@ -503,7 +500,7 @@ func (r *NotaryRepository) RemoveTarget(targetName string, roles ...data.RoleNam
 // its entries will be strictly shadowed by those in other parts of the "targets/a"
 // subtree and also the "targets/x" subtree, as we will defer parsing it until
 // we explicitly reach it in our iteration of the provided list of roles.
-func (r *NotaryRepository) ListTargets(roles ...data.RoleName) ([]*TargetWithRole, error) {
+func (r *repository) ListTargets(roles ...data.RoleName) ([]*TargetWithRole, error) {
 	if err := r.Update(false); err != nil {
 		return nil, err
 	}
@@ -556,7 +553,7 @@ func (r *NotaryRepository) ListTargets(roles ...data.RoleName) ([]*TargetWithRol
 // the target entry found in the subtree of the highest priority role
 // will be returned.
 // See the IMPORTANT section on ListTargets above. Those roles also apply here.
-func (r *NotaryRepository) GetTargetByName(name string, roles ...data.RoleName) (*TargetWithRole, error) {
+func (r *repository) GetTargetByName(name string, roles ...data.RoleName) (*TargetWithRole, error) {
 	if err := r.Update(false); err != nil {
 		return nil, err
 	}
@@ -610,7 +607,7 @@ func (f ErrNoSuchTarget) Error() string {
 // GetAllTargetMetadataByName searches the entire delegation role tree to find the specified target by name for all
 // roles, and returns a list of TargetSignedStructs for each time it finds the specified target.
 // If given an empty string for a target name, it will return back all targets signed into the repository in every role
-func (r *NotaryRepository) GetAllTargetMetadataByName(name string) ([]TargetSignedStruct, error) {
+func (r *repository) GetAllTargetMetadataByName(name string) ([]TargetSignedStruct, error) {
 	if err := r.Update(false); err != nil {
 		return nil, err
 	}
@@ -657,13 +654,13 @@ func (r *NotaryRepository) GetAllTargetMetadataByName(name string) ([]TargetSign
 }
 
 // GetChangelist returns the list of the repository's unpublished changes
-func (r *NotaryRepository) GetChangelist() (changelist.Changelist, error) {
+func (r *repository) GetChangelist() (changelist.Changelist, error) {
 	return r.changelist, nil
 }
 
 // getRemoteStore returns the remoteStore of a repository if valid or
 // or an OfflineStore otherwise
-func (r *NotaryRepository) getRemoteStore() store.RemoteStore {
+func (r *repository) getRemoteStore() store.RemoteStore {
 	if r.remoteStore != nil {
 		return r.remoteStore
 	}
@@ -681,7 +678,7 @@ type RoleWithSignatures struct {
 
 // ListRoles returns a list of RoleWithSignatures objects for this repo
 // This represents the latest metadata for each role in this repo
-func (r *NotaryRepository) ListRoles() ([]RoleWithSignatures, error) {
+func (r *repository) ListRoles() ([]RoleWithSignatures, error) {
 	// Update to latest repo state
 	if err := r.Update(false); err != nil {
 		return nil, err
@@ -720,7 +717,7 @@ func (r *NotaryRepository) ListRoles() ([]RoleWithSignatures, error) {
 
 // Publish pushes the local changes in signed material to the remote notary-server
 // Conceptually it performs an operation similar to a `git rebase`
-func (r *NotaryRepository) Publish() error {
+func (r *repository) Publish() error {
 	if err := r.publish(r.changelist); err != nil {
 		return err
 	}
@@ -735,7 +732,7 @@ func (r *NotaryRepository) Publish() error {
 
 // publish pushes the changes in the given changelist to the remote notary-server
 // Conceptually it performs an operation similar to a `git rebase`
-func (r *NotaryRepository) publish(cl changelist.Changelist) error {
+func (r *repository) publish(cl changelist.Changelist) error {
 	var initialPublish bool
 	// update first before publishing
 	if err := r.Update(true); err != nil {
@@ -842,7 +839,7 @@ func signRootIfNecessary(updates map[data.RoleName][]byte, repo *tuf.Repo, extra
 
 // Fetch back a `legacyVersions` number of roots files, collect the root public keys
 // This includes old `root` roles as well as legacy versioned root roles, e.g. `1.root`
-func (r *NotaryRepository) oldKeysForLegacyClientSupport(legacyVersions int, initialPublish bool) (data.KeyList, error) {
+func (r *repository) oldKeysForLegacyClientSupport(legacyVersions int, initialPublish bool) (data.KeyList, error) {
 	if initialPublish {
 		return nil, nil
 	}
@@ -932,7 +929,7 @@ func signTargets(updates map[data.RoleName][]byte, repo *tuf.Repo, initialPublis
 // r.tufRepo.  This attempts to load metadata for all roles.  Since server
 // snapshots are supported, if the snapshot metadata fails to load, that's ok.
 // This assumes that bootstrapRepo is only used by Publish() or RotateKey()
-func (r *NotaryRepository) bootstrapRepo() error {
+func (r *repository) bootstrapRepo() error {
 	b := tuf.NewRepoBuilder(r.gun, r.GetCryptoService(), r.trustPinning)
 
 	logrus.Debugf("Loading trusted collection.")
@@ -963,7 +960,7 @@ func (r *NotaryRepository) bootstrapRepo() error {
 
 // saveMetadata saves contents of r.tufRepo onto the local disk, creating
 // signatures as necessary, possibly prompting for passphrases.
-func (r *NotaryRepository) saveMetadata(ignoreSnapshot bool) error {
+func (r *repository) saveMetadata(ignoreSnapshot bool) error {
 	logrus.Debugf("Saving changes to Trusted Collection.")
 
 	rootJSON, err := serializeCanonicalRole(r.tufRepo, data.CanonicalRootRole, nil)
@@ -1007,7 +1004,7 @@ func (r *NotaryRepository) saveMetadata(ignoreSnapshot bool) error {
 
 // returns a properly constructed ErrRepositoryNotExist error based on this
 // repo's information
-func (r *NotaryRepository) errRepositoryNotExist() error {
+func (r *repository) errRepositoryNotExist() error {
 	host := r.baseURL
 	parsed, err := url.Parse(r.baseURL)
 	if err == nil {
@@ -1018,7 +1015,7 @@ func (r *NotaryRepository) errRepositoryNotExist() error {
 
 // Update bootstraps a trust anchor (root.json) before updating all the
 // metadata from the repo.
-func (r *NotaryRepository) Update(forWrite bool) error {
+func (r *repository) Update(forWrite bool) error {
 	c, err := r.bootstrapClient(forWrite)
 	if err != nil {
 		if _, ok := err.(store.ErrMetaNotFound); ok {
@@ -1064,7 +1061,7 @@ func (r *NotaryRepository) Update(forWrite bool) error {
 //
 // Returns a TUFClient for the remote server, which may not be actually
 // operational (if the URL is invalid but a root.json is cached).
-func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufClient, error) {
+func (r *repository) bootstrapClient(checkInitialized bool) (*tufClient, error) {
 	minVersion := 1
 	// the old root on disk should not be validated against any trust pinning configuration
 	// because if we have an old root, it itself is the thing that pins trust
@@ -1139,7 +1136,7 @@ func (r *NotaryRepository) bootstrapClient(checkInitialized bool) (*tufClient, e
 // managing the key to the server. If key(s) are specified by keyList, then they are
 // used for signing the role.
 // These changes are staged in a changelist until publish is called.
-func (r *NotaryRepository) RotateKey(role data.RoleName, serverManagesKey bool, keyList []string) error {
+func (r *repository) RotateKey(role data.RoleName, serverManagesKey bool, keyList []string) error {
 	if err := checkRotationInput(role, serverManagesKey); err != nil {
 		return err
 	}
@@ -1157,7 +1154,7 @@ func (r *NotaryRepository) RotateKey(role data.RoleName, serverManagesKey bool, 
 }
 
 // Given a set of new keys to rotate to and a set of keys to drop, returns the list of current keys to use
-func (r *NotaryRepository) pubKeyListForRotation(role data.RoleName, serverManaged bool, newKeys []string) (pubKeyList data.KeyList, err error) {
+func (r *repository) pubKeyListForRotation(role data.RoleName, serverManaged bool, newKeys []string) (pubKeyList data.KeyList, err error) {
 	var pubKey data.PublicKey
 
 	// If server manages the key being rotated, request a rotation and return the new key
@@ -1202,7 +1199,7 @@ func (r *NotaryRepository) pubKeyListForRotation(role data.RoleName, serverManag
 	return pubKeyList, nil
 }
 
-func (r *NotaryRepository) pubKeysToCerts(role data.RoleName, pubKeyList data.KeyList) (data.KeyList, error) {
+func (r *repository) pubKeysToCerts(role data.RoleName, pubKeyList data.KeyList) (data.KeyList, error) {
 	// only generate certs for root keys
 	if role != data.CanonicalRootRole {
 		return pubKeyList, nil
@@ -1243,7 +1240,7 @@ func checkRotationInput(role data.RoleName, serverManaged bool) error {
 	return nil
 }
 
-func (r *NotaryRepository) rootFileKeyChange(cl changelist.Changelist, role data.RoleName, action string, keyList []data.PublicKey) error {
+func (r *repository) rootFileKeyChange(cl changelist.Changelist, role data.RoleName, action string, keyList []data.PublicKey) error {
 	meta := changelist.TUFRootData{
 		RoleName: role,
 		Keys:     keyList,
@@ -1271,7 +1268,7 @@ func DeleteTrustData(baseDir string, gun data.GUN, URL string, rt http.RoundTrip
 	if err := os.RemoveAll(localRepo); err != nil {
 		return fmt.Errorf("error clearing TUF repo data: %v", err)
 	}
-	// Note that this will require admin permission in this NotaryRepository's roundtripper
+	// Note that this will require admin permission for the gun in the roundtripper
 	if deleteRemote {
 		remote, err := getRemoteStore(URL, gun, rt)
 		if err != nil {
@@ -1287,6 +1284,6 @@ func DeleteTrustData(baseDir string, gun data.GUN, URL string, rt http.RoundTrip
 
 // SetLegacyVersions allows the number of legacy versions of the root
 // to be inspected for old signing keys to be configured.
-func (r NotaryRepository) SetLegacyVersions(n int) {
+func (r *repository) SetLegacyVersions(n int) {
 	r.LegacyVersions = n
 }

--- a/client/delegations.go
+++ b/client/delegations.go
@@ -14,7 +14,7 @@ import (
 
 // AddDelegation creates changelist entries to add provided delegation public keys and paths.
 // This method composes AddDelegationRoleAndKeys and AddDelegationPaths (each creates one changelist if called).
-func (r *NotaryRepository) AddDelegation(name data.RoleName, delegationKeys []data.PublicKey, paths []string) error {
+func (r *repository) AddDelegation(name data.RoleName, delegationKeys []data.PublicKey, paths []string) error {
 	if len(delegationKeys) > 0 {
 		err := r.AddDelegationRoleAndKeys(name, delegationKeys)
 		if err != nil {
@@ -33,7 +33,7 @@ func (r *NotaryRepository) AddDelegation(name data.RoleName, delegationKeys []da
 // AddDelegationRoleAndKeys creates a changelist entry to add provided delegation public keys.
 // This method is the simplest way to create a new delegation, because the delegation must have at least
 // one key upon creation to be valid since we will reject the changelist while validating the threshold.
-func (r *NotaryRepository) AddDelegationRoleAndKeys(name data.RoleName, delegationKeys []data.PublicKey) error {
+func (r *repository) AddDelegationRoleAndKeys(name data.RoleName, delegationKeys []data.PublicKey) error {
 
 	if !data.IsDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -57,7 +57,7 @@ func (r *NotaryRepository) AddDelegationRoleAndKeys(name data.RoleName, delegati
 
 // AddDelegationPaths creates a changelist entry to add provided paths to an existing delegation.
 // This method cannot create a new delegation itself because the role must meet the key threshold upon creation.
-func (r *NotaryRepository) AddDelegationPaths(name data.RoleName, paths []string) error {
+func (r *repository) AddDelegationPaths(name data.RoleName, paths []string) error {
 
 	if !data.IsDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -78,7 +78,7 @@ func (r *NotaryRepository) AddDelegationPaths(name data.RoleName, paths []string
 
 // RemoveDelegationKeysAndPaths creates changelist entries to remove provided delegation key IDs and paths.
 // This method composes RemoveDelegationPaths and RemoveDelegationKeys (each creates one changelist if called).
-func (r *NotaryRepository) RemoveDelegationKeysAndPaths(name data.RoleName, keyIDs, paths []string) error {
+func (r *repository) RemoveDelegationKeysAndPaths(name data.RoleName, keyIDs, paths []string) error {
 	if len(paths) > 0 {
 		err := r.RemoveDelegationPaths(name, paths)
 		if err != nil {
@@ -95,7 +95,7 @@ func (r *NotaryRepository) RemoveDelegationKeysAndPaths(name data.RoleName, keyI
 }
 
 // RemoveDelegationRole creates a changelist to remove all paths and keys from a role, and delete the role in its entirety.
-func (r *NotaryRepository) RemoveDelegationRole(name data.RoleName) error {
+func (r *repository) RemoveDelegationRole(name data.RoleName) error {
 
 	if !data.IsDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -108,7 +108,7 @@ func (r *NotaryRepository) RemoveDelegationRole(name data.RoleName) error {
 }
 
 // RemoveDelegationPaths creates a changelist entry to remove provided paths from an existing delegation.
-func (r *NotaryRepository) RemoveDelegationPaths(name data.RoleName, paths []string) error {
+func (r *repository) RemoveDelegationPaths(name data.RoleName, paths []string) error {
 
 	if !data.IsDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -132,7 +132,7 @@ func (r *NotaryRepository) RemoveDelegationPaths(name data.RoleName, paths []str
 // the role itself will be deleted in its entirety.
 // It can also delete a key from all delegations under a parent using a name
 // with a wildcard at the end.
-func (r *NotaryRepository) RemoveDelegationKeys(name data.RoleName, keyIDs []string) error {
+func (r *repository) RemoveDelegationKeys(name data.RoleName, keyIDs []string) error {
 
 	if !data.IsDelegation(name) && !data.IsWildDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -152,7 +152,7 @@ func (r *NotaryRepository) RemoveDelegationKeys(name data.RoleName, keyIDs []str
 }
 
 // ClearDelegationPaths creates a changelist entry to remove all paths from an existing delegation.
-func (r *NotaryRepository) ClearDelegationPaths(name data.RoleName) error {
+func (r *repository) ClearDelegationPaths(name data.RoleName) error {
 
 	if !data.IsDelegation(name) {
 		return data.ErrInvalidRole{Role: name, Reason: "invalid delegation role name"}
@@ -203,7 +203,7 @@ func newDeleteDelegationChange(name data.RoleName, content []byte) *changelist.T
 
 // GetDelegationRoles returns the keys and roles of the repository's delegations
 // Also converts key IDs to canonical key IDs to keep consistent with signing prompts
-func (r *NotaryRepository) GetDelegationRoles() ([]data.Role, error) {
+func (r *repository) GetDelegationRoles() ([]data.Role, error) {
 	// Update state of the repo to latest
 	if err := r.Update(false); err != nil {
 		return nil, err

--- a/client/witness.go
+++ b/client/witness.go
@@ -8,7 +8,7 @@ import (
 
 // Witness creates change objects to witness (i.e. re-sign) the given
 // roles on the next publish. One change is created per role
-func (r *NotaryRepository) Witness(roles ...data.RoleName) ([]data.RoleName, error) {
+func (r *repository) Witness(roles ...data.RoleName) ([]data.RoleName, error) {
 	var err error
 	successful := make([]data.RoleName, 0, len(roles))
 	for _, role := range roles {

--- a/cmd/notary/delegations.go
+++ b/cmd/notary/delegations.go
@@ -103,7 +103,7 @@ func (d *delegationCommander) delegationPurgeKeys(cmd *cobra.Command, args []str
 		return err
 	}
 
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedRepository(
 		config.GetString("trust_dir"),
 		gun,
 		getRemoteTrustServer(config),
@@ -153,7 +153,7 @@ func (d *delegationCommander) delegationsList(cmd *cobra.Command, args []string)
 	}
 
 	// initialize repo with transport to get latest state of the world before listing delegations
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, d.retriever, trustPin)
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func (d *delegationCommander) delegationRemove(cmd *cobra.Command, args []string
 
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, d.retriever, trustPin)
 	if err != nil {
 		return err
@@ -314,7 +314,7 @@ func (d *delegationCommander) delegationAdd(cmd *cobra.Command, args []string) e
 
 	// no online operations are performed by add so the transport argument
 	// should be nil
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), nil, d.retriever, trustPin)
 	if err != nil {
 		return err

--- a/cmd/notary/keys.go
+++ b/cmd/notary/keys.go
@@ -310,7 +310,7 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config),
 		rt, k.getRetriever(), trustPin)
 	if err != nil {
@@ -341,7 +341,7 @@ func (k *keyCommander) keysRotate(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	}
-	nRepo.LegacyVersions = k.legacyVersions
+	nRepo.SetLegacyVersions(k.legacyVersions)
 	if err := nRepo.RotateKey(rotateKeyRole, k.rotateKeyServerManaged, keyList); err != nil {
 		return err
 	}

--- a/cmd/notary/keys_test.go
+++ b/cmd/notary/keys_test.go
@@ -333,7 +333,7 @@ func setUpRepo(t *testing.T, tempBaseDir string, gun data.GUN, ret notary.PassRe
 	cryptoService := cryptoservice.NewCryptoService(trustmanager.NewKeyMemoryStore(ret))
 	ts := httptest.NewServer(server.RootHandler(ctx, nil, cryptoService, nil, nil, nil))
 
-	repo, err := client.NewFileCachedNotaryRepository(
+	repo, err := client.NewFileCachedRepository(
 		tempBaseDir, gun, ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
@@ -376,7 +376,7 @@ func TestRotateKeyRemoteServerManagesKey(t *testing.T) {
 		}
 		require.NoError(t, k.keysRotate(&cobra.Command{}, []string{gun.String(), role, "-r"}))
 
-		repo, err := client.NewFileCachedNotaryRepository(tempBaseDir, data.GUN(gun), ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
+		repo, err := client.NewFileCachedRepository(tempBaseDir, data.GUN(gun), ts.URL, http.DefaultTransport, ret, trustpinning.TrustPinConfig{})
 		require.NoError(t, err, "error creating repo: %s", err)
 
 		cl, err := repo.GetChangelist()
@@ -430,7 +430,7 @@ func TestRotateKeyBothKeys(t *testing.T) {
 	require.NoError(t, k.keysRotate(&cobra.Command{}, []string{gun.String(), data.CanonicalTargetsRole.String()}))
 	require.NoError(t, k.keysRotate(&cobra.Command{}, []string{gun.String(), data.CanonicalSnapshotRole.String()}))
 
-	repo, err := client.NewFileCachedNotaryRepository(tempBaseDir, data.GUN(gun), ts.URL, nil, ret, trustpinning.TrustPinConfig{})
+	repo, err := client.NewFileCachedRepository(tempBaseDir, data.GUN(gun), ts.URL, nil, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
 	cl, err := repo.GetChangelist()
@@ -495,7 +495,7 @@ func TestRotateKeyRootIsInteractive(t *testing.T) {
 
 	require.Contains(t, out.String(), "Aborting action")
 
-	repo, err := client.NewFileCachedNotaryRepository(tempBaseDir, gun, ts.URL, nil, ret, trustpinning.TrustPinConfig{})
+	repo, err := client.NewFileCachedRepository(tempBaseDir, gun, ts.URL, nil, ret, trustpinning.TrustPinConfig{})
 	require.NoError(t, err, "error creating repo: %s", err)
 
 	// There should still just be one root key (and one targets and one snapshot)

--- a/cmd/notary/repo_factory.go
+++ b/cmd/notary/repo_factory.go
@@ -31,7 +31,7 @@ func ConfigureRepo(v *viper.Viper, retriever notary.PassRetriever, onlineOperati
 				return nil, err
 			}
 		}
-		return client.NewFileCachedNotaryRepository(
+		return client.NewFileCachedRepository(
 			v.GetString("trust_dir"),
 			gun,
 			getRemoteTrustServer(v),

--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -1035,7 +1035,7 @@ func maybeAutoPublish(cmd *cobra.Command, doPublish bool, gun data.GUN, config *
 		return err
 	}
 
-	nRepo, err := notaryclient.NewFileCachedNotaryRepository(
+	nRepo, err := notaryclient.NewFileCachedRepository(
 		config.GetString("trust_dir"), gun, getRemoteTrustServer(config), rt, passRetriever, trustPin)
 	if err != nil {
 		return err

--- a/trustmanager/remoteks/server_test.go
+++ b/trustmanager/remoteks/server_test.go
@@ -3,10 +3,9 @@ package remoteks
 import (
 	"testing"
 
+	"github.com/docker/notary/storage"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-
-	"github.com/docker/notary/storage"
 )
 
 func TestNewGRPCStorage(t *testing.T) {


### PR DESCRIPTION
Also fixes a small bug with SetLegacyVersions.

Signed-off-by: Tibor Vass <teabee89@gmail.com>