### PR TITLE
Bump Go to 1.8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.8.4
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.8.4
 
 RUN apt-get update && apt-get install -y \
 	curl \

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3-alpine
+FROM golang:1.8.4-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*

--- a/signer.Dockerfile
+++ b/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3-alpine
+FROM golang:1.8.4-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Bumps the Go version used to 1.8.4, which contains security fixes;
https://groups.google.com/forum/#!topic/golang-announce/1hZYiemnkdE

This will currently fail, as the images are not live yet on Docker Hub, but they're currently building, so should be available shortly(r)(tm)

https://hub.docker.com/r/library/golang/tags/

ping @riyazdf @endophage 