### PR TITLE
fix updated linting to remove redundant else clauses

### DIFF
--- a/server/handlers/validation.go
+++ b/server/handlers/validation.go
@@ -228,8 +228,5 @@ func loadFromStore(gun data.GUN, roleName data.RoleName, builder tuf.RepoBuilder
 	if err != nil {
 		return err
 	}
-	if err := builder.Load(roleName, metaJSON, 1, true); err != nil {
-		return err
-	}
-	return nil
+	return builder.Load(roleName, metaJSON, 1, true)
 }

--- a/storage/filestore.go
+++ b/storage/filestore.go
@@ -206,10 +206,7 @@ func (f *FilesystemStore) Set(name string, meta []byte) error {
 	os.RemoveAll(fp)
 
 	// Write the file to disk
-	if err = ioutil.WriteFile(fp, meta, notary.PrivNoExecPerms); err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(fp, meta, notary.PrivNoExecPerms)
 }
 
 // RemoveAll clears the existing filestore by removing its base directory


### PR DESCRIPTION
There was an update to lint!  Fix the extraneous `else` clauses appropriately.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>