### PR TITLE
remove derek as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -13,7 +13,6 @@
 		people = [
 			"cyli",
 			"diogomonica",
-			"dmcgowan",
 			"endophage",
 			"ecordell",
 			"hukeping",
@@ -38,11 +37,6 @@
 	Name = "Diogo Monica"
 	Email = "diogo@docker.com"
 	GitHub = "diogomonica"
-
-	[people.dmcgowan]
-	Name = "Derek McGowan"
-	Email = "derek@docker.com"
-	GitHub = "dmcgowan"
 
 	[people.endophage]
 	Name = "David Lawrence"

--- a/MAINTAINERS.ALUMNI
+++ b/MAINTAINERS.ALUMNI
@@ -1,0 +1,22 @@
+# Notary maintainers alumni file
+#
+# This file describes past maintainers who have stepped down from the role.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+[Org]
+	[Org."Notary Alumni"]
+		people = [
+			"dmcgowan",
+		]
+
+[people]
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.dmcgowan]
+	Name = "Derek McGowan"
+	Email = "derek@docker.com"
+	GitHub = "dmcgowan"


### PR DESCRIPTION
@dmcgowan pinged you about this a while ago. Please LGTM for the sake of protocol. Thanks!

maintainers: I'll merge this with just Derek's LGTM

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)